### PR TITLE
Location related fixes for iOS

### DIFF
--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.h
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.h
@@ -28,12 +28,12 @@ typedef struct iOSNotificationData
 
     //Custom data
     char* data;
-    BOOL showInForeground;
+    int showInForeground;
     int showInForegroundPresentationOptions;
 
     // Trigger
     int triggerType;  //0 - time, 1 - calendar, 2 - location, 3 - push.
-    BOOL repeats;
+    int repeats;
 
     //Time trigger
     int timeTriggerInterval;
@@ -50,8 +50,8 @@ typedef struct iOSNotificationData
     float locationTriggerCenterX;
     float locationTriggerCenterY;
     float locationTriggerRadius;
-    bool locationTriggerNotifyOnEntry;
-    bool locationTriggerNotifyOnExit;
+    int locationTriggerNotifyOnEntry;
+    int locationTriggerNotifyOnExit;
 } iOSNotificationData;
 
 typedef struct iOSNotificationAuthorizationData

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
@@ -221,7 +221,7 @@ namespace Unity.Notifications.iOS
                     var trigger = (iOSNotificationLocationTrigger)value;
                     data.triggerType = iOSNotificationLocationTrigger.Type;
                     data.locationTriggerCenterX = trigger.Center.x;
-                    data.locationTriggerCenterY = trigger.Center.x;
+                    data.locationTriggerCenterY = trigger.Center.y;
                     data.locationTriggerNotifyOnEntry = trigger.NotifyOnEntry;
                     data.locationTriggerNotifyOnExit = trigger.NotifyOnExit;
                     data.locationTriggerRadius = trigger.Radius;


### PR DESCRIPTION
Fix iOSNotificationData struct marshalling (bools are marshalled as 32-bit integers, so far all worked fine thanks to alignment except for locationTriggerNotifyOnExit always being false (and would have issues if one more field was appended).
Location coordinate had typo and wasn't passed correctly.