### PR TITLE
pass image_url to show image in iOS notification

### DIFF
--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -277,6 +277,21 @@ bool validateAuthorizationStatus(UnityNotificationManager* manager)
     content.title = [NSString localizedUserNotificationStringForKey: dataTitle arguments: nil];
     content.body  = [NSString localizedUserNotificationStringForKey: dataBody arguments: nil];
     content.userInfo = userInfo;
+    
+    if ([userInfo valueForKey:@"image_url"]) {
+        NSURL *imageURL = [NSURL URLWithString:[userInfo valueForKey:@"image_url"]];
+        NSLog(@"imageURL = %@", imageURL);
+        NSError *error;
+        UNNotificationAttachment *icon = [UNNotificationAttachment attachmentWithIdentifier:@"image" URL:imageURL options:nil error:&error];
+        if (icon)
+        {
+            content.attachments = @[icon];
+        }
+        if (error)
+        {
+            NSLog(@"error while attaching image to notification: %@", error);
+        }
+    }
 
     if (data->badge >= 0)
         content.badge = [NSNumber numberWithInt: data->badge];


### PR DESCRIPTION
Proof of concept.

Example usage:

```cs
{"image_url", "file:///MyApp/Documents/image.png"}
```

Maybe this is helpful? If not feel free to close this PR after reading.

I considered to implement Android as well, it's quite difficult though as there is no gradle project (and I would prefer Kotlin).