### PR TITLE
Thread-safety to AuthorizationRequest

### DIFF
--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this package will be documented in this file.
 
+## [1.4.0] - 2020-11-26
+
+### Fixes:
+- [iOS] Multiple authorization requests now can be performed simultaneously.
+
 ## [1.3.2] - 2020-11-10
 
 ### Changes & Improvements:

--- a/com.unity.mobile.notifications/Runtime/iOS/AuthorizationRequest.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/AuthorizationRequest.cs
@@ -89,6 +89,11 @@ namespace Unity.Notifications.iOS
         /// </summary>
         public string DeviceToken { get; private set; }
 
+        static AuthorizationRequest()
+        {
+            iOSNotificationsWrapper.RegisterAuthorizationRequestCallback();
+        }
+
         /// <summary>
         /// Initiate an authorization request.
         /// </summary>
@@ -97,7 +102,6 @@ namespace Unity.Notifications.iOS
         /// If registration succeeds the DeviceToken will be returned. You should pass this token along to the server you use to generate remote notifications for the device. </param>
         public AuthorizationRequest(AuthorizationOption authorizationOption, bool registerForRemoteNotifications)
         {
-            iOSNotificationsWrapper.RegisterAuthorizationRequestCallback();
             iOSNotificationsWrapper.RequestAuthorization((int)authorizationOption, registerForRemoteNotifications);
 
             iOSNotificationCenter.OnAuthorizationRequestCompleted += OnAuthorizationRequestCompleted;

--- a/com.unity.mobile.notifications/Runtime/iOS/AuthorizationRequest.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/AuthorizationRequest.cs
@@ -147,8 +147,9 @@ namespace Unity.Notifications.iOS
                 handle.Free();
                 req.OnAuthorizationRequestCompleted(requestData);
             }
-            catch
+            catch (Exception e)
             {
+                Debug.LogException(e);
             }
         }
 

--- a/com.unity.mobile.notifications/Runtime/iOS/AuthorizationRequest.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/AuthorizationRequest.cs
@@ -34,9 +34,8 @@ namespace Unity.Notifications.iOS
     [StructLayout(LayoutKind.Sequential)]
     internal struct iOSAuthorizationRequestData
     {
-        internal bool granted;
+        internal int granted;
         internal string error;
-        internal bool finished;
         internal string deviceToken;
     }
 
