### PR TITLE
Don't derive AndroidNotificationIntentData from MonoBehavior.

### DIFF
--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -398,12 +398,7 @@ namespace Unity.Notifications.Android
             notification.sortKey = notificationIntent.Call<string>("getStringExtra", "sortKey");
             notification.groupAlertBehaviour = notificationIntent.Call<int>("getIntExtra", "groupAlertBehaviour", -1);
 
-            return new AndroidNotificationIntentData
-            {
-                id = id,
-                channel = channel,
-                notification = notification,
-            };
+            return new AndroidNotificationIntentData(id, channel, notification);
         }
 
         internal static void ReceivedNotificationCallback(AndroidJavaObject intent)

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationIntentData.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationIntentData.cs
@@ -2,25 +2,32 @@ using UnityEngine;
 
 namespace Unity.Notifications.Android
 {
-    public class AndroidNotificationIntentData : MonoBehaviour
+    public class AndroidNotificationIntentData
     {
-        internal int id;
-        internal string channel;
-        internal AndroidNotification notification;
+        protected int m_Id;
+        protected string m_Channel;
+        protected AndroidNotification m_Notification;
+
+        public AndroidNotificationIntentData(int id, string channel, AndroidNotification notification)
+        {
+            m_Id = id;
+            m_Channel = channel;
+            m_Notification = notification;
+        }
 
         public int Id
         {
-            get { return id; }
+            get { return m_Id; }
         }
 
         public string Channel
         {
-            get { return channel; }
+            get { return m_Channel; }
         }
 
         public AndroidNotification Notification
         {
-            get { return notification; }
+            get { return m_Notification; }
         }
     }
 }


### PR DESCRIPTION
Fix the issue that AndroidNotificationCenter.GetLastNotificationIntent() returns null. The problem is `AndroidNotificationIntentData` derives from `MonoBehavior` which you can't really new the instance by `new` keyword. I made this mistake in https://github.com/Unity-Technologies/com.unity.mobile.notifications/commit/3bde4a716de530a366af31de33bd893073d89e3e...
