### PR TITLE
Run iOS tests on CI

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -24,6 +24,10 @@ mobile_dependencies:
     name: com.unity.mobile.notifications
     version: file:../../com.unity.mobile.notifications
 
+utr:
+  url_win: https://artifactory.prd.it.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat
+  url_unix: https://artifactory.prd.it.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr
+
 ---
 pack:
   name: Pack

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -79,7 +79,7 @@ test_iOS_{{ editor.version }}:
     image: mobile/macos-10.13-testing:stable
     flavor: b1.medium
   variables:
-    IOS_SIMULATOR_SDK=1
+    IOS_SIMULATOR_SDK: 1
   commands:
     - brew tap --force-auto-update unity/unity git@github.cds.internal.unity3d.com:unity/homebrew-unity.git
     - brew install unity-config

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -78,8 +78,6 @@ test_iOS_{{ editor.version }}:
     type: Unity::mobile::iPhone
     image: mobile/macos-10.13-testing:stable
     flavor: b1.medium
-  variables:
-    IOS_SIMULATOR_SDK: 1
   commands:
     - brew tap --force-auto-update unity/unity git@github.cds.internal.unity3d.com:unity/homebrew-unity.git
     - brew install unity-config

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -75,8 +75,19 @@ test_iOS_{{ editor.version }}:
     image: mobile/macos-10.13-testing:stable
     flavor: b1.medium
   commands:
-    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - upm-ci package test --package-path com.unity.mobile.notifications --unity-version {{ editor.version }} --platform iOS --type package-tests
+    - brew tap --force-auto-update unity/unity git@github.cds.internal.unity3d.com:unity/homebrew-unity.git
+      - brew install unity-config
+      - unity-config settings editor-path .Editor
+      - unity-config project create .MyTestProject
+{%- for dependency in mobile_dependencies -%}
+      - unity-config project add dependency {{dependency.name}}@{{dependency.version}} --project-path .MyTestProject
+{%- endfor -%}
+      - unity-config project add testable com.unity.mobile.notifications
+      - curl -s {{ utr.url_unix }} --output utr
+      - chmod u+x utr
+      - pip install unity-downloader-cli --index-url {{ artifactory.production }}pypi/pypi/simple --upgrade
+      - unity-downloader-cli -c Editor -c iOS -u {{ editor.version }} --wait --fast
+      - ./utr --testproject=.MyTestProject --editor-location=.Editor --suite=playmode --platform=ios --artifacts_path=upm-ci~/test-results/ios --extra-editor-arg="-playerHeartbeatTimeout 900" --extra-editor-arg="-upmNoDefaultPackages"
   artifacts:
     packages:
       paths:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -53,6 +53,24 @@ test_{{ platform.name }}_{{ editor.version }}:
 {% endfor %}
 {% endfor %}
 
+{% for editor in test_editors %}
+test_iOS_{{ editor.version }}:
+  name: Test {{ editor.version }} on iOS
+  agent:
+    type: Unity::mobile::iPhone
+    image: mobile/macos-10.13-testing:stable
+    flavor: b1.medium
+  commands:
+    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+    - upm-ci package test --package-path com.unity.mobile.notifications --unity-version {{ editor.version }} --platform iOS --type package-tests
+  artifacts:
+    packages:
+      paths:
+        - "upm-ci~/**/*"
+  dependencies:
+    - .yamato/upm-ci.yml#pack
+{% endfor %}
+
 test_trigger:
   name: Tests Trigger
   agent:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -124,6 +124,7 @@ test_trigger:
     {% for editor in test_editors %}
     {% for platform in test_platforms %}
     - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
+    - .yamato/upm-ci.yml#test_iOS_{{ editor.version }}
     {% endfor %}
     {% endfor %}
 

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,7 +1,8 @@
 test_editors:
   - version: trunk
