### PR TITLE
Fix Android crash when many notifications are scheduled at once (case…

### DIFF
--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this package will be documented in this file.
 - [iOS] [[1259811](https://issuetracker.unity3d.com/product/unity/issues/guid/1259811)] Fixed UNITY_USES_REMOTE_NOTIFICATIONS being falsely set to 1 when Mobile Notifications isn't used.
 - [Android] [[1271866](https://issuetracker.unity3d.com/product/unity/issues/guid/1271866)] Fixed AndroidReceivedNotificationMainThreadDispatcher allocating a new list on every frame.
 - [Editor] [[1254618](https://issuetracker.unity3d.com/product/unity/issues/guid/1254618)] Fixed "SerializedObject target has been destroyed" errors when navigating Mobile Notifications settings.
+- [Android] [[1172850](https://issuetracker.unity3d.com/product/unity/issues/guid/1172850)] Fix Android crash when many notifications are scheduled at once.
 
 ## [1.3.0] - 2020-06-02
 


### PR DESCRIPTION
Fix Android app crash when a high number of notifications is scheduled ([case 1172850](https://fogbugz.unity3d.com/f/cases/1172850/)).
When profiling the app, it was clear that the crash was caused by GC overhead caused by excess allocations and destructions each time a notification was polled. To remedy this, some of the iterative allocations were replaced by static, re-usable members of AndroidNotificationCenter class.

In the repro project, 1000 notifications are scheduled to cause a crash, but it seems that ~50 notifications is the maximum limit for the number of notifications the OS allows at once.

Tester notice:
* Please check the target FB case no longer reproduces.
* It may still be possible for the crash to occur on old/low-end devices, but the optimization in this PR reduces those chances greatly.