### PR TITLE
Remove hardcoded notification identifier for location notifications

### DIFF
--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -290,6 +290,7 @@ bool validateAuthorizationStatus(UnityNotificationManager* manager)
     // TODO add a way to specify custom sounds.
     content.sound = [UNNotificationSound defaultSound];
 
+    NSString* identifier = [NSString stringWithUTF8String: data->identifier];
     // Generate UNNotificationTrigger from iOSNotificationData.
     UNNotificationTrigger* trigger;
     if (data->triggerType == TIME_TRIGGER)
@@ -320,7 +321,7 @@ bool validateAuthorizationStatus(UnityNotificationManager* manager)
         CLLocationCoordinate2D center = CLLocationCoordinate2DMake(data->locationTriggerCenterX, data->locationTriggerCenterY);
 
         CLCircularRegion* region = [[CLCircularRegion alloc] initWithCenter: center
-                                    radius: data->locationTriggerRadius identifier: @"Headquarters"];
+                                    radius: data->locationTriggerRadius identifier: identifier];
         region.notifyOnEntry = data->locationTriggerNotifyOnEntry;
         region.notifyOnExit = data->locationTriggerNotifyOnExit;
 
@@ -334,7 +335,6 @@ bool validateAuthorizationStatus(UnityNotificationManager* manager)
         return;
     }
 
-    NSString* identifier = [NSString stringWithUTF8String: data->identifier];
     UNNotificationRequest* request = [UNNotificationRequest requestWithIdentifier: identifier content: content trigger: trigger];
 
     // Schedule the notification.


### PR DESCRIPTION
We were using "Headquarters" for every single location notification which meant that every single notification was triggered when you entered the location for just one of them. We now use the Identifier.