### PR TITLE
Improve iOS post processor

### DIFF
--- a/com.unity.mobile.notifications/Editor/iOSNotificationPostProcessor.cs
+++ b/com.unity.mobile.notifications/Editor/iOSNotificationPostProcessor.cs
@@ -17,6 +17,22 @@ public class iOSNotificationPostProcessor : MonoBehaviour
         if (buildTarget != BuildTarget.iOS)
             return;
 
+        // Check if we have the minimal iOS version set.
+        bool hasMinOSVersion;
+        try
+        {
+            var requiredVersion = new Version(10, 0);
+            var currentVersion = new Version(PlayerSettings.iOS.targetOSVersionString);
+            hasMinOSVersion = currentVersion >= requiredVersion;
+        }
+        catch (Exception)
+        {
+            hasMinOSVersion = false;
+        }
+
+        if (!hasMinOSVersion)
+            Debug.Log("UserNotifications framework is only available on iOS 10.0+, please make sure that you set a correct `Target minimum iOS Version` in Player Settings.");
+
         var projPath = path + "/Unity-iPhone.xcodeproj/project.pbxproj";
 
         var proj = new PBXProject();
@@ -82,21 +98,6 @@ public class iOSNotificationPostProcessor : MonoBehaviour
         // Get root
         var rootDict = plist.root;
 
-        var requiredVersion = new Version(8, 0);
-        bool hasMinOSVersion;
-
-        try
-        {
-            var currentVersion = new Version(PlayerSettings.iOS.targetOSVersionString);
-            hasMinOSVersion = currentVersion >= requiredVersion;
-        }
-        catch (Exception)
-        {
-            hasMinOSVersion = false;
-        }
-
-        if (!hasMinOSVersion)
-            Debug.Log("UserNotifications are only available on iOSSettings 10 and above, please make sure that you set a correct `Target minimum iOSSettings Version` in Player Settings.");
 
         foreach (var setting in settings)
         {


### PR DESCRIPTION
Improve the iOS post processor code by
- Splitting the function into several small ones.
- Fixed the wrong required iOS version.

This is an identical pr to https://github.com/Unity-Technologies/com.unity.mobile.notifications/pull/50 which has already approved but can't get merged into master with merging issue. So I created a new one to get it into master.