### PR TITLE
case 1328578 print out if app was launched using notification

### DIFF
--- a/TestProjects/com.unity.mobile-notifications-sample/Scripts/iOSTest.cs
+++ b/TestProjects/com.unity.mobile-notifications-sample/Scripts/iOSTest.cs
@@ -72,12 +72,24 @@ namespace Unity.Notifications.Tests.Sample
 
         void Start()
         {
+            // in case a killed app was launched by clicking a notification
+            iOSNotification notification = iOSNotificationCenter.GetLastRespondedNotification();
             InstantiateAllTestButtons();
             ClearBadge();
             RemoveAllNotifications();
             m_LOGGER
                 .Clear()
                 .White("Welcome!");
+            if (notification != null)
+            {
+                m_LOGGER.Green("Application launched via notification");
+                if (notification.Data != "IGNORE")
+                {
+                    m_LOGGER
+                        .Orange($"[{DateTime.Now.ToString("HH:mm:ss.ffffff")}] Received notification")
+                        .Properties(notification, 1);
+                }
+            }
         }
 
         void OnApplicationPause(bool isPaused)


### PR DESCRIPTION
When app is killed on iOS and relaunched by clicking on notification, it now doesn't print notification info. This PR addresses that.