### PR TITLE
Case 1244642: Fixed the bug that we can't really set the foreground p…

### DIFF
--- a/com.unity.mobile.notifications/Editor/NotificationSettingsProvider.cs
+++ b/com.unity.mobile.notifications/Editor/NotificationSettingsProvider.cs
@@ -305,7 +305,7 @@ namespace Unity.Notifications
                 {
                     setting.Value = (AuthorizationOption)EditorGUILayout.EnumFlagsField((iOSAuthorizationOption)setting.Value, dropdownStyle);
                     if ((iOSAuthorizationOption)setting.Value == 0)
-                        setting.Value = (AuthorizationOption)iOSAuthorizationOption.All;
+                        setting.Value = (AuthorizationOption)(iOSAuthorizationOption.Badge | iOSAuthorizationOption.Sound | iOSAuthorizationOption.Alert);
                 }
                 if (EditorGUI.EndChangeCheck())
                 {

--- a/com.unity.mobile.notifications/Editor/NotificationSettingsProvider.cs
+++ b/com.unity.mobile.notifications/Editor/NotificationSettingsProvider.cs
@@ -300,8 +300,6 @@ namespace Unity.Notifications
                 else if (setting.Value.GetType() == typeof(PresentationOption))
                 {
                     setting.Value = (PresentationOption)EditorGUILayout.EnumFlagsField((iOSPresentationOption)setting.Value, dropdownStyle);
-                    if ((iOSPresentationOption)setting.Value == 0)
-                        setting.Value = (PresentationOption)iOSPresentationOption.All;
                 }
                 else if (setting.Value.GetType() == typeof(AuthorizationOption))
                 {

--- a/com.unity.mobile.notifications/Editor/iOSAuthorizationOption.cs
+++ b/com.unity.mobile.notifications/Editor/iOSAuthorizationOption.cs
@@ -5,6 +5,7 @@ namespace Unity.Notifications
     [Flags]
     internal enum iOSAuthorizationOption
     {
+        Default = 0,
         Badge = 1 << 0,
         Sound = 1 << 1,
         Alert = 1 << 2,

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -11,8 +11,6 @@
 #import <CoreLocation/CoreLocation.h>
 #endif
 
-const int kDefaultPresentationOptions = -1;
-
 @implementation UnityNotificationManager
 
 + (instancetype)sharedInstance
@@ -111,7 +109,7 @@ const int kDefaultPresentationOptions = -1;
     self.deviceToken = [str copy];
 }
 
-//Called when a notification is delivered to a foreground app.
+// Called when a notification is delivered to a foreground app.
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification
     withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler
 {
@@ -139,8 +137,6 @@ const int kDefaultPresentationOptions = -1;
         {
             showInForeground = YES;
             presentationOptions = self.remoteNotificationForegroundPresentationOptions;
-            if (presentationOptions == 0)
-                presentationOptions = kDefaultPresentationOptions;
         }
     }
     else
@@ -160,7 +156,7 @@ const int kDefaultPresentationOptions = -1;
     [[UnityNotificationManager sharedInstance] updateDeliveredNotificationList];
 }
 
-//Called to let your app know which action was selected by the user for a given notification.
+// Called to let your app know which action was selected by the user for a given notification.
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response
     withCompletionHandler:(nonnull void(^)(void))completionHandler
 {


### PR DESCRIPTION
Fixed bug https://fogbugz.unity3d.com/f/cases/1244642/.
Previously we don't allow users to set presentation option to None, if you select Nothing, we converted it to All. This caused problem if users don't want to show anything for remote notifications if the app is running in foreground.

So I removed this restriction from both notification settings side and the native plugin side.


To QA:
I personally verify on iOS locally.