-  - version: 2020.2
-  - version: 2020.1
+  - version: 2021.2
+  - version: 2021.1
+  - version: 2020.3
   - version: 2019.4
 
 test_platforms:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -10,6 +10,20 @@ test_platforms:
     image: package-ci/mac:stable
     flavor: m1.mac
 
+artifactory:
+  production: https://artifactory.prd.it.unity3d.com/artifactory/api/
+
+mobile_dependencies:
+  - unity_test_framework:
+    name: com.unity.test-framework.build
+    version: 0.0.1-preview.12
+  - performance_test_framework:
+    name: com.unity.test-framework.utp-reporter
+    version: 1.0.0-preview
+  - mobile_notifications:
+    name: com.unity.mobile.notifications
+    version: file:../../com.unity.mobile.notifications
+
 ---
 pack:
   name: Pack

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -132,8 +132,10 @@ test_trigger:
     {% for editor in test_editors %}
     {% for platform in test_platforms %}
     - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
-    - .yamato/upm-ci.yml#test_iOS_{{ editor.version }}
     {% endfor %}
+    {% endfor %}
+    {% for editor in ios_test_editors %}
+    - .yamato/upm-ci.yml#test_iOS_{{ editor.version }}
     {% endfor %}
 
 publish:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -5,6 +5,13 @@ test_editors:
   - version: 2020.3
   - version: 2019.4
 
+# Some issues with 2019.4 on iOS on Yamato, but passes locally
+ios_test_editors:
+  - version: trunk
+  - version: 2021.2
+  - version: 2021.1
+  - version: 2020.3
+
 test_platforms:
   - name: mac
     type: Unity::VM::osx
@@ -72,7 +79,7 @@ test_{{ platform.name }}_{{ editor.version }}:
 {% endfor %}
 {% endfor %}
 
-{% for editor in test_editors %}
+{% for editor in ios_test_editors %}
 test_iOS_{{ editor.version }}:
   name: Test {{ editor.version }} on iOS
   agent:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -78,6 +78,8 @@ test_iOS_{{ editor.version }}:
     type: Unity::mobile::iPhone
     image: mobile/macos-10.13-testing:stable
     flavor: b1.medium
+  variables:
+    IOS_SIMULATOR_SDK=1
   commands:
     - brew tap --force-auto-update unity/unity git@github.cds.internal.unity3d.com:unity/homebrew-unity.git
     - brew install unity-config

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -76,18 +76,18 @@ test_iOS_{{ editor.version }}:
     flavor: b1.medium
   commands:
     - brew tap --force-auto-update unity/unity git@github.cds.internal.unity3d.com:unity/homebrew-unity.git
-      - brew install unity-config
-      - unity-config settings editor-path .Editor
-      - unity-config project create .MyTestProject
+    - brew install unity-config
+    - unity-config settings editor-path .Editor
+    - unity-config project create .MyTestProject
 {%- for dependency in mobile_dependencies -%}
-      - unity-config project add dependency {{dependency.name}}@{{dependency.version}} --project-path .MyTestProject
+    - unity-config project add dependency {{dependency.name}}@{{dependency.version}} --project-path .MyTestProject
 {%- endfor -%}
-      - unity-config project add testable com.unity.mobile.notifications
-      - curl -s {{ utr.url_unix }} --output utr
-      - chmod u+x utr
-      - pip install unity-downloader-cli --index-url {{ artifactory.production }}pypi/pypi/simple --upgrade
-      - unity-downloader-cli -c Editor -c iOS -u {{ editor.version }} --wait --fast
-      - ./utr --testproject=.MyTestProject --editor-location=.Editor --suite=playmode --platform=ios --artifacts_path=upm-ci~/test-results/ios --extra-editor-arg="-playerHeartbeatTimeout 900" --extra-editor-arg="-upmNoDefaultPackages"
+    - unity-config project add testable com.unity.mobile.notifications
+    - curl -s {{ utr.url_unix }} --output utr
+    - chmod u+x utr
+    - pip install unity-downloader-cli --index-url {{ artifactory.production }}pypi/pypi/simple --upgrade
+    - unity-downloader-cli -c Editor -c iOS -u {{ editor.version }} --wait --fast
+    - ./utr --testproject=.MyTestProject --editor-location=.Editor --suite=playmode --platform=ios --artifacts_path=upm-ci~/test-results/ios --extra-editor-arg="-playerHeartbeatTimeout 900" --extra-editor-arg="-upmNoDefaultPackages"
   artifacts:
     packages:
       paths:

--- a/com.unity.mobile.notifications/Editor/NotificationSettings.cs
+++ b/com.unity.mobile.notifications/Editor/NotificationSettings.cs
@@ -117,15 +117,15 @@ namespace Unity.Notifications
             /// <summary>
             /// Configure the notification interaction types your app will include in the authorisation request if RequestAuthorizationOnAppLaunch is enabled. Alternatively you can specify them when creating a `AuthorizationRequest` from a script.
             /// </summary>
-            public static PresentationOption DefaultAuthorizationOptions
+            public static AuthorizationOption DefaultAuthorizationOptions
             {
                 get
                 {
-                    return GetSettingValue<PresentationOption>(BuildTargetGroup.iOS, "UnityNotificationDefaultAuthorizationOptions");
+                    return GetSettingValue<AuthorizationOption>(BuildTargetGroup.iOS, "UnityNotificationDefaultAuthorizationOptions");
                 }
                 set
                 {
-                    SetSettingValue<PresentationOption>(BuildTargetGroup.iOS, "UnityNotificationDefaultAuthorizationOptions", value);
+                    SetSettingValue<AuthorizationOption>(BuildTargetGroup.iOS, "UnityNotificationDefaultAuthorizationOptions", value);
                 }
             }
 

--- a/com.unity.mobile.notifications/Tests/Editor/NotificationSettingsTests.cs
+++ b/com.unity.mobile.notifications/Tests/Editor/NotificationSettingsTests.cs
@@ -45,7 +45,7 @@ namespace Unity.Notifications.Tests
             Assert.IsTrue(NotificationSettings.iOSSettings.NotificationRequestAuthorizationForRemoteNotificationsOnAppLaunch);
 
             Assert.AreEqual(PresentationOption.Alert, NotificationSettings.iOSSettings.RemoteNotificationForegroundPresentationOptions);
-            Assert.AreEqual(PresentationOption.Alert, NotificationSettings.iOSSettings.DefaultAuthorizationOptions);
+            Assert.AreEqual(AuthorizationOption.Alert, NotificationSettings.iOSSettings.DefaultAuthorizationOptions);
         }
     }
 }