@@ -132,8 +131,8 @@ namespace Unity.Notifications.iOS
         {
             lock (this)
             {
-                IsFinished = requestData.finished;
-                Granted = requestData.granted;
+                IsFinished = true;
+                Granted = requestData.granted != 0;
                 Error = requestData.error;
                 DeviceToken = requestData.deviceToken;
             }

--- a/com.unity.mobile.notifications/Runtime/iOS/AuthorizationRequest.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/AuthorizationRequest.cs
@@ -68,26 +68,48 @@ namespace Unity.Notifications.iOS
     /// </example>
     public class AuthorizationRequest : IDisposable
     {
+        bool _IsFinished;
+        bool _Granted;
+        string _Error;
+        string _DeviceToken;
+
         /// <summary>
         /// Indicates whether the authorization request has completed.
         /// </summary>
-        public bool IsFinished { get; private set; }
+        public bool IsFinished
+        {
+            get { lock (this) { return _IsFinished; } }
+            private set { _IsFinished = value; }
+        }
 
         /// <summary>
         /// A property indicating whether authorization was granted. The value of this parameter is set to true when authorization was granted for one or more options. The value is set to false when authorization is denied for all options.
         /// </summary>
-        public bool Granted { get; private set; }
+        public bool Granted
+        {
+            get { lock (this) { return _Granted; } }
+            private set { _Granted = value; }
+        }
 
         /// <summary>
         /// Contains error information of the request failed for some reason or an empty string if no error occurred.
         /// </summary>
-        public string Error { get; private set; }
+        public string Error
+        {
+            get { lock (this) { return _Error; } }
+            private set { _Error = value; }
+        }
+
         /// <summary>
         /// A globally unique token that identifies this device to Apple Push Notification Network. Send this token to the server that you use to generate remote notifications.
         /// Your server must pass this token unmodified back to APNs when sending those remote notifications.
         /// This property will be empty if you set the registerForRemoteNotifications parameter to false when creating the Authorization request or if the app fails registration with the APN.
         /// </summary>
-        public string DeviceToken { get; private set; }
+        public string DeviceToken
+        {
+            get { lock (this) { return _DeviceToken; } }
+            private set { _DeviceToken = value; }
+        }
 
         static AuthorizationRequest()
         {
@@ -108,10 +130,13 @@ namespace Unity.Notifications.iOS
 
         private void OnAuthorizationRequestCompleted(iOSAuthorizationRequestData requestData)
         {
-            IsFinished = requestData.finished;
-            Granted = requestData.granted;
-            Error = requestData.error;
-            DeviceToken = requestData.deviceToken;
+            lock (this)
+            {
+                IsFinished = requestData.finished;
+                Granted = requestData.granted;
+                Error = requestData.error;
+                DeviceToken = requestData.deviceToken;
+            }
         }
 
         internal static void OnAuthorizationRequestCompleted(IntPtr request, iOSAuthorizationRequestData requestData)

--- a/com.unity.mobile.notifications/Runtime/iOS/AuthorizationRequest.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/AuthorizationRequest.cs
@@ -67,18 +67,18 @@ namespace Unity.Notifications.iOS
     /// </example>
     public class AuthorizationRequest : IDisposable
     {
-        bool _IsFinished;
-        bool _Granted;
-        string _Error;
-        string _DeviceToken;
+        bool m_IsFinished;
+        bool m_Granted;
+        string m_Error;
+        string m_DeviceToken;
 
         /// <summary>
         /// Indicates whether the authorization request has completed.
         /// </summary>
         public bool IsFinished
         {
-            get { lock (this) { return _IsFinished; } }
-            private set { _IsFinished = value; }
+            get { lock (this) { return m_IsFinished; } }
+            private set { m_IsFinished = value; }
         }
 
         /// <summary>
@@ -86,8 +86,8 @@ namespace Unity.Notifications.iOS
         /// </summary>
         public bool Granted
         {
-            get { lock (this) { return _Granted; } }
-            private set { _Granted = value; }
+            get { lock (this) { return m_Granted; } }
+            private set { m_Granted = value; }
         }
 
         /// <summary>
@@ -95,8 +95,8 @@ namespace Unity.Notifications.iOS
         /// </summary>
         public string Error
         {
-            get { lock (this) { return _Error; } }
-            private set { _Error = value; }
+            get { lock (this) { return m_Error; } }
+            private set { m_Error = value; }
         }
 
         /// <summary>
@@ -106,8 +106,8 @@ namespace Unity.Notifications.iOS
         /// </summary>
         public string DeviceToken
         {
-            get { lock (this) { return _DeviceToken; } }
-            private set { _DeviceToken = value; }
+            get { lock (this) { return m_DeviceToken; } }
+            private set { m_DeviceToken = value; }
         }
 
         static AuthorizationRequest()

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityAppController+Notifications.mm
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityAppController+Notifications.mm
@@ -86,7 +86,7 @@
                  NSData* data = (NSData*)notification.userInfo;
                  [manager setDeviceTokenFromNSData: data];
              }
-             [manager finishAuthorization];
+             [manager finishAuthorization: YES];
          }];
 
         [nc addObserverForName: kUnityDidFailToRegisterForRemoteNotificationsWithError
@@ -96,7 +96,7 @@
              NSLog(@"didFailToRegisterForRemoteNotificationsWithError");
              UnityNotificationManager* manager = [UnityNotificationManager sharedInstance];
              manager.remoteNotificationsRegistered = UNAuthorizationStatusDenied;
-             [manager finishAuthorization];
+             [manager finishAuthorization: NO];
          }];
     });
     return sharedInstance;

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityAppController+Notifications.mm
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityAppController+Notifications.mm
@@ -79,7 +79,7 @@
          usingBlock:^(NSNotification *notification) {
              NSLog(@"didRegisterForRemoteNotificationsWithDeviceToken");
              UnityNotificationManager* manager = [UnityNotificationManager sharedInstance];
-             [manager finishRemoveNotificationRegistration:UNAuthorizationStatusAuthorized notification:notification];
+             [manager finishRemoteNotificationRegistration:UNAuthorizationStatusAuthorized notification:notification];
          }];
 
         [nc addObserverForName: kUnityDidFailToRegisterForRemoteNotificationsWithError
@@ -88,7 +88,7 @@
          usingBlock:^(NSNotification *notification) {
              NSLog(@"didFailToRegisterForRemoteNotificationsWithError");
              UnityNotificationManager* manager = [UnityNotificationManager sharedInstance];
-             [manager finishRemoveNotificationRegistration:UNAuthorizationStatusDenied notification:notification];
+             [manager finishRemoteNotificationRegistration:UNAuthorizationStatusDenied notification:notification];
          }];
     });
     return sharedInstance;

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityAppController+Notifications.mm
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityAppController+Notifications.mm
@@ -68,7 +68,7 @@
              if (authorizeOnLaunch)
              {
                  UnityNotificationManager* manager = [UnityNotificationManager sharedInstance];
-                 [manager requestAuthorization: defaultAuthorizationOptions withRegisterRemote: registerRemoteOnLaunch];
+                 [manager requestAuthorization: defaultAuthorizationOptions withRegisterRemote: registerRemoteOnLaunch forRequest: NULL];
                  manager.remoteNotificationForegroundPresentationOptions = remoteForegroundPresentationOptions;
              }
          }];

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityAppController+Notifications.mm
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityAppController+Notifications.mm
@@ -79,14 +79,7 @@
          usingBlock:^(NSNotification *notification) {
              NSLog(@"didRegisterForRemoteNotificationsWithDeviceToken");
              UnityNotificationManager* manager = [UnityNotificationManager sharedInstance];
-             manager.remoteNotificationsRegistered = UNAuthorizationStatusAuthorized;
-
-             if ([notification.userInfo isKindOfClass: [NSData class]])
-             {
-                 NSData* data = (NSData*)notification.userInfo;
-                 [manager setDeviceTokenFromNSData: data];
-             }
-             [manager finishAuthorization: YES];
+             [manager finishRemoveNotificationRegistration:UNAuthorizationStatusAuthorized notification:notification];
          }];
 
         [nc addObserverForName: kUnityDidFailToRegisterForRemoteNotificationsWithError
@@ -95,8 +88,7 @@
          usingBlock:^(NSNotification *notification) {
              NSLog(@"didFailToRegisterForRemoteNotificationsWithError");
              UnityNotificationManager* manager = [UnityNotificationManager sharedInstance];
-             manager.remoteNotificationsRegistered = UNAuthorizationStatusDenied;
-             [manager finishAuthorization: NO];
+             [manager finishRemoveNotificationRegistration:UNAuthorizationStatusDenied notification:notification];
          }];
     });
     return sharedInstance;

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityAppController+Notifications.mm
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityAppController+Notifications.mm
@@ -79,7 +79,7 @@
          usingBlock:^(NSNotification *notification) {
              NSLog(@"didRegisterForRemoteNotificationsWithDeviceToken");
              UnityNotificationManager* manager = [UnityNotificationManager sharedInstance];
-             [manager finishRemoteNotificationRegistration:UNAuthorizationStatusAuthorized notification:notification];
+             [manager finishRemoteNotificationRegistration: UNAuthorizationStatusAuthorized notification: notification];
          }];
 
         [nc addObserverForName: kUnityDidFailToRegisterForRemoteNotificationsWithError
@@ -88,7 +88,7 @@
          usingBlock:^(NSNotification *notification) {
              NSLog(@"didFailToRegisterForRemoteNotificationsWithError");
              UnityNotificationManager* manager = [UnityNotificationManager sharedInstance];
-             [manager finishRemoteNotificationRegistration:UNAuthorizationStatusDenied notification:notification];
+             [manager finishRemoteNotificationRegistration: UNAuthorizationStatusDenied notification: notification];
          }];
     });
     return sharedInstance;

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityAppController+Notifications.mm
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityAppController+Notifications.mm
@@ -86,7 +86,7 @@
                  NSData* data = (NSData*)notification.userInfo;
                  [manager setDeviceTokenFromNSData: data];
              }
