### PR TITLE
Ios actionable notifications

### DIFF
--- a/TestProjects/com.unity.mobile-notifications-sample/Resources/iOSNotifications/TimeIntervalTrigger/Actionable two buttons.asset
+++ b/TestProjects/com.unity.mobile-notifications-sample/Resources/iOSNotifications/TimeIntervalTrigger/Actionable two buttons.asset
@@ -12,14 +12,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4fc6c74f6df364b36b9afcbfd8cfbca3, type: 3}
   m_Name: Actionable two buttons
   m_EditorClassIdentifier: 
-  ButtonName: Actionable two buttons
-  Identifier: ActionableTwoButtons
-  CategoryIdentifier: TWO_ACTIONS
+  ButtonName: Actionable 3 buttons
+  Identifier: ActionableThreeButtons
+  CategoryIdentifier: THREE_ACTIONS
   ThreadIdentifier: 
   Title: Actionable, two buttons
   Subtitle: 
   Body: Drag down to show actions
-  ShowInForeground: 0
+  ShowInForeground: 1
   PresentationOptions: 6
   Badge: -1
   Data: 

--- a/TestProjects/com.unity.mobile-notifications-sample/Resources/iOSNotifications/TimeIntervalTrigger/Actionable two buttons.asset
+++ b/TestProjects/com.unity.mobile-notifications-sample/Resources/iOSNotifications/TimeIntervalTrigger/Actionable two buttons.asset
@@ -1,0 +1,28 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4fc6c74f6df364b36b9afcbfd8cfbca3, type: 3}
+  m_Name: Actionable two buttons
+  m_EditorClassIdentifier: 
+  ButtonName: Actionable two buttons
+  Identifier: ActionableTwoButtons
+  CategoryIdentifier: TWO_ACTIONS
+  ThreadIdentifier: 
+  Title: Actionable, two buttons
+  Subtitle: 
+  Body: Drag down to show actions
+  ShowInForeground: 0
+  PresentationOptions: 6
+  Badge: -1
+  Data: 
+  TimeTriggerInterval: 5
+  Repeats: 0
+  UserInfo: []

--- a/TestProjects/com.unity.mobile-notifications-sample/Resources/iOSNotifications/TimeIntervalTrigger/Actionable two buttons.asset.meta
+++ b/TestProjects/com.unity.mobile-notifications-sample/Resources/iOSNotifications/TimeIntervalTrigger/Actionable two buttons.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c8d6c9947a559475c920da13b9ef4140
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/com.unity.mobile-notifications-sample/Resources/iOSNotifications/TimeIntervalTrigger/Actionable with input.asset
+++ b/TestProjects/com.unity.mobile-notifications-sample/Resources/iOSNotifications/TimeIntervalTrigger/Actionable with input.asset
@@ -1,0 +1,28 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4fc6c74f6df364b36b9afcbfd8cfbca3, type: 3}
+  m_Name: Actionable with input
+  m_EditorClassIdentifier: 
+  ButtonName: Actionable with input
+  Identifier: ActionableWithInput
+  CategoryIdentifier: WITH_INPUT
+  ThreadIdentifier: 
+  Title: Actionable with input
+  Subtitle: 
+  Body: Drag down to reveal actions
+  ShowInForeground: 0
+  PresentationOptions: 6
+  Badge: -1
+  Data: 
+  TimeTriggerInterval: 5
+  Repeats: 0
+  UserInfo: []

--- a/TestProjects/com.unity.mobile-notifications-sample/Resources/iOSNotifications/TimeIntervalTrigger/Actionable with input.asset.meta
+++ b/TestProjects/com.unity.mobile-notifications-sample/Resources/iOSNotifications/TimeIntervalTrigger/Actionable with input.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 397e208f98e174c728dce9a346fee66a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/com.unity.mobile-notifications-sample/Scripts/iOSTest.cs
+++ b/TestProjects/com.unity.mobile-notifications-sample/Scripts/iOSTest.cs
@@ -84,6 +84,9 @@ namespace Unity.Notifications.Tests.Sample
         {
             // in case a killed app was launched by clicking a notification
             iOSNotification notification = iOSNotificationCenter.GetLastRespondedNotification();
+            string lastAction = iOSNotificationCenter.GetLastRespondedNotificationAction();
+            string lastTextInput = iOSNotificationCenter.GetLastRespondedNotificationUserText();
+            RegisterCategories();
             InstantiateAllTestButtons();
             ClearBadge();
             RemoveAllNotifications();
@@ -98,6 +101,12 @@ namespace Unity.Notifications.Tests.Sample
                     m_LOGGER
                         .Orange($"[{DateTime.Now.ToString("HH:mm:ss.ffffff")}] Received notification")
                         .Properties(notification, 1);
+                    if (lastAction != null)
+                    {
+                        string output = lastTextInput != null ? $"Used action {lastAction} with input '{lastTextInput}'" : $"Used action {lastAction}";
+                        m_LOGGER
+                            .Orange(output);
+                    }
                 }
             }
         }
