### PR TITLE
Fix SettingsProvider not loading correctly after entering EditMode

### DIFF
--- a/com.unity.mobile.notifications/Editor/NotificationSettingsProvider.cs
+++ b/com.unity.mobile.notifications/Editor/NotificationSettingsProvider.cs
@@ -47,6 +47,7 @@ namespace Unity.Notifications
         public override void OnDeactivate()
         {
             m_SettingsManager.SaveSettings(false);
+            SettingsService.NotifySettingsProviderChanged();
         }
 
         private void Initialize()


### PR DESCRIPTION
If Notifications Settings window would be visible while entering edit mode (enter & exit play mode), this would result in the settings window loading incorrectly (issue #67), and exceptions being thrown when trying to interact with it.
Adding an explicit refresh of the window after it loses focus.