-             [manager checkAuthorizationFinished];
+             [manager finishAuthorization];
          }];
 
         [nc addObserverForName: kUnityDidFailToRegisterForRemoteNotificationsWithError
@@ -96,7 +96,7 @@
              NSLog(@"didFailToRegisterForRemoteNotificationsWithError");
              UnityNotificationManager* manager = [UnityNotificationManager sharedInstance];
              manager.remoteNotificationsRegistered = UNAuthorizationStatusDenied;
-             [manager checkAuthorizationFinished];
+             [manager finishAuthorization];
          }];
     });
     return sharedInstance;

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.h
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.h
@@ -75,7 +75,7 @@ typedef struct NotificationSettingsData
 } NotificationSettingsData;
 
 typedef void (*NotificationDataReceivedResponse)(struct iOSNotificationData* data);
-typedef void (*AuthorizationRequestResponse) (void* request, struct iOSNotificationAuthorizationData* data);
+typedef void (*AuthorizationRequestResponse) (void* request, struct iOSNotificationAuthorizationData data);
 
 // Who calls these two below methods should be responsible for freeing the returned memory.
 NotificationSettingsData* UNNotificationSettingsToNotificationSettingsData(UNNotificationSettings* settings);

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.h
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.h
@@ -56,9 +56,8 @@ typedef struct iOSNotificationData
 
 typedef struct iOSNotificationAuthorizationData
 {
-    bool granted;
+    int granted;
     const char* error;
-    bool finished;
     const char* deviceToken;
 } iOSNotificationAuthorizationData;
 

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.h
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.h
@@ -76,7 +76,7 @@ typedef struct NotificationSettingsData
 } NotificationSettingsData;
 
 typedef void (*NotificationDataReceivedResponse)(struct iOSNotificationData* data);