@@ -119,6 +128,14 @@ namespace Unity.Notifications.Tests.Sample
                             .Orange($"[{DateTime.Now.ToString("HH:mm:ss.ffffff")}] Received notification")
                             .Orange($"Setting BADGE to {iOSNotificationCenter.GetDeliveredNotifications().Length + 1}", 1)
                             .Properties(notification, 1);
+                        string lastAction = iOSNotificationCenter.GetLastRespondedNotificationAction();
+                        string lastTextInput = iOSNotificationCenter.GetLastRespondedNotificationUserText();
+                        if (lastAction != null)
+                        {
+                            string output = lastTextInput != null ? $"Used action {lastAction} with input '{lastTextInput}'" : $"Used action {lastAction}";
+                            m_LOGGER
+                                .Orange(output);
+                        }
                         iOSNotificationCenter.ApplicationBadge =
                             iOSNotificationCenter.GetDeliveredNotifications().Length + 1;
                     }
@@ -128,6 +145,18 @@ namespace Unity.Notifications.Tests.Sample
                     m_LOGGER.Red("Notification not found!", 1);
                 }
             }
+        }
+
+        private void RegisterCategories()
+        {
+            var actionConfirm = new iOSNotificationAction("ACTION_CONFIRM", "Confirm", iOSNotificationActionOptions.Foreground);
+            var actionReject = new iOSNotificationAction("ACTION_REJECT", "Reject");
+            var actionInput = new iOSTextInputNotificationAction("ACTION_INPUT", "Response", iOSNotificationActionOptions.Foreground, "Respond");
+            var twoActions = new iOSNotificationCategory("TWO_ACTIONS");
+            twoActions.AddActions(new[] { actionConfirm, actionReject });
+            var withInput = new iOSNotificationCategory("WITH_INPUT");
+            withInput.AddActions(new[] { actionInput, actionReject });
+            iOSNotificationCenter.SetNotificationCategories(new[] { twoActions, withInput });
         }
 
         private void InstantiateAllTestButtons()

