### PR TITLE
Cleanup public test APIs

### DIFF
--- a/com.unity.mobile.notifications/Tests/Editor/NotificationSettingsTests.cs
+++ b/com.unity.mobile.notifications/Tests/Editor/NotificationSettingsTests.cs
@@ -3,7 +3,7 @@ using Unity.Notifications.iOS;
 
 namespace Unity.Notifications.Tests
 {
-    public class NotificationSettingsTests
+    internal class NotificationSettingsTests
     {
         [OneTimeSetUp]
         public void ResetSettings()

--- a/com.unity.mobile.notifications/Tests/Editor/PostprocessorTests.cs
+++ b/com.unity.mobile.notifications/Tests/Editor/PostprocessorTests.cs
@@ -3,7 +3,7 @@ using NUnit.Framework;
 
 namespace Unity.Notifications.Tests
 {
-    public class PostprocessorTests
+    internal class PostprocessorTests
     {
         [Test]
         public void DummmyTest()


### PR DESCRIPTION
Change these two test classes to internal then they won't show in the public APIs documentation.
https://docs.unity3d.com/Packages/com.unity.mobile.notifications@1.1/api/Unity.Notifications.Tests.html