### PR TITLE
Notification settings ui improvement

### DIFF
--- a/com.unity.mobile.notifications/Editor/DrawableResourceData.cs
+++ b/com.unity.mobile.notifications/Editor/DrawableResourceData.cs
@@ -10,18 +10,18 @@ namespace Unity.Notifications
         public NotificationIconType Type;
         public Texture2D Asset;
 
-        private bool isValid = false;
-        private List<string> errors = null;
-        private Texture2D previewTexture;
+        private bool m_IsValid = false;
+        private List<string> m_Errors = null;
+        private Texture2D m_PreviewTexture;
 
         public bool IsValid
         {
             get
             {
-                if (isValid == false && errors == null)
+                if (m_IsValid == false && m_Errors == null)
                     Verify();
 
-                return isValid;
+                return m_IsValid;
             }
         }
 
@@ -29,24 +29,22 @@ namespace Unity.Notifications
         {
             get
             {
-                if (isValid == false && errors == null)
+                if (m_IsValid == false && m_Errors == null)
                     Verify();
 
-                return errors.ToArray();
+                return m_Errors.ToArray();
             }
         }
 
         public Texture2D GetPreviewTexture(bool update)
         {
             if (Asset == null)
-            {
                 return null;
-            }
 
-            if (isValid && (previewTexture == null || update))
-                previewTexture = TextureAssetUtils.ProcessTextureForType(Asset, Type);
+            if (m_IsValid && (m_PreviewTexture == null || update))
+                m_PreviewTexture = TextureAssetUtils.ProcessTextureForType(Asset, Type);
 
-            return previewTexture;
+            return m_PreviewTexture;
         }
 
         internal bool Initialized()
@@ -56,29 +54,28 @@ namespace Unity.Notifications
 
         public void Clean()
         {
-            isValid = false;
-            errors = null;
-            previewTexture = null;
+            m_IsValid = false;
+            m_Errors = null;
+            m_PreviewTexture = null;
         }
 
         public bool Verify()
         {
-            List<string> errors;
-            isValid = TextureAssetUtils.VerifyTextureByType(Asset, Type, out errors);
-            this.errors = errors;
-            return isValid;
+            m_IsValid = TextureAssetUtils.VerifyTextureByType(Asset, Type, out m_Errors);
+            return m_IsValid;
         }
 
-        public static string GenerateErrorString(string[] errors)
+        public string GenerateErrorString()
         {
-            var error = "";
+            var errors = Errors;
 
+            var errorString = string.Empty;
             for (var i = 0; i < errors.Length; i++)
             {
-                error += string.Format("{0}{1}", errors[i], i + 1 >= errors.Length ? "." : ", ");
+                errorString += string.Format("{0}{1}", errors[i], i + 1 >= errors.Length ? "." : ", ");
             }
 
-            return error;
+            return errorString;
         }
     }
 }

--- a/com.unity.mobile.notifications/Editor/NotificationSettingsManager.cs
+++ b/com.unity.mobile.notifications/Editor/NotificationSettingsManager.cs
@@ -268,8 +268,9 @@ namespace Unity.Notifications
             {
                 if (!drawableResource.Verify())
                 {
-                    Debug.LogWarning(string.Format("Failed exporting: '{0}' AndroidSettings notification icon because:\n {1} ", drawableResource.Id,
-                        DrawableResourceData.GenerateErrorString(drawableResource.Errors)));
+                    Debug.LogWarning(string.Format("Failed exporting: '{0}' AndroidSettings notification icon because:\n {1} ",
+                        drawableResource.Id,
+                        drawableResource.GenerateErrorString()));
                     continue;
                 }
 

--- a/com.unity.mobile.notifications/Editor/NotificationSettingsManagerEditor.cs
+++ b/com.unity.mobile.notifications/Editor/NotificationSettingsManagerEditor.cs
@@ -237,7 +237,7 @@ namespace Unity.Notifications
 
                 // Draw the help message for setting the icons.
                 var iconListMessageRect = new Rect(notificationsPanelRect.x, notificationsPanelRect.y + 105f, notificationsPanelRect.width, 55f);
-                EditorGUI.TextArea(iconListMessageRect, k_InfoStringAndroid, NotificationStyles.k_HeaderMsgStyle);
+                EditorGUI.SelectableLabel(iconListMessageRect, k_InfoStringAndroid, NotificationStyles.k_HeaderMsgStyle);
 
                 // Draw the reorderable list for the icon list.
                 var iconListRect = new Rect(iconListMessageRect.x, iconListMessageRect.y + 58f, notificationsPanelRect.width, notificationsPanelRect.height - 55f);

--- a/com.unity.mobile.notifications/Editor/NotificationSettingsManagerEditor.cs
+++ b/com.unity.mobile.notifications/Editor/NotificationSettingsManagerEditor.cs
@@ -44,6 +44,11 @@ namespace Unity.Notifications
             return new NotificationSettingsProvider("Project/Mobile Notifications", SettingsScope.Project);
         }
 