-typedef void (*AuthorizationRequestResponse) (struct iOSNotificationAuthorizationData* data);
+typedef void (*AuthorizationRequestResponse) (void* request, struct iOSNotificationAuthorizationData* data);
 
 // Who calls these two below methods should be responsible for freeing the returned memory.
 NotificationSettingsData* UNNotificationSettingsToNotificationSettingsData(UNNotificationSettings* settings);

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
@@ -26,7 +26,6 @@
 
 @property (nonatomic) UNNotification* lastReceivedNotification;
 
-@property BOOL authorized;
 @property BOOL authorizationRequestFinished;
 @property BOOL needRemoteNotifications;
 @property NSString* deviceToken;

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
@@ -15,7 +15,6 @@
 @interface UnityNotificationManager : NSObject<UNUserNotificationCenterDelegate>
 
 @property UNNotificationSettings* cachedNotificationSettings;
-@property struct iOSNotificationAuthorizationData* authData;
 
 @property NotificationDataReceivedResponse onNotificationReceivedCallback;
 @property NotificationDataReceivedResponse onRemoteNotificationReceivedCallback;
@@ -32,7 +31,7 @@
 
 + (instancetype)sharedInstance;
 
-- (void)finishAuthorization:(BOOL)granted;
+- (void)finishAuthorization:(struct iOSNotificationAuthorizationData*)authData;
 - (void)finishRemoveNotificationRegistration:(UNAuthorizationStatus)status notification:(NSNotification*) notification;
 - (void)updateScheduledNotificationList;
 - (void)updateDeliveredNotificationList;

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
@@ -26,7 +26,6 @@
 
 @property (nonatomic) UNNotification* lastReceivedNotification;
 
-@property BOOL needRemoteNotifications;
 @property NSString* deviceToken;
 @property UNAuthorizationStatus remoteNotificationsRegistered;
 

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
@@ -26,7 +26,6 @@
 
 @property (nonatomic) UNNotification* lastReceivedNotification;
 
-@property BOOL authorizationRequestFinished;
 @property BOOL needRemoteNotifications;
 @property NSString* deviceToken;
 @property UNAuthorizationStatus remoteNotificationsRegistered;
@@ -35,7 +34,7 @@
 
 + (instancetype)sharedInstance;
 
-- (void)finishAuthorization;
+- (void)finishAuthorization:(BOOL)granted;
 - (void)updateScheduledNotificationList;
 - (void)updateDeliveredNotificationList;
 - (void)updateNotificationSettings;

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
@@ -30,12 +30,12 @@
 + (instancetype)sharedInstance;
 
 - (id)init;
-- (void)finishAuthorization:(struct iOSNotificationAuthorizationData*)authData;
+- (void)finishAuthorization:(struct iOSNotificationAuthorizationData*)authData forRequest:(void*)request;
 - (void)finishRemoteNotificationRegistration:(UNAuthorizationStatus)status notification:(NSNotification*) notification;
 - (void)updateScheduledNotificationList;
 - (void)updateDeliveredNotificationList;
 - (void)updateNotificationSettings;
-- (void)requestAuthorization:(NSInteger)authorizationOptions withRegisterRemote:(BOOL)registerRemote;
+- (void)requestAuthorization:(NSInteger)authorizationOptions withRegisterRemote:(BOOL)registerRemote forRequest:(void*)request;
 - (void)scheduleLocalNotification:(iOSNotificationData*)data;
 
 @end

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
@@ -31,7 +31,7 @@
 
 - (id)init;
 - (void)finishAuthorization:(struct iOSNotificationAuthorizationData*)authData;
-- (void)finishRemoveNotificationRegistration:(UNAuthorizationStatus)status notification:(NSNotification*) notification;
+- (void)finishRemoteNotificationRegistration:(UNAuthorizationStatus)status notification:(NSNotification*) notification;
 - (void)updateScheduledNotificationList;
 - (void)updateDeliveredNotificationList;
 - (void)updateNotificationSettings;

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
@@ -27,18 +27,17 @@
 @property (nonatomic) UNNotification* lastReceivedNotification;
 
 @property NSString* deviceToken;
-@property UNAuthorizationStatus remoteNotificationsRegistered;
 
 @property UNNotificationPresentationOptions remoteNotificationForegroundPresentationOptions;
 
 + (instancetype)sharedInstance;
 
 - (void)finishAuthorization:(BOOL)granted;
+- (void)finishRemoveNotificationRegistration:(UNAuthorizationStatus)status notification:(NSNotification*) notification;
 - (void)updateScheduledNotificationList;
 - (void)updateDeliveredNotificationList;
 - (void)updateNotificationSettings;
 - (void)requestAuthorization:(NSInteger)authorizationOptions withRegisterRemote:(BOOL)registerRemote;
