### PR TITLE
Fixed the crash on iOS about iOSNotificationData.data is null for rem…

### DIFF
--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationWrapper.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationWrapper.m
@@ -99,7 +99,7 @@ void _ScheduleLocalNotification(struct iOSNotificationData* data)
     NSDictionary *userInfo = @{
         @"showInForeground": @(data->showInForeground),
         @"showInForegroundPresentationOptions": [NSNumber numberWithInteger: data->showInForegroundPresentationOptions],
-        @"data": @(data->data),
+        @"data": @(data->data ? data->data : ""),
     };
 
     UNMutableNotificationContent* content = [[UNMutableNotificationContent alloc] init];


### PR DESCRIPTION
The root cause is NSDictionary doesn't allow null value, in our case it’s `iOSNotificationData.data`. 
Normally this pointer won’t be null. But if we send a remote notification from that tool, it’s null. 
In `OnNotificationReceivedHandler()` test code, `iOSNotificationCenter.ScheduleNotification()` is called to use the received notification to schedule a new notification, this hit the null pointer crash.