### PR TITLE
Fixes for 1.3.1

### DIFF
--- a/add_sample.sh
+++ b/add_sample.sh
@@ -18,7 +18,7 @@ rm -rf tmp/Assets/Plugins
 mv tmp/Assets NotificationsSamples
 
 mv tmp/README.md NotificationsSamples/README.md
-mv tmp/License.md NotificationsSamples/Licnese.md
+mv tmp/License.md NotificationsSamples/License.md
 
 rm -rf tmp
 

--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Changes & Improvements:
+- [Editor] Improved content scaling in the Mobile Notifications settings UI.
+
 ### Fixes:
 - [Samples] [[1258554](https://issuetracker.unity3d.com/product/unity/issues/guid/1258554)] Fixed errors and warnings on startup in the demo scene.
 - [iOS] [[1259811](https://issuetracker.unity3d.com/product/unity/issues/guid/1259811)] Fixed UNITY_USES_REMOTE_NOTIFICATIONS being falsely set to 1 when Mobile Notifications isn't used.
+- [[1271866](https://issuetracker.unity3d.com/product/unity/issues/guid/1271866)] Fix AndroidReceivedNotificationMainThreadDispatcher allocating a new list on every frame.
 
 ## [1.3.0] - 2020-06-02
 

--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this package will be documented in this file.
 
-## [1.3.1] -
+## [Unreleased]
 
 ### Fixes:
 - [Samples] [[1258554](https://issuetracker.unity3d.com/product/unity/issues/guid/1258554)] Fixed errors and warnings on startup in the demo scene.

--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -5,13 +5,13 @@ All notable changes to this package will be documented in this file.
 ## [Unreleased]
 
 ### Changes & Improvements:
-- [Editor] Improved content scaling in the Mobile Notifications settings UI.
+- [Editor] [[1195293](https://issuetracker.unity3d.com/product/unity/issues/guid/1195293)] Improved content scaling in the Mobile Notifications settings UI.
 
 ### Fixes:
 - [Samples] [[1258554](https://issuetracker.unity3d.com/product/unity/issues/guid/1258554)] Fixed errors and warnings on startup in the demo scene.
 - [iOS] [[1259811](https://issuetracker.unity3d.com/product/unity/issues/guid/1259811)] Fixed UNITY_USES_REMOTE_NOTIFICATIONS being falsely set to 1 when Mobile Notifications isn't used.
-- [[Android] [1271866](https://issuetracker.unity3d.com/product/unity/issues/guid/1271866)] Fix AndroidReceivedNotificationMainThreadDispatcher allocating a new list on every frame.
-- [[Editor] [1254618](https://issuetracker.unity3d.com/product/unity/issues/guid/1254618)] Fix "SerializedObject target has been destroyed" errors when navigating Mobile Notifications settings.
+- [Android] [[1271866](https://issuetracker.unity3d.com/product/unity/issues/guid/1271866)] Fixed AndroidReceivedNotificationMainThreadDispatcher allocating a new list on every frame.
+- [Editor] [[1254618](https://issuetracker.unity3d.com/product/unity/issues/guid/1254618)] Fixed "SerializedObject target has been destroyed" errors when navigating Mobile Notifications settings.
 
 ## [1.3.0] - 2020-06-02
 

--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this package will be documented in this file.
 
+## [1.3.1] -
+
+### Fixes:
+- [Samples] [[1258554](https://issuetracker.unity3d.com/product/unity/issues/guid/1258554)] Fixed errors and warnings on startup in the demo scene.
+
 ## [1.3.0] - 2020-06-02
 
 ### Changes & Improvements:

--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this package will be documented in this file.
 
 ### Fixes:
 - [Samples] [[1258554](https://issuetracker.unity3d.com/product/unity/issues/guid/1258554)] Fixed errors and warnings on startup in the demo scene.
+- [iOS] [[1259811](https://issuetracker.unity3d.com/product/unity/issues/guid/1259811)] Fixed UNITY_USES_REMOTE_NOTIFICATIONS being falsely set to 1 when Mobile Notifications isn't used.
 
 ## [1.3.0] - 2020-06-02
 

--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this package will be documented in this file.
 
-## [Unreleased]
+## [1.3.1] - 2020-08-28
 
 ### Changes & Improvements:
 - [Editor] [[1195293](https://issuetracker.unity3d.com/product/unity/issues/guid/1195293)] Improved content scaling in the Mobile Notifications settings UI.

--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -10,7 +10,8 @@ All notable changes to this package will be documented in this file.
 ### Fixes:
 - [Samples] [[1258554](https://issuetracker.unity3d.com/product/unity/issues/guid/1258554)] Fixed errors and warnings on startup in the demo scene.
 - [iOS] [[1259811](https://issuetracker.unity3d.com/product/unity/issues/guid/1259811)] Fixed UNITY_USES_REMOTE_NOTIFICATIONS being falsely set to 1 when Mobile Notifications isn't used.
-- [[1271866](https://issuetracker.unity3d.com/product/unity/issues/guid/1271866)] Fix AndroidReceivedNotificationMainThreadDispatcher allocating a new list on every frame.
+- [[Android] [1271866](https://issuetracker.unity3d.com/product/unity/issues/guid/1271866)] Fix AndroidReceivedNotificationMainThreadDispatcher allocating a new list on every frame.
+- [[Editor] [1254618](https://issuetracker.unity3d.com/product/unity/issues/guid/1254618)] Fix "SerializedObject target has been destroyed" errors when navigating Mobile Notifications settings.
 
 ## [1.3.0] - 2020-06-02
 

--- a/com.unity.mobile.notifications/Editor/NotificationSettingsProvider.cs
+++ b/com.unity.mobile.notifications/Editor/NotificationSettingsProvider.cs
@@ -208,7 +208,8 @@ namespace Unity.Notifications
         public override void OnGUI(string searchContext)
         {
             // This has to be called to sync all the changes between m_SettingsManager and m_SettingsManagerObject.
-            m_SettingsManagerObject.Update();
+            if (m_SettingsManagerObject.targetObject != null)
+                m_SettingsManagerObject.Update();
 
             var noHeightRect = GUILayoutUtility.GetRect(GUIContent.none, EditorStyles.label, GUILayout.ExpandWidth(true), GUILayout.Height(0));
             var width = noHeightRect.width;

--- a/com.unity.mobile.notifications/Editor/NotificationSettingsProvider.cs
+++ b/com.unity.mobile.notifications/Editor/NotificationSettingsProvider.cs
@@ -213,8 +213,6 @@ namespace Unity.Notifications
 
             var noHeightRect = GUILayoutUtility.GetRect(GUIContent.none, EditorStyles.label, GUILayout.ExpandWidth(true), GUILayout.Height(0));
             var width = noHeightRect.width;
-            if (width < k_SlotSize * 10)
-                width = k_SlotSize * 10;
 
             var totalRect = new Rect(k_Padding, 0f, width - k_Padding, Screen.height);
 

--- a/com.unity.mobile.notifications/Editor/iOSNotificationPostProcessor.cs
+++ b/com.unity.mobile.notifications/Editor/iOSNotificationPostProcessor.cs
@@ -47,7 +47,7 @@ public class iOSNotificationPostProcessor : MonoBehaviour
 
         PatchPBXProject(path, needLocationFramework, addPushNotificationCapability, useReleaseAPSEnv);
         PatchPlist(path, settings, addPushNotificationCapability);
-        PatchPreprocessor(path, needLocationFramework);
+        PatchPreprocessor(path, needLocationFramework, addPushNotificationCapability);
     }
 
     private static void PatchPBXProject(string path, bool needLocationFramework, bool addPushNotificationCapability, bool useReleaseAPSEnv)
@@ -128,7 +128,7 @@ public class iOSNotificationPostProcessor : MonoBehaviour
         File.WriteAllText(plistPath, plist.WriteToString());
     }
 
-    private static void PatchPreprocessor(string path, bool needLocationFramework)
+    private static void PatchPreprocessor(string path, bool needLocationFramework, bool addPushNotificationCapability)
     {
         var preprocessorPath = path + "/Classes/Preprocessor.h";
         var preprocessor = File.ReadAllText(preprocessorPath);
@@ -136,7 +136,8 @@ public class iOSNotificationPostProcessor : MonoBehaviour
         if (needLocationFramework && preprocessor.Contains("UNITY_USES_LOCATION"))
             preprocessor = preprocessor.Replace("UNITY_USES_LOCATION 0", "UNITY_USES_LOCATION 1");
 
-        preprocessor = preprocessor.Replace("UNITY_USES_REMOTE_NOTIFICATIONS 0", "UNITY_USES_REMOTE_NOTIFICATIONS 1");
+        if (addPushNotificationCapability && preprocessor.Contains("UNITY_USES_REMOTE_NOTIFICATIONS"))
+            preprocessor = preprocessor.Replace("UNITY_USES_REMOTE_NOTIFICATIONS 0", "UNITY_USES_REMOTE_NOTIFICATIONS 1");
 
         File.WriteAllText(preprocessorPath, preprocessor);
     }

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidReceivedNotificationMainThreadDispatcher.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidReceivedNotificationMainThreadDispatcher.cs
@@ -7,7 +7,9 @@ namespace Unity.Notifications.Android
     {
         private static AndroidReceivedNotificationMainThreadDispatcher instance = null;
 
-        private static Queue<AndroidJavaObject> s_ReceivedNotificationQueue = new Queue<AndroidJavaObject>();
+        private static readonly Queue<AndroidJavaObject> s_ReceivedNotificationQueue = new Queue<AndroidJavaObject>();
+
+        private static readonly List<AndroidJavaObject> s_ReceivedNotificationList = new List<AndroidJavaObject>();
 
         internal static void EnqueueReceivedNotification(AndroidJavaObject intent)
         {
@@ -24,19 +26,20 @@ namespace Unity.Notifications.Android
 
         public void Update()
         {
-            var tempList = new List<AndroidJavaObject>();
             // Note: Don't call callbacks while locking receivedNotificationQueue, otherwise there's a risk
             //       that callback might introduce an operations which would create a deadlock
             lock (s_ReceivedNotificationQueue)
             {
-                tempList.AddRange(s_ReceivedNotificationQueue);
+                s_ReceivedNotificationList.AddRange(s_ReceivedNotificationQueue);
                 s_ReceivedNotificationQueue.Clear();
             }
 
-            foreach (var t in tempList)
+            foreach (var notification in s_ReceivedNotificationList)
             {
-                AndroidNotificationCenter.ReceivedNotificationCallback(t);
+                AndroidNotificationCenter.ReceivedNotificationCallback(notification);
             }
+
+            s_ReceivedNotificationList.Clear();
         }
 
         void Awake()

--- a/com.unity.mobile.notifications/package.json
+++ b/com.unity.mobile.notifications/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.mobile.notifications",
   "displayName": "Mobile Notifications",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "unity": "2018.3",
   "description": "Mobile Notifications package adds support for scheduling local repeatable or one-time notifications on iOS and Android.\n\nRequires iOS 10 and Android 4.4 or above.",
   "keywords": [


### PR DESCRIPTION
Bump version to 1.3.1:
- Improved content scaling in the Mobile Notifications settings UI.
- Fixed errors and warnings on startup in the demo scene.
- Fixed UNITY_USES_REMOTE_NOTIFICATIONS being falsely set to 1 when Mobile Notifications isn't used.
- Fixed AndroidReceivedNotificationMainThreadDispatcher allocating a new list on every frame.
- Fixed "SerializedObject target has been destroyed" errors when navigating Mobile Notifications settings.
- Fixed typo in NotificationsSample setup script.