-- (void)setDeviceTokenFromNSData:(NSData*)deviceToken;
 - (void)scheduleLocalNotification:(iOSNotificationData*)data;
 
 @end

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
@@ -31,7 +31,7 @@
 
 - (id)init;
 - (void)finishAuthorization:(struct iOSNotificationAuthorizationData*)authData forRequest:(void*)request;
-- (void)finishRemoteNotificationRegistration:(UNAuthorizationStatus)status notification:(NSNotification*) notification;
+- (void)finishRemoteNotificationRegistration:(UNAuthorizationStatus)status notification:(NSNotification*)notification;
 - (void)updateScheduledNotificationList;
 - (void)updateDeliveredNotificationList;
 - (void)updateNotificationSettings;

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
@@ -25,12 +25,11 @@
 
 @property (nonatomic) UNNotification* lastReceivedNotification;
 
-@property NSString* deviceToken;
-
 @property UNNotificationPresentationOptions remoteNotificationForegroundPresentationOptions;
 
 + (instancetype)sharedInstance;
 
+- (id)init;
 - (void)finishAuthorization:(struct iOSNotificationAuthorizationData*)authData;
 - (void)finishRemoveNotificationRegistration:(UNAuthorizationStatus)status notification:(NSNotification*) notification;
 - (void)updateScheduledNotificationList;

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
@@ -35,7 +35,7 @@
 
 + (instancetype)sharedInstance;
 
-- (void)checkAuthorizationFinished;
+- (void)finishAuthorization;
 - (void)updateScheduledNotificationList;
 - (void)updateDeliveredNotificationList;
 - (void)updateNotificationSettings;

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -46,7 +46,7 @@
         self.onAuthorizationCompletionCallback(authData);
 }
 
-- (void)finishRemoveNotificationRegistration:(UNAuthorizationStatus)status notification:(NSNotification*) notification
+- (void)finishRemoteNotificationRegistration:(UNAuthorizationStatus)status notification:(NSNotification*) notification
 {
     struct iOSNotificationAuthorizationData authData;
     authData.granted = status == UNAuthorizationStatusAuthorized;

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -48,14 +48,14 @@
         self.onAuthorizationCompletionCallback(request, authData);
 }
 
-- (void)finishRemoteNotificationRegistration:(UNAuthorizationStatus)status notification:(NSNotification*) notification
+- (void)finishRemoteNotificationRegistration:(UNAuthorizationStatus)status notification:(NSNotification*)notification
 {
     struct iOSNotificationAuthorizationData authData;
     authData.granted = status == UNAuthorizationStatusAuthorized;
     NSString* deviceToken = nil;
     if (authData.granted)
     {
-        deviceToken = [UnityNotificationManager deviceTokenFromNotification:notification];
+        deviceToken = [UnityNotificationManager deviceTokenFromNotification: notification];
         authData.deviceToken = [deviceToken UTF8String];
     }
     authData.error = NULL;
@@ -70,8 +70,8 @@
     while (pointers.count > 0)
     {
         unsigned long idx = pointers.count - 1;
-        void* request = [pointers pointerAtIndex:idx];
-        [pointers removePointerAtIndex:idx];
+        void* request = [pointers pointerAtIndex: idx];
+        [pointers removePointerAtIndex: idx];
         [self finishAuthorization: &authData forRequest: request];
     }
 }
@@ -103,8 +103,8 @@
                 if (request)
                 {
                     if (_pendingRemoteAuthRequests == nil)
-                        _pendingRemoteAuthRequests = [NSPointerArray pointerArrayWithOptions:NSPointerFunctionsOpaqueMemory];
-                    [_pendingRemoteAuthRequests addPointer:request];
+                        _pendingRemoteAuthRequests = [NSPointerArray pointerArrayWithOptions: NSPointerFunctionsOpaqueMemory];
+                    [_pendingRemoteAuthRequests addPointer: request];
                 }
                 dispatch_async(dispatch_get_main_queue(), ^{
                     [[UIApplication sharedApplication] registerForRemoteNotifications];
@@ -123,7 +123,7 @@
     }];
 }
 
