### PR TITLE
Case 1340464 - remove GC allocation every frame on Android

### DIFF
--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCallback.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCallback.cs
@@ -10,7 +10,7 @@ namespace Unity.Notifications.Android
 
         public void onSentNotification(AndroidJavaObject notificationIntent)
         {
-            AndroidReceivedNotificationMainThreadDispatcher.EnqueueReceivedNotification(notificationIntent);
+            AndroidReceivedNotificationMainThreadDispatcher.GetInstance().EnqueueReceivedNotification(notificationIntent);
         }
     }
 }

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidReceivedNotificationMainThreadDispatcher.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidReceivedNotificationMainThreadDispatcher.cs
@@ -10,15 +10,15 @@ namespace Unity.Notifications.Android
     {
         private static AndroidReceivedNotificationMainThreadDispatcher instance = null;
 
-        private static List<AndroidJavaObject> s_ReceivedNotificationQueue = new List<AndroidJavaObject>();
+        private List<AndroidJavaObject> m_ReceivedNotificationQueue = new List<AndroidJavaObject>();
 
-        private static List<AndroidJavaObject> s_ReceivedNotificationList = new List<AndroidJavaObject>();
+        private List<AndroidJavaObject> m_ReceivedNotificationList = new List<AndroidJavaObject>();
 
-        internal static void EnqueueReceivedNotification(AndroidJavaObject intent)
+        internal void EnqueueReceivedNotification(AndroidJavaObject intent)
         {
-            lock (instance)
+            lock (this)
             {
-                s_ReceivedNotificationQueue.Add(intent);
+                m_ReceivedNotificationQueue.Add(intent);
             }
         }
 
@@ -34,19 +34,19 @@ namespace Unity.Notifications.Android
         {
             // Note: Don't call callbacks while locking receivedNotificationQueue, otherwise there's a risk
             //       that callback might introduce an operations which would create a deadlock
-            lock (instance)
+            lock (this)
             {
-                var temp = s_ReceivedNotificationQueue;
-                s_ReceivedNotificationQueue = s_ReceivedNotificationList;
-                s_ReceivedNotificationList = temp;
+                var temp = m_ReceivedNotificationQueue;
+                m_ReceivedNotificationQueue = m_ReceivedNotificationList;
+                m_ReceivedNotificationList = temp;
             }
 
-            foreach (var notification in s_ReceivedNotificationList)
+            foreach (var notification in m_ReceivedNotificationList)
             {
                 AndroidNotificationCenter.ReceivedNotificationCallback(notification);
             }
 
-            s_ReceivedNotificationList.Clear();
+            m_ReceivedNotificationList.Clear();
         }
 
         void Awake()

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidReceivedNotificationMainThreadDispatcher.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidReceivedNotificationMainThreadDispatcher.cs
@@ -36,6 +36,8 @@ namespace Unity.Notifications.Android
             //       that callback might introduce an operations which would create a deadlock
             lock (this)
             {
+                if (m_ReceivedNotificationQueue.Count == 0)
+                    return;
                 var temp = m_ReceivedNotificationQueue;
                 m_ReceivedNotificationQueue = m_ReceivedNotificationList;
                 m_ReceivedNotificationList = temp;


### PR DESCRIPTION
Improve Android implementation to be more performance and not make GC allocation every frame.
Changes:
- Replace Queue with List (that alone fixes allocation when AddRange is used)
- Rotate the two lists
- Quick return if no queued notifications
- Some refactoring

To QA: try to break it (flood notifications).
