### PR TITLE
Case 1288346: iOS Notification Settings don't get printed in the test project

### DIFF
--- a/TestProjects/com.unity.mobile-notifications-sample/Scripts/Helpers/Logger.cs
+++ b/TestProjects/com.unity.mobile-notifications-sample/Scripts/Helpers/Logger.cs
@@ -90,5 +90,18 @@ namespace Unity.Notifications.Tests.Sample
 
             return this;
         }
+
+        public Logger Fields(object obj, int tabs = 0)
+        {
+            foreach (var field in obj.GetType().GetFields(BindingFlags.Instance|BindingFlags.NonPublic|BindingFlags.Public))
+            {
+                var value = field.GetValue(obj).ToString();
+                if (string.IsNullOrEmpty(value))
+                    continue;
+                Blue($"{field.Name}: {value}");
+            }
+
+            return this;
+        }
     }
 }

--- a/TestProjects/com.unity.mobile-notifications-sample/Scripts/Helpers/Logger.cs
+++ b/TestProjects/com.unity.mobile-notifications-sample/Scripts/Helpers/Logger.cs
@@ -98,7 +98,7 @@ namespace Unity.Notifications.Tests.Sample
                 var value = field.GetValue(obj).ToString();
                 if (string.IsNullOrEmpty(value))
                     continue;
-                Blue($"{field.Name}: {value}");
+                Blue($"{field.Name}: {value}", tabs);
             }
 
             return this;

--- a/TestProjects/com.unity.mobile-notifications-sample/Scripts/Helpers/Logger.cs
+++ b/TestProjects/com.unity.mobile-notifications-sample/Scripts/Helpers/Logger.cs
@@ -93,7 +93,7 @@ namespace Unity.Notifications.Tests.Sample
 
         public Logger Fields(object obj, int tabs = 0)
         {
-            foreach (var field in obj.GetType().GetFields(BindingFlags.Instance|BindingFlags.NonPublic|BindingFlags.Public))
+            foreach (var field in obj.GetType().GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public))
             {
                 var value = field.GetValue(obj).ToString();
                 if (string.IsNullOrEmpty(value))

--- a/TestProjects/com.unity.mobile-notifications-sample/Scripts/iOSTest.cs
+++ b/TestProjects/com.unity.mobile-notifications-sample/Scripts/iOSTest.cs
@@ -368,7 +368,7 @@ namespace Unity.Notifications.Tests.Sample
         {
             m_LOGGER.Blue($"[{DateTime.Now.ToString("HH:mm:ss.ffffff")}] Call {MethodBase.GetCurrentMethod().Name}");
             iOSNotificationSettings settings = iOSNotificationCenter.GetNotificationSettings();
-            m_LOGGER.Properties(settings);
+            m_LOGGER.Fields(settings);
         }
 
         public void ListScheduledNotifications()


### PR DESCRIPTION
The reason is stripping. Because properties are not used, they get stripped and then reflection does not find them.
Unfortunately link.xml is not supported in packages.
Introduced field printing support instead.