-+ (NSString*)deviceTokenFromNotification:(NSNotification*) notification
++ (NSString*)deviceTokenFromNotification:(NSNotification*)notification
 {
     NSData* deviceTokenData;
     if ([notification.userInfo isKindOfClass: [NSData class]])

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -59,7 +59,7 @@
     UNUserNotificationCenter* center = [UNUserNotificationCenter currentNotificationCenter];
 
     BOOL supportsPushNotification = [[[NSBundle mainBundle] objectForInfoDictionaryKey: @"UnityAddRemoteNotificationCapability"] boolValue];
-    registerRemote = supportsPushNotification == YES ? registerRemote : NO;
+    registerRemote = registerRemote && supportsPushNotification;
 
     [center requestAuthorizationWithOptions: authorizationOptions completionHandler:^(BOOL granted, NSError * _Nullable error)
     {

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -27,7 +27,7 @@
     return sharedInstance;
 }
 
-- (void)checkAuthorizationFinished
+- (void)finishAuthorization
 {
     bool requestRejected = self.authorizationRequestFinished;
 
@@ -88,7 +88,7 @@
             NSLog(@"Requesting notification authorization failed with: %@", error);
         }
 
-        [self checkAuthorizationFinished];
+        [self finishAuthorization];
         [self updateNotificationSettings];
     }];
 }

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -58,7 +58,6 @@
         deviceToken = [UnityNotificationManager deviceTokenFromNotification:notification];
         authData.deviceToken = [deviceToken UTF8String];
     }
-    authData.finished = YES;
     authData.error = NULL;
 
     [_lock lock];
@@ -91,7 +90,6 @@
     {
         BOOL authorizationRequestFinished = YES;
         struct iOSNotificationAuthorizationData authData;
-        authData.finished = YES;
         authData.granted = granted;
         authData.error =  [[error localizedDescription]cStringUsingEncoding: NSUTF8StringEncoding];
         authData.deviceToken = "";

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -79,6 +79,8 @@
                     [[UIApplication sharedApplication] registerForRemoteNotifications];
                 });
             }
+            else
+                authData.deviceToken = [self.deviceToken UTF8String];
         }
         else
             NSLog(@"Requesting notification authorization failed with: %@", error);

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -40,10 +40,10 @@
     return self;
 }
 
-- (void)finishAuthorization:(struct iOSNotificationAuthorizationData*)authData
+- (void)finishAuthorization:(struct iOSNotificationAuthorizationData*)authData forRequest:(void*)request
 {
     if (self.onAuthorizationCompletionCallback != NULL)
-        self.onAuthorizationCompletionCallback(authData);
+        self.onAuthorizationCompletionCallback(request, authData);
 }
 
 - (void)finishRemoteNotificationRegistration:(UNAuthorizationStatus)status notification:(NSNotification*) notification
@@ -64,10 +64,10 @@
     _deviceToken = deviceToken;
     [_lock unlock];
 
-    [self finishAuthorization: &authData];
+    [self finishAuthorization: &authData forRequest: NULL];
 }
 
