### PR TITLE
Bug fixes

### DIFF
--- a/com.unity.mobile.notifications/Editor/AndroidNotificationPostProcessor.cs
+++ b/com.unity.mobile.notifications/Editor/AndroidNotificationPostProcessor.cs
@@ -16,37 +16,9 @@ namespace Unity.Notifications
 
         public void OnPostGenerateGradleAndroidProject(string projectPath)
         {
-            InsertGradleDependencies(projectPath);
-
             CopyNotificationResources(projectPath);
 
             InjectAndroidManifest(projectPath);
-        }
-
-        // Insert dependencies that need by mobile notification package.
-        private void InsertGradleDependencies(string projectPath)
-        {
-            // Here always insert a '\n' at the beginning, as in gradle:
-            //  1. for dependencies, you can put '}' at the end of the last 'implementation' line;
-            //  2. but you can't put two 'implementation's in one line.
-            // so just always add a new line to make sure it work for all cases.
-            const string kDependency = "\n    implementation 'com.android.support:appcompat-v7:27.1.1'\n";
-
-            var gradleFilePath = Path.Combine(projectPath, "build.gradle");
-            if (!File.Exists(gradleFilePath))
-                throw new FileNotFoundException(string.Format("'{0}' doesn't exist.", gradleFilePath));
-
-            var content = File.ReadAllText(gradleFilePath);
-            if (string.IsNullOrEmpty(content))
-                throw new ArgumentException(string.Format("'{0}' is empty.", gradleFilePath));
-
-            // Find the first '}' after 'dependencies' which has 'implementation' come after.
-            var regex = new Regex(@"dependencies[\s\S]+?implementation[\s\S]+?(?<index>}+?)");
-            var result = regex.Match(content);
-            if (!result.Success)
-                throw new ArgumentException(string.Format("Failed to parse '{0}'.", gradleFilePath));
-
-            File.WriteAllText(gradleFilePath, content.Insert(result.Groups["index"].Index, kDependency));
         }
 
         private void CopyNotificationResources(string projectPath)

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/NotificationCallback.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/NotificationCallback.java
@@ -1,9 +1,7 @@
 package com.unity.androidnotifications;
 
 import android.content.Intent;
-import android.support.annotation.Keep;
 
-@Keep
 public interface NotificationCallback {
     void onSentNotification(Intent intent);
 }

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/NotificationChannelWrapper.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/NotificationChannelWrapper.java
@@ -1,10 +1,7 @@
 package com.unity.androidnotifications;
 
-import android.support.annotation.Keep;
-
 // Provide a wrapper for NotificationChannel.
 // Create this wrapper for all Android versions as NotificationChannel is only available for Android O or above.
-@Keep
 public class NotificationChannelWrapper {
 
     public String id;

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -17,7 +17,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.BadParcelableException;
 import android.service.notification.StatusBarNotification;
-import android.support.annotation.Keep;
 import android.util.Log;
 
 import static android.app.Notification.VISIBILITY_PUBLIC;
@@ -29,7 +28,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-@Keep
 public class UnityNotificationManager extends BroadcastReceiver {
     protected static NotificationCallback mNotificationCallback;
     protected static UnityNotificationManager mUnityNotificationManager;

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManagerOreo.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManagerOreo.java
@@ -4,12 +4,10 @@ import android.app.Activity;
 import android.app.NotificationChannel;
 import android.content.Context;
 import android.os.Build;
-import android.support.annotation.Keep;
 
 import java.util.ArrayList;
 import java.util.List;
 
-@Keep
 public class UnityNotificationManagerOreo extends UnityNotificationManager {
     public UnityNotificationManagerOreo(Context context, Activity activity) {
         super(context, activity);

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
@@ -4,13 +4,11 @@ import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.support.annotation.Keep;
 
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
-@Keep
 public class UnityNotificationRestartOnBootReceiver extends BroadcastReceiver {
 
     @Override

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationUtilities.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationUtilities.java
@@ -7,11 +7,9 @@ import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.os.Bundle;
 import android.os.Parcel;
-import android.support.annotation.Keep;
 import android.util.Base64;
 import android.util.Log;
 
-@Keep
 public class UnityNotificationUtilities {
     protected static int findResourceIdInContextByName(Context context, String name) {
         if (name == null)

--- a/project/androidnotifications/build.gradle
+++ b/project/androidnotifications/build.gradle
@@ -29,7 +29,6 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'com.android.support:appcompat-v7:27.1.1'
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'


### PR DESCRIPTION
https://fogbugz.unity3d.com/f/cases/1231218/
https://fogbugz.unity3d.com/f/cases/1239769/
https://github.com/Unity-Technologies/com.unity.mobile.notifications/issues/44

This mainly fixed the android build failure introduced by `com.android.support:appcompat-v7:27.1.1` dependency. We use the `annotation.Keep` from that library but but we don't really need now.

I guess the reason we first added it is users can use the deassembly tools to check the class/method names of our android plugin, since we expose the source, we don't need it any more.

This gets rid of some bugs by not injecting the gradle file.

To QA: **_Could you please priotirize this?_** As this blocks people from upgrading to the 1.1.0-preview and above. I planned to have a patch release with it.
And I personally tested it on pixel 2 with android 8. 