+        public override void OnDeactivate()
+        {
+            m_SettingsManager.SaveSettings(false);
+        }
+
         private void Initialize()
         {
             label = "Mobile Notifications";

--- a/com.unity.mobile.notifications/Editor/NotificationSettingsManagerEditor.cs
+++ b/com.unity.mobile.notifications/Editor/NotificationSettingsManagerEditor.cs
@@ -247,7 +247,7 @@ namespace Unity.Notifications
             }
 
             // We have to do this to occupy the space that ScrollView can set the scrollbars correctly.
-            EditorGUILayout.GetControlRect(true, heightPlaceHolder);
+            EditorGUILayout.GetControlRect(true, heightPlaceHolder, GUILayout.MinWidth(width));
         }
 
         private bool DrawNotificationSettingsPanel(Rect rect, int toolbarIndex)

--- a/com.unity.mobile.notifications/Editor/NotificationSettingsManagerEditor.cs
+++ b/com.unity.mobile.notifications/Editor/NotificationSettingsManagerEditor.cs
@@ -161,15 +161,10 @@ namespace Unity.Notifications
                 var errorMsgWidth = rect.width - k_Padding * 2;
                 var errorRect = AddPadding(new Rect(elementRect.x, elementRect.y + k_SlotSize, errorMsgWidth, k_SlotSize), 4, 4);
 
-                EditorGUI.HelpBox(errorRect,
-                    "Specified texture can't be used because: \n"
-                    + (errorMsgWidth > 145 ? DrawableResourceData.GenerateErrorString(drawableResource.Errors) : "...expand to see more..."),
-                    MessageType.Error);
+                var errorMsg = "Specified texture can't be used because: \n" + DrawableResourceData.GenerateErrorString(drawableResource.Errors);
+                EditorGUI.HelpBox(errorRect, errorMsg, MessageType.Error);
 