-- (void)requestAuthorization:(NSInteger)authorizationOptions withRegisterRemote:(BOOL)registerRemote
+- (void)requestAuthorization:(NSInteger)authorizationOptions withRegisterRemote:(BOOL)registerRemote forRequest:(void*)request
 {
     if (!SYSTEM_VERSION_10_OR_ABOVE)
         return;
@@ -104,7 +104,7 @@
             NSLog(@"Requesting notification authorization failed with: %@", error);
 
         if (authorizationRequestFinished)
-            [self finishAuthorization: &authData];
+            [self finishAuthorization: &authData forRequest: request];
         [self updateNotificationSettings];
     }];
 }

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -45,7 +45,7 @@
 - (void)finishAuthorization:(struct iOSNotificationAuthorizationData*)authData forRequest:(void*)request
 {
     if (self.onAuthorizationCompletionCallback != NULL && request)
-        self.onAuthorizationCompletionCallback(request, authData);
+        self.onAuthorizationCompletionCallback(request, *authData);
 }
 
 - (void)finishRemoteNotificationRegistration:(UNAuthorizationStatus)status notification:(NSNotification*)notification

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -29,7 +29,7 @@
 
 - (void)checkAuthorizationFinished
 {
-    bool requestRejected = self.authorizationRequestFinished && !self.authorized;
+    bool requestRejected = self.authorizationRequestFinished;
 
     if (!requestRejected && self.needRemoteNotifications && self.remoteNotificationsRegistered == UNAuthorizationStatusNotDetermined)
         return;
@@ -68,8 +68,7 @@
         authData->deviceToken = "";
 
         self.authData = authData;
-        self.authorized = granted;
-        if (self.authorized)
+        if (granted)
         {
             if (registerRemote)
             {

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -50,7 +50,6 @@
     BOOL supportsPushNotification = [[[NSBundle mainBundle] objectForInfoDictionaryKey: @"UnityAddRemoteNotificationCapability"] boolValue];
     registerRemote = supportsPushNotification == YES ? registerRemote : NO;
 
-    self.needRemoteNotifications = registerRemote;
     [center requestAuthorizationWithOptions: authorizationOptions completionHandler:^(BOOL granted, NSError * _Nullable error)
     {
         BOOL authorizationRequestFinished = YES;

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationWrapper.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationWrapper.m
@@ -41,10 +41,10 @@ void _SetRemoteNotificationReceivedDelegate(NotificationDataReceivedResponse cal
     manager.onRemoteNotificationReceivedCallback = callback;
 }
 
-void _RequestAuthorization(int options, BOOL registerRemote)
+void _RequestAuthorization(void* request, int options, BOOL registerRemote)
 {
     UnityNotificationManager* manager = [UnityNotificationManager sharedInstance];
-    [manager requestAuthorization: options withRegisterRemote: registerRemote];
+    [manager requestAuthorization: options withRegisterRemote: registerRemote forRequest: request];
     UNUserNotificationCenter* center = [UNUserNotificationCenter currentNotificationCenter];
     center.delegate = manager;
 }

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationWrapper.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationWrapper.m
@@ -8,6 +8,12 @@
 
 #import "UnityNotificationManager.h"
 
+
+int _NativeSizeof_iOSNotificationAuthorizationData()
+{
+    return sizeof(iOSNotificationAuthorizationData);
+}
+
 void _FreeUnmanagedMemory(void* ptr)
 {
     if (ptr != NULL)

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCenter.cs
@@ -67,7 +67,6 @@ namespace Unity.Notifications.iOS
         private static event NotificationReceivedCallback s_OnRemoteNotificationReceived = delegate {};
 
         internal delegate void AuthorizationRequestCompletedCallback(iOSAuthorizationRequestData data);
-        internal static event AuthorizationRequestCompletedCallback OnAuthorizationRequestCompleted = delegate {};
 
         /// <summary>
         /// The number currently set as the badge of the app icon.
@@ -209,11 +208,6 @@ namespace Unity.Notifications.iOS
             var notification = new iOSNotification(data.identifier);
             notification.data = data;
             s_OnNotificationReceived(notification);
-        }
-
-        internal static void OnFinishedAuthorizationRequest(iOSAuthorizationRequestData data)
-        {
-            OnAuthorizationRequestCompleted(data);
         }
     }
 }

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationsWrapper.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationsWrapper.cs
@@ -11,7 +11,7 @@ namespace Unity.Notifications.iOS
     internal class iOSNotificationsWrapper : MonoBehaviour
     {
         [DllImport("__Internal")]
-        private static extern void _RequestAuthorization(Int32 options, bool registerForRemote);
+        private static extern void _RequestAuthorization(IntPtr request, Int32 options, bool registerForRemote);
 
         [DllImport("__Internal")]
         private static extern void _ScheduleLocalNotification(IntPtr ptr);
@@ -70,7 +70,7 @@ namespace Unity.Notifications.iOS
         [DllImport("__Internal")]
         private static extern void _FreeUnmanagediOSNotificationData(IntPtr ptr);
 
-        private delegate void AuthorizationRequestCallback(IntPtr authdata);
+        private delegate void AuthorizationRequestCallback(IntPtr request, IntPtr authdata);
         private delegate void NotificationReceivedCallback(IntPtr notificationData);
 
 #if UNITY_IOS && !UNITY_EDITOR
@@ -102,13 +102,13 @@ namespace Unity.Notifications.iOS
         }
 
         [MonoPInvokeCallback(typeof(AuthorizationRequestCallback))]
-        public static void AuthorizationRequestReceived(IntPtr authRequestDataPtr)
+        public static void AuthorizationRequestReceived(IntPtr request, IntPtr authRequestDataPtr)
         {
 #if UNITY_IOS && !UNITY_EDITOR
             iOSAuthorizationRequestData data;
             data = (iOSAuthorizationRequestData)Marshal.PtrToStructure(authRequestDataPtr, typeof(iOSAuthorizationRequestData));
 
-            iOSNotificationCenter.OnFinishedAuthorizationRequest(data);
+            AuthorizationRequest.OnAuthorizationRequestCompleted(request, data);
 #endif
         }
 
@@ -134,10 +134,10 @@ namespace Unity.Notifications.iOS
 #endif
         }
 
-        public static void RequestAuthorization(int options, bool registerRemote)
+        public static void RequestAuthorization(IntPtr request, int options, bool registerRemote)
         {
 #if UNITY_IOS && !UNITY_EDITOR
-            _RequestAuthorization(options, registerRemote);
+            _RequestAuthorization(request, options, registerRemote);
 #endif
         }
 

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationsWrapper.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationsWrapper.cs
@@ -91,11 +91,7 @@ namespace Unity.Notifications.iOS
                 var nativeSize = _NativeSizeof_iOSNotificationAuthorizationData();
                 var managedSize = Marshal.SizeOf(typeof(iOSAuthorizationRequestData));
                 if (nativeSize != managedSize)
-                {
-                    var error = string.Format("Native/managed struct size missmatch: {0} vs {1}", nativeSize, managedSize);
-                    Debug.LogError(error);
-                    throw new Exception(error);
-                }
+                    throw new Exception(string.Format("Native/managed struct size missmatch: {0} vs {1}", nativeSize, managedSize));
             }
     #endif
             _SetAuthorizationRequestReceivedDelegate(AuthorizationRequestReceived);

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationsWrapper.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationsWrapper.cs
@@ -74,7 +74,6 @@ namespace Unity.Notifications.iOS
         private delegate void NotificationReceivedCallback(IntPtr notificationData);
 
 #if UNITY_IOS && !UNITY_EDITOR
-        private static AuthorizationRequestCallback s_OnAuthenticationRequestFinished = null;
         private static NotificationReceivedCallback s_OnNotificationReceived = null;
         private static NotificationReceivedCallback s_OnRemoteNotificationReceived = null;
 #endif
@@ -82,8 +81,7 @@ namespace Unity.Notifications.iOS
         public static void RegisterAuthorizationRequestCallback()
         {
 #if UNITY_IOS && !UNITY_EDITOR
-            s_OnAuthenticationRequestFinished = new AuthorizationRequestCallback(AuthorizationRequestReceived);
-            _SetAuthorizationRequestReceivedDelegate(s_OnAuthenticationRequestFinished);
+            _SetAuthorizationRequestReceivedDelegate(AuthorizationRequestReceived);
 #endif
         }
 

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationsWrapper.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationsWrapper.cs
@@ -70,7 +70,7 @@ namespace Unity.Notifications.iOS
         [DllImport("__Internal")]
         private static extern void _FreeUnmanagediOSNotificationData(IntPtr ptr);
 
-        private delegate void AuthorizationRequestCallback(IntPtr request, IntPtr authdata);
+        private delegate void AuthorizationRequestCallback(IntPtr request, iOSAuthorizationRequestData data);
         private delegate void NotificationReceivedCallback(IntPtr notificationData);
 
 #if UNITY_IOS && !UNITY_EDITOR
@@ -102,12 +102,9 @@ namespace Unity.Notifications.iOS
         }
 
         [MonoPInvokeCallback(typeof(AuthorizationRequestCallback))]
