### PR TITLE
Fix qa round comments

### DIFF
--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
@@ -199,17 +199,10 @@ namespace Unity.Notifications.iOS
                     data.triggerType = iOSNotificationTimeIntervalTrigger.Type;
                     data.timeTriggerInterval = trigger.timeInterval;
 
-                    if (trigger.timeInterval > 60)
-                    {
-                        data.repeats = trigger.Repeats;
-                    }
-                    else
-                    {
-                        if (trigger.Repeats)
-                        {
-                            Debug.LogWarning("Time interval must be at least 60 for repeating notifications.");
-                        }
-                    }
+                    if (trigger.Repeats && trigger.timeInterval < 60)
+                        throw new ArgumentException("Time interval must be 60 seconds or greater for repeating notifications.");
+
+                    data.repeats = trigger.Repeats;
                 }
                 else if (value is iOSNotificationCalendarTrigger)
                 {

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationTriggers.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationTriggers.cs
@@ -86,6 +86,8 @@ namespace Unity.Notifications.iOS
             set
             {
                 timeInterval = (int)value.TotalSeconds;
+                if (timeInterval <= 0)
+                    throw new ArgumentException("Time interval must be greater than 0.");
             }
         }
         public bool Repeats { get; set; }

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationsWrapper.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationsWrapper.cs
@@ -4,6 +4,8 @@ using System.Runtime.InteropServices;
 using AOT;
 using UnityEngine;
 
+#pragma warning disable 162
+
 namespace Unity.Notifications.iOS
 {
     internal class iOSNotificationsWrapper : MonoBehaviour
@@ -255,3 +257,4 @@ namespace Unity.Notifications.iOS
         }
     }
 }
+#pragma warning restore 162


### PR DESCRIPTION
Fixed several issues that are found during qa pass.
1. Throw exceptions for invalid argument like 0 time interval, less than 60s for repeating notifications, rather than doing nothing or just a debug warning.
2. Have to add #pragma warning 162 back for now, will find a better way to do it along with iOS plugin code polishing.