### PR TITLE
Include the userInfo dictionary in the notificationData.

### DIFF
--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.h
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.h
@@ -27,6 +27,7 @@ typedef struct iOSNotificationData
     char* threadIdentifier;
 
     //Custom data
+    char* userInfo;
     char* data;
     int showInForeground;
     int showInForegroundPresentationOptions;

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
@@ -46,11 +46,27 @@ void initiOSNotificationData(iOSNotificationData* notificationData)
     notificationData->categoryIdentifier = NULL;
     notificationData->threadIdentifier = NULL;
     notificationData->triggerType = PUSH_TRIGGER;
+    notificationData->userInfo = NULL;
     notificationData->data = NULL;
 }
 
 void parseCustomizedData(iOSNotificationData* notificationData, UNNotificationRequest* request)
 {
+    NSError* userInfoError;
+    NSData* userInfo = [NSJSONSerialization dataWithJSONObject: request.content.userInfo options: NSJSONWritingPrettyPrinted error: &userInfoError];
+    if (!userInfo)
+    {
+        NSLog(@"Failed parsing notification userInfo: %@", userInfoError);
+        return;
+    }
+    else
+    {
+        // Cannot promise NSData:bytes is a C style string.
+        notificationData->userInfo = malloc(userInfo.length + 1);
+        [userInfo getBytes: notificationData->userInfo length: userInfo.length];
+        notificationData->userInfo[userInfo.length] = '\0';
+    }
+        
     NSObject* customizedData = [request.content.userInfo objectForKey: @"data"];
     if (customizedData == nil)
         return;

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
@@ -43,6 +43,7 @@ namespace Unity.Notifications.iOS
         public string threadIdentifier;
 
         //Custom information
+        public string userInfo;
         public string data;
         public bool showInForeground;
         public Int32 showInForegroundPresentationOptions;
@@ -177,6 +178,15 @@ namespace Unity.Notifications.iOS
         }
 
         /// <summary>
+        /// UserInfo which can be retrieved when the notification is used to open the app or is received while the app is running.
+        /// </summary>
+        public string UserInfo
+        {
+            get { return data.userInfo; }
+            set { data.userInfo = value; }
+        }
+
+        /// <summary>
         /// Arbitrary string data which can be retrieved when the notification is used to open the app or is received while the app is running.
         /// </summary>
         public string Data
@@ -308,6 +318,7 @@ namespace Unity.Notifications.iOS
             data.categoryIdentifier = "";
             data.threadIdentifier = "";
 
+            data.userInfo = "";
             data.data = "";
             data.showInForeground = false;
             data.showInForegroundPresentationOptions = (int)(PresentationOption.Alert |


### PR DESCRIPTION
Sometimes, third party push notifications include important information outside of a "data" userInfo key, which is why we expose userInfo directly.