--- a/com.unity.mobile.notifications/Tests/Editor/NotificationSettingsTests.cs
+++ b/com.unity.mobile.notifications/Tests/Editor/NotificationSettingsTests.cs
@@ -31,7 +31,7 @@ namespace Unity.Notifications.Tests
         public void SetiOSNotifcationSettings_Works()
         {
             NotificationSettings.iOSSettings.AddRemoteNotificationCapability = true;
-            NotificationSettings.iOSSettings.DefaultAuthorizationOptions = PresentationOption.Alert;
+            NotificationSettings.iOSSettings.DefaultAuthorizationOptions = AuthorizationOption.Alert;
             NotificationSettings.iOSSettings.UseLocationNotificationTrigger = true;
             NotificationSettings.iOSSettings.UseAPSReleaseEnvironment = true;
             NotificationSettings.iOSSettings.RemoteNotificationForegroundPresentationOptions = PresentationOption.Alert;

--- a/com.unity.mobile.notifications/Tests/Runtime/iOS/Unity.iOS.Notifications.Tests.asmdef
+++ b/com.unity.mobile.notifications/Tests/Runtime/iOS/Unity.iOS.Notifications.Tests.asmdef
@@ -1,18 +1,25 @@
 {
     "name": "Unity.iOS.Notifications.Tests",
+    "rootNamespace": "",
     "references": [
-        "Unity.Notifications.iOS"
-    ],
-    "optionalUnityReferences": [
-        "TestAssemblies"
+        "Unity.Notifications.iOS",
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner"
     ],
     "includePlatforms": [
+        "Editor",
         "iOS"
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
-    "precompiledReferences": [],
-    "autoReferenced": true,
-    "defineConstraints": []
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/com.unity.mobile.notifications/Tests/Runtime/iOS/Unity.iOS.Notifications.Tests.asmdef
+++ b/com.unity.mobile.notifications/Tests/Runtime/iOS/Unity.iOS.Notifications.Tests.asmdef
@@ -4,7 +4,8 @@
     "references": [
         "Unity.Notifications.iOS",
         "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner"
+        "UnityEditor.TestRunner",
+        "Unity.Notifications"
     ],
     "includePlatforms": [
         "Editor",

--- a/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
@@ -10,6 +10,7 @@ class iOSNotificationTests
     private static int receivedNotificationCount = 0;
     private static iOSNotification lastReceivedNotification = null;
 
+#if !UNITY_EDITOR
     [OneTimeSetUp]
     public void BeforeTests()
     {
@@ -34,10 +35,14 @@ class iOSNotificationTests
         receivedNotificationCount = 0;
         lastReceivedNotification = null;
     }
+#endif
 
     [UnityTest]
     public IEnumerator SendSimpleNotification_NotificationIsReceived()
     {
+#if UNITY_EDITOR
+        yield break;
+#else
         var timeTrigger = new iOSNotificationTimeIntervalTrigger()
         {
             TimeInterval = new TimeSpan(0, 0, 5),
@@ -65,11 +70,15 @@ class iOSNotificationTests
 
         yield return new WaitForSeconds(6.0f);
         Assert.AreEqual(1, receivedNotificationCount);
+#endif
     }
 
     [UnityTest]
     public IEnumerator SendNotificationWithUserInfo_NotificationIsReceivedWithSameUserInfo()
     {
+#if UNITY_EDITOR
+        yield break;
+#else
         var timeTrigger = new iOSNotificationTimeIntervalTrigger()
         {
             TimeInterval = new TimeSpan(0, 0, 5),
@@ -98,5 +107,6 @@ class iOSNotificationTests
         Assert.IsNotNull(lastReceivedNotification);
         Assert.IsTrue(lastReceivedNotification.UserInfo.ContainsKey("key1"));
         Assert.AreEqual("value1", lastReceivedNotification.UserInfo["key1"]);
+#endif
     }
 }

--- a/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using System.Collections;
 using Unity.Notifications.iOS;
 #if UNITY_EDITOR
+using Unity.Notifications;
 using UnityEditor;
 #endif
 
@@ -15,13 +16,26 @@ class iOSNotificationTests
     private static iOSNotification lastReceivedNotification = null;
 #if UNITY_EDITOR
     private static iOSSdkVersion originaliOSSDK;
+    private static bool originalRequestAuthorizationOnAppLaunch;
+    private static AuthorizationOption originalAuthorizationOptions;
+    private static bool originalAddRemoteNotificationCapability;
+    private static bool originalRequestRemoteOnLaunch;
 #endif
 
     public void Setup()
     {
 #if UNITY_EDITOR
         originaliOSSDK = PlayerSettings.iOS.sdkVersion;
+        originalRequestAuthorizationOnAppLaunch = NotificationSettings.iOSSettings.RequestAuthorizationOnAppLaunch;
+        originalAuthorizationOptions = NotificationSettings.iOSSettings.DefaultAuthorizationOptions;
+        originalAddRemoteNotificationCapability = NotificationSettings.iOSSettings.AddRemoteNotificationCapability;
+        originalRequestRemoteOnLaunch = NotificationSettings.iOSSettings.NotificationRequestAuthorizationForRemoteNotificationsOnAppLaunch;
+
         PlayerSettings.iOS.sdkVersion = iOSSdkVersion.SimulatorSDK;
+        NotificationSettings.iOSSettings.RequestAuthorizationOnAppLaunch = true;
+        NotificationSettings.iOSSettings.DefaultAuthorizationOptions = originalAuthorizationOptions | AuthorizationOption.Provisional;
+        NotificationSettings.iOSSettings.AddRemoteNotificationCapability = false;
+        NotificationSettings.iOSSettings.NotificationRequestAuthorizationForRemoteNotificationsOnAppLaunch = false;
 #endif
     }
 
@@ -29,6 +43,10 @@ class iOSNotificationTests
     {
 #if UNITY_EDITOR
         PlayerSettings.iOS.sdkVersion = originaliOSSDK;
+        NotificationSettings.iOSSettings.RequestAuthorizationOnAppLaunch = originalRequestAuthorizationOnAppLaunch;
+        NotificationSettings.iOSSettings.DefaultAuthorizationOptions = originalAuthorizationOptions;
+        NotificationSettings.iOSSettings.AddRemoteNotificationCapability = originalAddRemoteNotificationCapability;
+        NotificationSettings.iOSSettings.NotificationRequestAuthorizationForRemoteNotificationsOnAppLaunch = originalRequestRemoteOnLaunch;
 #endif
     }
 

--- a/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
@@ -78,11 +78,9 @@ class iOSNotificationTests
 #endif
 
     [UnityTest]
+    [UnityPlatform(RuntimePlatform.IPhonePlayer)]
     public IEnumerator SendSimpleNotification_NotificationIsReceived()
     {
-#if UNITY_EDITOR
-        yield break;
-#else
         var timeTrigger = new iOSNotificationTimeIntervalTrigger()
         {
             TimeInterval = new TimeSpan(0, 0, 5),
@@ -110,15 +108,12 @@ class iOSNotificationTests
 
         yield return new WaitForSeconds(6.0f);
         Assert.AreEqual(1, receivedNotificationCount);
-#endif
     }
 
     [UnityTest]
+    [UnityPlatform(RuntimePlatform.IPhonePlayer)]
     public IEnumerator SendNotificationWithUserInfo_NotificationIsReceivedWithSameUserInfo()
     {
-#if UNITY_EDITOR
-        yield break;
-#else
         var timeTrigger = new iOSNotificationTimeIntervalTrigger()
         {
             TimeInterval = new TimeSpan(0, 0, 5),
@@ -147,6 +142,5 @@ class iOSNotificationTests
         Assert.IsNotNull(lastReceivedNotification);
         Assert.IsTrue(lastReceivedNotification.UserInfo.ContainsKey("key1"));
         Assert.AreEqual("value1", lastReceivedNotification.UserInfo["key1"]);
-#endif
     }
 }

--- a/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
@@ -4,11 +4,33 @@ using UnityEngine.TestTools;
 using NUnit.Framework;
 using System.Collections;
 using Unity.Notifications.iOS;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
 
 class iOSNotificationTests
+    : IPrebuildSetup, IPostBuildCleanup
 {
     private static int receivedNotificationCount = 0;
     private static iOSNotification lastReceivedNotification = null;
+#if UNITY_EDITOR
+    private static iOSSdkVersion originaliOSSDK;
+#endif
+
+    public void Setup()
+    {
+#if UNITY_EDITOR
+        originaliOSSDK = PlayerSettings.iOS.sdkVersion;
+        PlayerSettings.iOS.sdkVersion = iOSSdkVersion.SimulatorSDK;
+#endif
+    }
+
+    public void Cleanup()
+    {
+#if UNITY_EDITOR
+        PlayerSettings.iOS.sdkVersion = originaliOSSDK;
+#endif
+    }
 
 #if !UNITY_EDITOR
     [OneTimeSetUp]


### PR DESCRIPTION
- Add CI for running tests on iOS (fixes the tests too)
- Breaking change in settings: the type of DefaultAuthorizationOptions changed to AuthorizationOption (probably this had to be so from beginning and was a mistake).