-                if (drawableResource.Type == NotificationIconType.Small)
-                {
-                    GUI.Box(previewTextureRect, "Preview not available. \n Make sure the texture is readable!", NotificationStyles.k_HelpBoxMessageTextStyle);
-                }
+                GUI.Box(previewTextureRect, "Preview not available", NotificationStyles.k_PreviewMessageTextStyle);
             }
             else
             {
@@ -240,7 +235,7 @@ namespace Unity.Notifications
 
                 // Draw the help message for setting the icons.
                 var iconListMessageRect = new Rect(iconListlabelRect.x, iconListlabelRect.y + 20, notificationSettingsRect.width, 55f);
-                EditorGUI.SelectableLabel(iconListMessageRect, k_InfoStringAndroid, NotificationStyles.k_HeaderMsgStyle);
+                EditorGUI.SelectableLabel(iconListMessageRect, k_InfoStringAndroid, NotificationStyles.k_IconHelpMessageStyle);
 
                 // Draw the reorderable list for the icon list.
                 var iconListRect = new Rect(iconListMessageRect.x, iconListMessageRect.y + 58f, iconListMessageRect.width, notificationSettingsRect.height - 55f);
@@ -272,7 +267,7 @@ namespace Unity.Notifications
         {
             var spaceOffset = layer * 13;
 
-            var labelStyle = new GUIStyle(NotificationStyles.s_LabelStyle);
+            var labelStyle = new GUIStyle(NotificationStyles.k_LabelStyle);
             labelStyle.fixedWidth = k_SlotSize * 5 - spaceOffset;
 
             var toggleStyle = NotificationStyles.k_ToggleStyle;

--- a/com.unity.mobile.notifications/Editor/NotificationSettingsManagerEditor.cs
+++ b/com.unity.mobile.notifications/Editor/NotificationSettingsManagerEditor.cs
@@ -35,15 +35,13 @@ namespace Unity.Notifications
         private NotificationSettingsProvider(string path, SettingsScope scopes)
             : base(path, scopes)
         {
+            Initialize();
         }
 
         [SettingsProvider]
         static SettingsProvider CreateMobileNotificationsSettingsProvider()
         {
-            var provider = new NotificationSettingsProvider("Project/Mobile Notifications", SettingsScope.Project);
-            provider.Initialize();
-
-            return provider;
+            return new NotificationSettingsProvider("Project/Mobile Notifications", SettingsScope.Project);
         }
 
         private void Initialize()
@@ -161,7 +159,7 @@ namespace Unity.Notifications
                 var errorMsgWidth = rect.width - k_Padding * 2;
                 var errorRect = AddPadding(new Rect(elementRect.x, elementRect.y + k_SlotSize, errorMsgWidth, k_SlotSize), 4, 4);
 
-                var errorMsg = "Specified texture can't be used because: \n" + DrawableResourceData.GenerateErrorString(drawableResource.Errors);
+                var errorMsg = "Specified texture can't be used because: \n" + drawableResource.GenerateErrorString();
                 EditorGUI.HelpBox(errorRect, errorMsg, MessageType.Error);
 
                 GUI.Box(previewTextureRect, "Preview not available", NotificationStyles.k_PreviewMessageTextStyle);
@@ -234,14 +232,14 @@ namespace Unity.Notifications
                 GUI.Label(iconListlabelRect, "Notification Icons", EditorStyles.label);
 
                 // Draw the help message for setting the icons.
-                var iconListMessageRect = new Rect(iconListlabelRect.x, iconListlabelRect.y + 20, notificationSettingsRect.width, 55f);
-                EditorGUI.SelectableLabel(iconListMessageRect, k_InfoStringAndroid, NotificationStyles.k_IconHelpMessageStyle);
+                var iconListMsgRect = new Rect(iconListlabelRect.x, iconListlabelRect.y + 20, notificationSettingsRect.width, 55f);
+                EditorGUI.SelectableLabel(iconListMsgRect, k_InfoStringAndroid, NotificationStyles.k_IconHelpMessageStyle);
 
                 // Draw the reorderable list for the icon list.
-                var iconListRect = new Rect(iconListMessageRect.x, iconListMessageRect.y + 58f, iconListMessageRect.width, notificationSettingsRect.height - 55f);
+                var iconListRect = new Rect(iconListMsgRect.x, iconListMsgRect.y + 58f, iconListMsgRect.width, notificationSettingsRect.height - 55f);
                 m_ReorderableList.DoList(iconListRect);
 
-                heightPlaceHolder += iconListMessageRect.height + m_ReorderableList.GetHeight();
+                heightPlaceHolder += iconListMsgRect.height + m_ReorderableList.GetHeight();
             }
 
             // We have to do this to occupy the space that ScrollView can set the scrollbars correctly.

--- a/com.unity.mobile.notifications/Editor/NotificationStyles.cs
+++ b/com.unity.mobile.notifications/Editor/NotificationStyles.cs
@@ -10,7 +10,7 @@ namespace Unity.Notifications
         public static readonly GUIStyle k_PreviewLabelTextStyle = new GUIStyle(GUI.skin.label) { fontSize = 8, wordWrap = true, alignment = TextAnchor.UpperCenter };
         public static readonly GUIStyle k_HeaderMsgStyle = new GUIStyle(GUI.skin.GetStyle("HelpBox")) { fontSize = 10, wordWrap = true, alignment = TextAnchor.UpperLeft };
         public static readonly GUIStyle k_ToggleStyle = new GUIStyle(GUI.skin.GetStyle("Toggle")) { alignment = TextAnchor.MiddleRight };
-        public static readonly GUIStyle k_DropwDownStyle = new GUIStyle(GUI.skin.GetStyle("Button")) { fixedWidth = NotificationSettingsProvider.k_SlotSize * 2.5f };
-        public static GUIStyle s_LabelStyle = new GUIStyle(GUI.skin.GetStyle("Label")) { wordWrap = true };
+        public static readonly GUIStyle k_DropwDownStyle = new GUIStyle(GUI.skin.GetStyle("Button")) { alignment = TextAnchor.MiddleLeft };
+        public static readonly GUIStyle s_LabelStyle = new GUIStyle(GUI.skin.GetStyle("Label")) { wordWrap = true };
     }
 }