--- a/TestProjects/com.unity.mobile-notifications-sample/Scripts/iOSTest.cs
+++ b/TestProjects/com.unity.mobile-notifications-sample/Scripts/iOSTest.cs
@@ -151,7 +151,7 @@ namespace Unity.Notifications.Tests.Sample
         {
             var actionConfirm = new iOSNotificationAction("ACTION_CONFIRM", "Confirm", iOSNotificationActionOptions.Foreground);
             var actionReject = new iOSNotificationAction("ACTION_REJECT", "Reject");
-            var actionInput = new iOSTextInputNotificationAction("ACTION_INPUT", "Response", iOSNotificationActionOptions.Foreground, "Respond");
+            var actionInput = new iOSTextInputNotificationAction("ACTION_INPUT", "Respond", iOSNotificationActionOptions.Foreground, "Respond");
             var twoActions = new iOSNotificationCategory("TWO_ACTIONS");
             twoActions.AddActions(new[] { actionConfirm, actionReject });
             var withInput = new iOSNotificationCategory("WITH_INPUT");

--- a/TestProjects/com.unity.mobile-notifications-sample/Scripts/iOSTest.cs
+++ b/TestProjects/com.unity.mobile-notifications-sample/Scripts/iOSTest.cs
@@ -150,7 +150,7 @@ namespace Unity.Notifications.Tests.Sample
         private void RegisterCategories()
         {
             var actionConfirm = new iOSNotificationAction("ACTION_CONFIRM", "Confirm", iOSNotificationActionOptions.Foreground);
-            var actionReject = new iOSNotificationAction("ACTION_REJECT", "Reject");
+            var actionReject = new iOSNotificationAction("ACTION_REJECT", "Reject", iOSNotificationActionOptions.Destructive);
             var actionInput = new iOSTextInputNotificationAction("ACTION_INPUT", "Respond", iOSNotificationActionOptions.Foreground, "Respond");
             var twoActions = new iOSNotificationCategory("TWO_ACTIONS");
             twoActions.AddActions(new[] { actionConfirm, actionReject });

--- a/TestProjects/com.unity.mobile-notifications-sample/Scripts/iOSTest.cs
+++ b/TestProjects/com.unity.mobile-notifications-sample/Scripts/iOSTest.cs
@@ -149,11 +149,12 @@ namespace Unity.Notifications.Tests.Sample
 
         private void RegisterCategories()
         {
-            var actionConfirm = new iOSNotificationAction("ACTION_CONFIRM", "Confirm", iOSNotificationActionOptions.Foreground);
+            var actionConfirm = new iOSNotificationAction("ACTION_CONFIRM", "Confirm", iOSNotificationActionOptions.Foreground|iOSNotificationActionOptions.Required);
+            var actionLater = new iOSNotificationAction("ACTION_LATER", "Later");
             var actionReject = new iOSNotificationAction("ACTION_REJECT", "Reject", iOSNotificationActionOptions.Destructive);
             var actionInput = new iOSTextInputNotificationAction("ACTION_INPUT", "Respond", iOSNotificationActionOptions.Foreground, "Respond");
-            var twoActions = new iOSNotificationCategory("TWO_ACTIONS");
-            twoActions.AddActions(new[] { actionConfirm, actionReject });
+            var twoActions = new iOSNotificationCategory("THREE_ACTIONS");
+            twoActions.AddActions(new[] { actionConfirm, actionLater, actionReject });
             var withInput = new iOSNotificationCategory("WITH_INPUT");
             withInput.AddActions(new[] { actionInput, actionReject });
             iOSNotificationCenter.SetNotificationCategories(new[] { twoActions, withInput });

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
@@ -25,6 +25,7 @@
 
 @property (nonatomic) UNNotification* lastReceivedNotification;
 @property NSString* lastRespondedNotificationAction;
+@property NSString* lastRespondedNotificationUserText;
 
 @property UNNotificationPresentationOptions remoteNotificationForegroundPresentationOptions;
 

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
@@ -24,6 +24,7 @@
 @property NSArray<UNNotification *> * cachedDeliveredNotifications;
 
 @property (nonatomic) UNNotification* lastReceivedNotification;
+@property NSString* lastRespondedNotificationAction;
 
 @property UNNotificationPresentationOptions remoteNotificationForegroundPresentationOptions;
 

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -201,6 +201,13 @@
 {
     self.lastReceivedNotification = response.notification;
     self.lastRespondedNotificationAction = response.actionIdentifier;
+    if ([response isKindOfClass: UNTextInputNotificationResponse.class])
+    {
+        UNTextInputNotificationResponse* resp = (UNTextInputNotificationResponse*)response;
+        self.lastRespondedNotificationUserText = resp.userText;
+    }
+    else
+        self.lastRespondedNotificationUserText = nil;
     completionHandler();
     [[UnityNotificationManager sharedInstance] updateDeliveredNotificationList];
 }

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -200,6 +200,7 @@
     withCompletionHandler:(nonnull void(^)(void))completionHandler
 {
     self.lastReceivedNotification = response.notification;
+    self.lastRespondedNotificationAction = response.actionIdentifier;
     completionHandler();
     [[UnityNotificationManager sharedInstance] updateDeliveredNotificationList];
 }

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationWrapper.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationWrapper.m
@@ -191,6 +191,17 @@ void* _CreateUNNotificationAction(const char* identifier, const char* title, int
     return (__bridge_retained void*)action;
 }
 
+void* _CreateUNTextInputNotificationAction(const char* identifier, const char* title, int options, const char* buttonTitle, const char* placeholder)
+{
+    UNNotificationActionOptions opts = (UNNotificationActionOptions)options;
+    NSString* idr = [NSString stringWithUTF8String: identifier];
+    NSString* titl = [NSString stringWithUTF8String: title];
+    NSString* btnTitle = [NSString stringWithUTF8String: buttonTitle];
+    NSString* placeHolder = placeholder ? [NSString stringWithUTF8String: placeholder] : NULL;
+    UNTextInputNotificationAction* action = [UNTextInputNotificationAction actionWithIdentifier: idr title: titl options: opts textInputButtonTitle: btnTitle textInputPlaceholder: placeHolder];
+    return (__bridge_retained void*)action;
+}
+
 void _ReleaseUNNotificationAction(void* action)
 {
     UNNotificationAction* a = (__bridge_transfer UNNotificationAction*)action;

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationWrapper.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationWrapper.m
@@ -182,6 +182,15 @@ const char* _GetLastRespondedNotificationAction()
     return strdup(action.UTF8String);
 }
 
+const char* _GetLastRespondedNotificationUserText()
+{
+    UnityNotificationManager* manager = [UnityNotificationManager sharedInstance];
+    NSString* userText = manager.lastRespondedNotificationUserText;
+    if (userText == nil)
+        return NULL;
+    return strdup(userText.UTF8String);
+}
+
 void* _CreateUNNotificationAction(const char* identifier, const char* title, int options)
 {
     UNNotificationActionOptions opts = (UNNotificationActionOptions)options;

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationAction.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationAction.cs
@@ -2,25 +2,65 @@ using System;
 
 namespace Unity.Notifications.iOS
 {
+    /// <summary>
+    /// Options for notification actions.
+    /// These represent values from UNNotificationActionOptions.
+    /// </summary>
+    /// <see cref="https://developer.apple.com/documentation/usernotifications/unnotificationactionoptions"/>
     [Flags]
     public enum iOSNotificationActionOptions
     {
+        None = 0,
         Required = (1 << 0),
         Destructive = (1 << 1),
         Foreground = (1 << 2),
     }
 
+    /// <summary>
+    /// Represents action for an actionable notification.
+    /// Actions are supposed to be added to notification categories, which are then registered prior to sending notifications.
+    /// User can choose to tap a notification or one of associated actions. Application gets feedback of the choice.
+    /// </summary>
+    /// <seealso cref="iOSNotificationCategory"/>
+    /// <seealso cref="iOSNotificationCenter.GetLastRespondedNotificationAction"/>
     public class iOSNotificationAction
     {
+        /// <summary>
+        /// An identifier for this action.
+        /// Each action within an application unique must have unique ID.
+        /// This ID will be returned by iOSNotificationCenter.GetLastRespondedNotificationAction if user chooses this action.
+        /// </summary>
         public string Id { get; set; }
+
+        /// <summary>
+        /// Title for the action.
+        /// This will be the title of the button that appears below the notification.
+        /// </summary>
         public string Title { get; set; }
+
+        /// <summary>
+        /// Options for the action. Can be a combination of given flags.
+        /// Refer to Apple documentation for UNNotificationActionOptions for exact meanings.
+        /// </summary>
+        /// <see cref="https://developer.apple.com/documentation/usernotifications/unnotificationactionoptions"/>
         public iOSNotificationActionOptions Options { get; set; }
 
+        /// <summary>
+        /// Creates new action.
+        /// </summary>
+        /// <param name="id">Unique identifier for this action</param>
+        /// <param name="title">Title for the action (and button label)</param>
         public iOSNotificationAction(string id, string title)
             : this(id, title, 0)
         {
         }
 
+        /// <summary>
+        /// Creates new action.
+        /// </summary>
+        /// <param name="id">Unique identifier for this action</param>
+        /// <param name="title">Title for the action (and button label)</param>
+        /// <param name="options">Options for the action</param>
         public iOSNotificationAction(string id, string title, iOSNotificationActionOptions options)
         {
             Id = id;
@@ -38,18 +78,45 @@ namespace Unity.Notifications.iOS
         }
     }
 
+    /// <summary>
+    /// Represents a special notification action with text input support.
+    /// Each action within an application unique must have unique ID.
+    /// When user chooses this action, a prompt for text input appears.
+    /// If this action is responded to by the user, iOSNotificationCenter.GetLastRespondedNotificationAction will return it's ID,
+    /// while iOSNotificationCenter.GetLastRespondedNotificationUserText will return the text entered.
+    /// </summary>
     public class iOSTextInputNotificationAction
         : iOSNotificationAction
     {
+        /// <summary>
+        /// Text label for the button for submitting the text input.
+        /// </summary>
         public string TextInputButtonTitle { get; set; }
+
+        /// <summary>
+        /// The placeholder text for input.
+        /// </summary>
         public string TextInputPlaceholder { get; set; }
 
+        /// <summary>
+        /// Creates new text input action.
+        /// </summary>
+        /// <param name="id">Unique identifier for this action</param>
+        /// <param name="title">Title for the action (and button label)</param>
+        /// <param name="buttonTitle">Label for a button for submitting the text input</param>
         public iOSTextInputNotificationAction(string id, string title, string buttonTitle)
             : base(id, title)
         {
             TextInputButtonTitle = buttonTitle;
         }
 
+        /// <summary>
+        /// Creates new text input action.
+        /// </summary>
+        /// <param name="id">Unique identifier for this action</param>
+        /// <param name="title">Title for the action (and button label)</param>
+        /// <param name="options">Options for the action</param>
+        /// <param name="buttonTitle">Label for a button for submitting the text input</param>
         public iOSTextInputNotificationAction(string id, string title, iOSNotificationActionOptions options, string buttonTitle)
             : base(id, title, options)
         {

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationAction.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationAction.cs
@@ -27,5 +27,14 @@ namespace Unity.Notifications.iOS
             Title = title;
             Options = options;
         }
+
+        internal virtual IntPtr CreateUNNotificationAction()
+        {
+#if UNITY_IOS && !UNITY_EDITOR
+            return iOSNotificationsWrapper._CreateUNNotificationAction(Id, Title, (int)Options);
+#else
+            return IntPtr.Zero;
+#endif
+        }
     }
 }

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationAction.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationAction.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace Unity.Notifications.iOS
+{
+    [Flags]
+    public enum iOSNotificationActionOptions
+    {
+        Required = (1 << 0),
+        Destructive = (1 << 1),
+        Foreground = (1 << 2),
+    }
+
+    public class iOSNotificationAction
+    {
+        public string Id { get; set; }
+        public string Title { get; set; }
+        public iOSNotificationActionOptions Options { get; set; }
+
+        public iOSNotificationAction(string id, string title)
+            : this(id, title, 0)
+        {
+        }
+
+        public iOSNotificationAction(string id, string title, iOSNotificationActionOptions options)
+        {
+            Id = id;
+            Title = title;
+            Options = options;
+        }
+    }
+}

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationAction.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationAction.cs
@@ -37,4 +37,32 @@ namespace Unity.Notifications.iOS
 #endif
         }
     }
+
+    public class iOSTextInputNotificationAction
+        : iOSNotificationAction
+    {
+        public string TextInputButtonTitle { get; set; }
+        public string TextInputPlaceholder { get; set; }
+
+        public iOSTextInputNotificationAction(string id, string title, string buttonTitle)
+            : base(id, title)
+        {
+            TextInputButtonTitle = buttonTitle;
+        }
+
+        public iOSTextInputNotificationAction(string id, string title, iOSNotificationActionOptions options, string buttonTitle)
+            : base(id, title, options)
+        {
+            TextInputButtonTitle = buttonTitle;
+        }
+
+        internal override IntPtr CreateUNNotificationAction()
+        {
+#if UNITY_IOS && !UNITY_EDITOR
+            return iOSNotificationsWrapper._CreateUNTextInputNotificationAction(Id, Title, (int)Options, TextInputButtonTitle, TextInputPlaceholder);
+#else
+            return IntPtr.Zero;
+#endif
+        }
+    }
 }

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationAction.cs.meta
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f7d19fa19fc06456eac4adb06cbf32e8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCategory.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCategory.cs
@@ -3,6 +3,11 @@ using System.Collections.Generic;
 
 namespace Unity.Notifications.iOS
 {
+    /// <summary>
+    /// Options for notification category. Multiple options can be combined.
+    /// These represent values from UNNotificationCategoryOptions.
+    /// </summary>
+    /// <see cref="https://developer.apple.com/documentation/usernotifications/unnotificationcategoryoptions"/>
     [Flags]
     public enum iOSNotificationCategoryOptions
     {
@@ -13,23 +18,68 @@ namespace Unity.Notifications.iOS
         HiddenPreviewsShowSubtitle = (1 << 3),
     }
 
+    /// <summary>
+    /// Represents notification category.
+    /// Notification categories need to be registered on application start to be useful.
+    /// By adding actions to category, you make all notification sent with this category identifier actionable.
+    /// </summary>
+    /// <see cref="iOSNotification.CategoryIdentifier"/>
+    /// <seealso cref="https://developer.apple.com/documentation/usernotifications/unnotificationcategory"/>
     public class iOSNotificationCategory
     {
         List<iOSNotificationAction> m_Actions = new List<iOSNotificationAction>();
         List<string> m_IntentIdentifiers = new List<string>();
 
+        /// <summary>
+        /// A unique identifier for this category.
+        /// </summary>
         public string Id { get; set; }
+
+        /// <summary>
+        /// Get actions set for this category.
+        /// </summary>
+        /// <see cref="iOSNotificationAction"/>
         public iOSNotificationAction[] Actions { get { return m_Actions.ToArray(); } }
+
+        /// <summary>
+        /// Intent identifiers set for this category.
+        /// </summary>
+        /// <see cref="https://developer.apple.com/documentation/usernotifications/unnotificationcategory/1649282-intentidentifiers"/>
         public string[] IntentIdentifiers { get { return m_IntentIdentifiers.ToArray(); } }
+
+        /// <summary>
+        /// The placeholder text to display when the system disables notification previews for the app.
+        /// </summary>
+        /// <see cref="https://developer.apple.com/documentation/usernotifications/unnotificationcategory/2873736-hiddenpreviewsbodyplaceholder"/>
         public string HiddenPreviewsBodyPlaceholder { get; set; }
+
+        /// <summary>
+        /// A format string for the summary description used when the system groups the category’s notifications.
+        /// </summary>
+        /// <see cref="https://developer.apple.com/documentation/usernotifications/unnotificationcategory/2963112-categorysummaryformat"/>
         public string SummaryFormat { get; set; }
+
+        /// <summary>
+        /// Options for how to handle notifications of this type.
+        /// </summary>
         public iOSNotificationCategoryOptions Options { get; set; }
 
+        /// <summary>
+        /// Create notification category.
+        /// Category must be registered using iOSNotificationCenter.SetNotificationCategories.
+        /// </summary>
+        /// <param name="id">A unique identifier for this category</param>
         public iOSNotificationCategory(string id)
         {
             Id = id;
         }
 
+        /// <summary>
+        /// Create notification category.
+        /// Category must be registered using iOSNotificationCenter.SetNotificationCategories.
+        /// </summary>
+        /// <param name="id">A unique identifier for this category</param>
+        /// <param name="actions">Add provided actions to this category</param>
         public iOSNotificationCategory(string id, IEnumerable<iOSNotificationAction> actions)
             : this(id)
         {
@@ -37,6 +87,13 @@ namespace Unity.Notifications.iOS
                 m_Actions.AddRange(actions);
         }
 
+        /// <summary>
+        /// Create notification category.
+        /// Category must be registered using iOSNotificationCenter.SetNotificationCategories.
+        /// </summary>
+        /// <param name="id">A unique identifier for this category</param>
+        /// <param name="actions">Add provided actions to this category</param>
+        /// <param name="intentIdentifiers">Add provided intent identifiers to this category</param>
         public iOSNotificationCategory(string id, IEnumerable<iOSNotificationAction> actions, IEnumerable<string> intentIdentifiers)
             : this(id, actions)
         {
@@ -44,6 +101,11 @@ namespace Unity.Notifications.iOS
                 m_IntentIdentifiers.AddRange(intentIdentifiers);
         }
 
+        /// <summary>
+        /// Add action to this category.
+        /// Actions must be added prior to registering the category.
+        /// </summary>
+        /// <param name="action">Action to add</param>
         public void AddAction(iOSNotificationAction action)
         {
             if (action == null)
@@ -51,6 +113,11 @@ namespace Unity.Notifications.iOS
             m_Actions.Add(action);
         }
 
+        /// <summary>
+        /// Add actions to this category.
+        /// Actions must be added prior to registering the category.
+        /// </summary>
+        /// <param name="actions">Actions to add</param>
         public void AddActions(IEnumerable<iOSNotificationAction> actions)
         {
             if (actions == null)
@@ -58,6 +125,11 @@ namespace Unity.Notifications.iOS
             m_Actions.AddRange(actions);
         }
 
+        /// <summary>
+        /// Add intent identifier to this category.
+        /// Intent identifiers must be added prior to registering the category.
+        /// </summary>
+        /// <param name="identifier">Intent identifier to add</param>
         public void AddIntentIdentifier(string identifier)
         {
             if (identifier == null)
@@ -65,6 +137,11 @@ namespace Unity.Notifications.iOS
             m_IntentIdentifiers.Add(identifier);
         }
 
+        /// <summary>
+        /// Add intent identifier to this category.
+        /// Intent identifiers must be added prior to registering the category.
+        /// </summary>
+        /// <param name="identifiers">Intent identifiers to add</param>
         public void AddIntentIdentifiers(IEnumerable<string> identifiers)
         {
             if (identifiers == null)

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCategory.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCategory.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+
+namespace Unity.Notifications.iOS
+{
+    [Flags]
+    public enum iOSNotificationCategoryOptions
+    {
+        None = 0,
+        CustomDismissAction = (1 << 0),
+        AllowInCarPlay = (1 << 1),
+        HiddenPreviewsShowTitle = (1 << 2),
+        HiddenPreviewsShowSubtitle = (1 << 3),
+    }
+
+    public class iOSNotificationCategory
+    {
+        List<iOSNotificationAction> m_Actions = new List<iOSNotificationAction>();
+        List<string> m_IntentIdentifiers = new List<string>();
+
+        public string Id { get; set; }
+        public iOSNotificationAction[] Actions { get { return m_Actions.ToArray(); } }
+        public string[] IntentIdentifiers { get { return m_IntentIdentifiers.ToArray(); } }
+        public string HiddenPreviewsBodyPlaceholder { get; set; }
+        public string SummaryFormat { get; set; }
+        public iOSNotificationCategoryOptions Options { get; set; }
+
+        public iOSNotificationCategory(string id)
+        {
+            Id = id;
+        }
+
+        public iOSNotificationCategory(string id, IEnumerable<iOSNotificationAction> actions)
+            : this(id)
+        {
+            if (actions != null)
+                m_Actions.AddRange(actions);
+        }
+
+        public iOSNotificationCategory(string id, IEnumerable<iOSNotificationAction> actions, IEnumerable<string> intentIdentifiers)
+            : this(id, actions)
+        {
+            if (intentIdentifiers != null)
+                m_IntentIdentifiers.AddRange(intentIdentifiers);
+        }
+
+        public void AddAction(iOSNotificationAction action)
+        {
+            if (action == null)
+                throw new ArgumentException("Cannot add null action");
+            m_Actions.Add(action);
+        }
+
+        public void AddActions(IEnumerable<iOSNotificationAction> actions)
+        {
+            if (actions == null)
+                throw new ArgumentException("Cannot add null actions collection");
+            m_Actions.AddRange(actions);
+        }
+
+        public void AddIntentIdentifier(string identifier)
+        {
+            if (identifier == null)
+                throw new ArgumentException("Cannot add null intent identifier");
+            m_IntentIdentifiers.Add(identifier);
+        }
+
+        public void AddIntentIdentifiers(IEnumerable<string> identifiers)
+        {
+            if (identifiers == null)
+                throw new ArgumentException("Cannot add null intent identifiers collection");
+            m_IntentIdentifiers.AddRange(identifiers);
+        }
+    }
+}

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCategory.cs.meta
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCategory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7f323c7093dfc41d587ecb64426dceb2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCenter.cs
@@ -149,6 +149,11 @@ namespace Unity.Notifications.iOS
             return iOSNotificationsWrapper.GetLastRespondedNotificationAction();
         }
 
+        public static string GetLastRespondedNotificationUserText()
+        {
+            return iOSNotificationsWrapper.GetLastRespondedNotificationUserText();
+        }
+
         /// <summary>
         /// Unschedules the specified notification.
         /// </summary>

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCenter.cs
@@ -144,6 +144,11 @@ namespace Unity.Notifications.iOS
             return new iOSNotification(data.Value);
         }
 
+        public static string GetLastRespondedNotificationAction()
+        {
+            return iOSNotificationsWrapper.GetLastRespondedNotificationAction();
+        }
+
         /// <summary>
         /// Unschedules the specified notification.
         /// </summary>
@@ -186,6 +191,11 @@ namespace Unity.Notifications.iOS
         public static iOSNotificationSettings GetNotificationSettings()
         {
             return iOSNotificationsWrapper.GetNotificationSettings();
+        }
+
+        public static void SetNotificationCategories(IEnumerable<iOSNotificationCategory> categories)
+        {
+            iOSNotificationsWrapper.SetNotificationCategories(categories);
         }
 
         internal static void OnReceivedRemoteNotification(iOSNotificationWithUserInfo data)

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCenter.cs
@@ -131,6 +131,7 @@ namespace Unity.Notifications.iOS
         /// <summary>
         /// Use this to retrieve the last local or remote notification received by the app.
         /// </summary>
+        /// <seealso cref="SetNotificationCategories(IEnumerable{iOSNotificationCategory})"/>
         /// <returns>
         /// Returns the last local or remote notification used to open the app or clicked on by the user. If no notification is available it returns null.
         /// </returns>
@@ -144,11 +145,20 @@ namespace Unity.Notifications.iOS
             return new iOSNotification(data.Value);
         }
 
+        /// <summary>
+        /// Get users chosen action for the last actionable notification, null if no action was chosen.
+        /// </summary>
+        /// <seealso cref="SetNotificationCategories(IEnumerable{iOSNotificationCategory})"/>
+        /// <returns>Action identifier</returns>
         public static string GetLastRespondedNotificationAction()
         {
             return iOSNotificationsWrapper.GetLastRespondedNotificationAction();
         }
 
+        /// <summary>
+        /// Get users text input for the last actionable notification with input support, null if no input.
+        /// </summary>
+        /// <returns>Text user extered in the input field from notification</returns>
         public static string GetLastRespondedNotificationUserText()
         {
             return iOSNotificationsWrapper.GetLastRespondedNotificationUserText();
@@ -198,6 +208,13 @@ namespace Unity.Notifications.iOS
             return iOSNotificationsWrapper.GetNotificationSettings();
         }
 
+        /// <summary>
+        /// Set (replace if already set) notification categories.
+        /// Use this to setup actionable notifications. You can specify actions for each category,
+        /// which then will be available for each notification with the same category identifier.
+        /// Categories must be registered before sending notifications.
+        /// </summary>
+        /// <param name="categories">All notification categories for your application</param>
         public static void SetNotificationCategories(IEnumerable<iOSNotificationCategory> categories)
         {
             iOSNotificationsWrapper.SetNotificationCategories(categories);

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationsWrapper.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationsWrapper.cs
@@ -88,7 +88,7 @@ namespace Unity.Notifications.iOS
         private static extern void _ReadNSDictionary(IntPtr handle, IntPtr nsDict, ReceiveNSDictionaryKeyValueCallback callback);
 
         [DllImport("__Internal")]
-        private static extern IntPtr _CreateUNNotificationAction(string id, string title, int options);
+        internal static extern IntPtr _CreateUNNotificationAction(string id, string title, int options);
 
         [DllImport("__Internal")]
         private static extern void _ReleaseUNNotificationAction(IntPtr action);
@@ -345,15 +345,6 @@ namespace Unity.Notifications.iOS
             return null;
         }
 
-        private static IntPtr CreateUNNotificationAction(iOSNotificationAction action)
-        {
-#if UNITY_IOS && !UNITY_EDITOR
-            return _CreateUNNotificationAction(action.Id, action.Title, (int)action.Options);
-#else
-            return IntPtr.Zero;
-#endif
-        }
-
         public static void SetNotificationCategories(IEnumerable<iOSNotificationCategory> categories)
         {
             var allActions = new Dictionary<string, IntPtr>();
@@ -363,7 +354,7 @@ namespace Unity.Notifications.iOS
                 {
                     if (string.IsNullOrEmpty(action.Id) || allActions.ContainsKey(action.Id))
                         throw new ArgumentException("Action must have a valid and unique ID");
-                    allActions[action.Id] = CreateUNNotificationAction(action);
+                    allActions[action.Id] = action.CreateUNNotificationAction();
                 }
             }
 

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationsWrapper.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationsWrapper.cs
@@ -91,6 +91,9 @@ namespace Unity.Notifications.iOS
         internal static extern IntPtr _CreateUNNotificationAction(string id, string title, int options);
 
         [DllImport("__Internal")]
+        internal static extern IntPtr _CreateUNTextInputNotificationAction(string id, string title, int options, string buttonTitle, string placeholder);
+
+        [DllImport("__Internal")]
         private static extern void _ReleaseUNNotificationAction(IntPtr action);
 
         [DllImport("__Internal")]

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationsWrapper.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationsWrapper.cs
@@ -79,6 +79,9 @@ namespace Unity.Notifications.iOS
         private static extern string _GetLastRespondedNotificationAction();
 
         [DllImport("__Internal")]
+        private static extern string _GetLastRespondedNotificationUserText();
+
+        [DllImport("__Internal")]
         private static extern void _FreeUnmanagediOSNotificationDataArray(IntPtr ptr, int count);
 
         [DllImport("__Internal")]
@@ -235,6 +238,15 @@ namespace Unity.Notifications.iOS
         {
 #if UNITY_IOS && !UNITY_EDITOR
             return _GetLastRespondedNotificationAction();
+#else
+            return null;
+#endif
+        }
+
+        public static string GetLastRespondedNotificationUserText()
+        {
+#if UNITY_IOS && !UNITY_EDITOR
+            return _GetLastRespondedNotificationUserText();
 #else
             return null;
 #endif

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationsWrapper.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationsWrapper.cs
@@ -355,9 +355,10 @@ namespace Unity.Notifications.iOS
             {
                 foreach (var action in category.Actions)
                 {
-                    if (string.IsNullOrEmpty(action.Id) || allActions.ContainsKey(action.Id))
+                    if (string.IsNullOrEmpty(action.Id))
                         throw new ArgumentException("Action must have a valid and unique ID");
-                    allActions[action.Id] = action.CreateUNNotificationAction();
+                    if (!allActions.ContainsKey(action.Id))
+                        allActions[action.Id] = action.CreateUNNotificationAction();
                 }
             }
 


### PR DESCRIPTION
Adds support for iOS actionable notifications.
Add API to register notification categories with associated actions and to get which action was used and input.
Actionable notifications can be dragged down to reveal the actions.
The test project update to have a couple buttons with simple buttons and text input.