-        public static void AuthorizationRequestReceived(IntPtr request, IntPtr authRequestDataPtr)
+        public static void AuthorizationRequestReceived(IntPtr request, iOSAuthorizationRequestData data)
         {
 #if UNITY_IOS && !UNITY_EDITOR
-            iOSAuthorizationRequestData data;
-            data = (iOSAuthorizationRequestData)Marshal.PtrToStructure(authRequestDataPtr, typeof(iOSAuthorizationRequestData));
-
             AuthorizationRequest.OnAuthorizationRequestCompleted(request, data);
 #endif
         }

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationsWrapper.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationsWrapper.cs
@@ -10,6 +10,11 @@ namespace Unity.Notifications.iOS
 {
     internal class iOSNotificationsWrapper : MonoBehaviour
     {
+#if DEVELOPMENT_BUILD
+        [DllImport("__Internal")]
+        private static extern int _NativeSizeof_iOSNotificationAuthorizationData();
+#endif
+
         [DllImport("__Internal")]
         private static extern void _RequestAuthorization(IntPtr request, Int32 options, bool registerForRemote);
 
@@ -81,6 +86,18 @@ namespace Unity.Notifications.iOS
         public static void RegisterAuthorizationRequestCallback()
         {
 #if UNITY_IOS && !UNITY_EDITOR
+    #if DEVELOPMENT_BUILD
+            {
+                var nativeSize = _NativeSizeof_iOSNotificationAuthorizationData();
+                var managedSize = Marshal.SizeOf(typeof(iOSAuthorizationRequestData));
+                if (nativeSize != managedSize)
+                {
+                    var error = string.Format("Native/managed struct size missmatch: {0} vs {1}", nativeSize, managedSize);
+                    Debug.LogError(error);
+                    throw new Exception(error);
+                }
+            }
+    #endif
             _SetAuthorizationRequestReceivedDelegate(AuthorizationRequestReceived);
 #endif
         }

--- a/com.unity.mobile.notifications/package.json
+++ b/com.unity.mobile.notifications/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.mobile.notifications",
   "displayName": "Mobile Notifications",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "unity": "2019.4",
   "description": "Mobile Notifications package adds support for scheduling local repeatable or one-time notifications on iOS and Android.\n\nRequires iOS 10 and Android 4.4 or above.",
   "keywords": [


### PR DESCRIPTION
Reviewing commit-by-commit might be easier.

Mutiple fixes:
* AuthorizationRequest is filled in callback from other thread, need to sync
* Multiple requests can be submitted at once, need to handle that
  - the objc code before changes had race conditions if multiple requests at once
  - in C# we had a single static event, meaning one finishing request finishes all current ones
  - if request isn't disposed and another is created, the first one is also affected