### PR TITLE
Check to see if we actually need to write any changes to the Preprocssor and/or Plist

### DIFF
--- a/com.unity.mobile.notifications/Editor/iOSNotificationPostProcessor.cs
+++ b/com.unity.mobile.notifications/Editor/iOSNotificationPostProcessor.cs
@@ -55,6 +55,8 @@ public class iOSNotificationPostProcessor : MonoBehaviour
     {
         var pbxProjectPath = PBXProject.GetPBXProjectPath(path);
 
+        var needsToWriteChanges = false;
+
         var pbxProject = new PBXProject();
         pbxProject.ReadFromString(File.ReadAllText(pbxProjectPath));
 
@@ -76,11 +78,19 @@ public class iOSNotificationPostProcessor : MonoBehaviour
         }
 
         // Add necessary frameworks.
-        pbxProject.AddFrameworkToProject(unityFrameworkTarget, "UserNotifications.framework", true);
-        if (needLocationFramework)
+        if (!pbxProject.ContainsFramework(unityFrameworkTarget, "UserNotifications.framework"))
+        {
+            pbxProject.AddFrameworkToProject(unityFrameworkTarget, "UserNotifications.framework", true);
+            needsToWriteChanges = true;
+        }
+        if (needLocationFramework && !pbxProject.ContainsFramework(unityFrameworkTarget, "CoreLocation.framework"))
+        {
             pbxProject.AddFrameworkToProject(unityFrameworkTarget, "CoreLocation.framework", false);
+            needsToWriteChanges = true;
+        }
 
-        File.WriteAllText(pbxProjectPath, pbxProject.WriteToString());
+        if (needsToWriteChanges)
+            File.WriteAllText(pbxProjectPath, pbxProject.WriteToString());
 
         // Update the entitlements file.
         if (addPushNotificationCapability)
@@ -140,7 +150,6 @@ public class iOSNotificationPostProcessor : MonoBehaviour
             }
         }
 
-        // only write if there have been changes to prevent unnecessary compilation
         if (needsToWriteChanges)
             File.WriteAllText(plistPath, plist.WriteToString());
     }
@@ -178,7 +187,6 @@ public class iOSNotificationPostProcessor : MonoBehaviour
             needsToWriteChanges = true;
         }
 
-        // only write if there have been changes to prevent unnecessary compilation
         if (needsToWriteChanges)
             File.WriteAllText(preprocessorPath, preprocessor);
     }

--- a/com.unity.mobile.notifications/Editor/iOSNotificationPostProcessor.cs
+++ b/com.unity.mobile.notifications/Editor/iOSNotificationPostProcessor.cs
@@ -106,7 +106,7 @@ public class iOSNotificationPostProcessor : MonoBehaviour
 
         var rootDict = plist.root;
         var needsToWriteChanges = false;
-        
+
         // Add all the settings to the plist.
         foreach (var setting in settings)
         {
@@ -115,12 +115,12 @@ public class iOSNotificationPostProcessor : MonoBehaviour
                 needsToWriteChanges = true;
                 if (setting.Value.GetType() == typeof(bool))
                 {
-                    rootDict.SetBoolean(setting.Key, (bool) setting.Value);
+                    rootDict.SetBoolean(setting.Key, (bool)setting.Value);
                 }
                 else if (setting.Value.GetType() == typeof(PresentationOption) ||
                          setting.Value.GetType() == typeof(AuthorizationOption))
                 {
-                    rootDict.SetInteger(setting.Key, (int) setting.Value);
+                    rootDict.SetInteger(setting.Key, (int)setting.Value);
                 }
             }
         }


### PR DESCRIPTION
We currently just overwrite the Plist if we need to or not, this causes Xcode to recompile each time which is a source of pain for our users. This PR is a simple set of checks for each item so we only write when needed.