--- a/com.unity.mobile.notifications/Editor/NotificationStyles.cs
+++ b/com.unity.mobile.notifications/Editor/NotificationStyles.cs
@@ -6,11 +6,11 @@ namespace Unity.Notifications
     {
         public static readonly GUIStyle k_EvenRow = new GUIStyle("CN EntryBackEven");
         public static readonly GUIStyle k_OddRow = new GUIStyle("CN EntryBackOdd");
-        public static readonly GUIStyle k_HelpBoxMessageTextStyle = new GUIStyle(GUI.skin.label) { fontSize = 8, wordWrap = true, alignment = TextAnchor.MiddleCenter };
+        public static readonly GUIStyle k_PreviewMessageTextStyle = new GUIStyle(GUI.skin.label) { fontSize = 8, wordWrap = true, alignment = TextAnchor.MiddleCenter };
         public static readonly GUIStyle k_PreviewLabelTextStyle = new GUIStyle(GUI.skin.label) { fontSize = 8, wordWrap = true, alignment = TextAnchor.UpperCenter };
-        public static readonly GUIStyle k_HeaderMsgStyle = new GUIStyle(GUI.skin.GetStyle("HelpBox")) { fontSize = 10, wordWrap = true, alignment = TextAnchor.UpperLeft };
+        public static readonly GUIStyle k_IconHelpMessageStyle = new GUIStyle(GUI.skin.GetStyle("HelpBox")) { fontSize = 10, wordWrap = true, alignment = TextAnchor.UpperLeft };
         public static readonly GUIStyle k_ToggleStyle = new GUIStyle(GUI.skin.GetStyle("Toggle")) { alignment = TextAnchor.MiddleRight };
         public static readonly GUIStyle k_DropwDownStyle = new GUIStyle(GUI.skin.GetStyle("Button")) { alignment = TextAnchor.MiddleLeft };
-        public static readonly GUIStyle s_LabelStyle = new GUIStyle(GUI.skin.GetStyle("Label")) { wordWrap = true };
+        public static readonly GUIStyle k_LabelStyle = new GUIStyle(GUI.skin.GetStyle("Label")) { wordWrap = true };
     }
 }

--- a/com.unity.mobile.notifications/Editor/TextureAssetUtils.cs
+++ b/com.unity.mobile.notifications/Editor/TextureAssetUtils.cs
@@ -27,7 +27,7 @@ namespace Unity.Notifications
 
             var isSquare = texture.width == texture.height;
             var isLargeEnough = texture.width >= minSize;
-            var hasAlpha = true;// texture.format == TextureFormat.Alpha8;
+            var hasAlpha = true;// TODO: texture.format == TextureFormat.Alpha8;
 
             var isReadable = texture.isReadable;
 


### PR DESCRIPTION
Improved the notification settings UI, including
1. Moving the icon requirement message below the `Notification Icons` header.
2. Improve the drawing code a little bit.
3. Fixed the issue that dependent settings are not aligned correctly.
4. Fixed https://fogbugz.unity3d.com/f/cases/1195293/, now scrollview works fine with notification settings.
5. Other minor changes.

Now the UI looks like
![image](https://user-images.githubusercontent.com/39640649/79100127-396a7300-7d98-11ea-8ba4-629d8b7ed5a7.png)
