### PR TITLE
case 1360115 fix focus loss when switching settings

### DIFF
--- a/com.unity.mobile.notifications/Editor/NotificationSettingsProvider.cs
+++ b/com.unity.mobile.notifications/Editor/NotificationSettingsProvider.cs
@@ -5,6 +5,7 @@ using UnityEditor;
 using UnityEditorInternal;
 using Unity.Notifications.iOS;
 using UnityEngine.Assertions;
+using UnityEngine.UIElements;
 
 namespace Unity.Notifications
 {
@@ -47,10 +48,18 @@ namespace Unity.Notifications
             return new NotificationSettingsProvider("Project/Mobile Notifications", SettingsScope.Project);
         }
 
+        public override void OnActivate(string searchContext, VisualElement rootElement)
+        {
+            base.OnActivate(searchContext, rootElement);
+            // in case of domain reload (enter-exit play mode, this gets lost)
+            if (m_SettingsManager == null)
+                Initialize();
+        }
+
         public override void OnDeactivate()
         {
+            base.OnDeactivate();
             m_SettingsManager.SaveSettings(false);
-            SettingsService.NotifySettingsProviderChanged();
         }
 
         private void Initialize()

--- a/com.unity.mobile.notifications/Editor/NotificationSettingsProvider.cs
+++ b/com.unity.mobile.notifications/Editor/NotificationSettingsProvider.cs
@@ -232,7 +232,12 @@ namespace Unity.Notifications
 
             // Draw the toolbar for Android/iOS.
             var toolBarRect = new Rect(totalRect.x, totalRect.y, totalRect.width, k_ToolbarHeight);
-            m_SettingsManager.ToolbarIndex = GUI.Toolbar(toolBarRect, m_SettingsManager.ToolbarIndex, k_ToolbarStrings);
+            var toolbarIndex = GUI.Toolbar(toolBarRect, m_SettingsManager.ToolbarIndex, k_ToolbarStrings);
+            if (toolbarIndex != m_SettingsManager.ToolbarIndex)
+            {
+                m_SettingsManager.ToolbarIndex = toolbarIndex;
+                m_SettingsManager.SaveSettings();
+            }
 
             var notificationSettingsRect = new Rect(totalRect.x, k_ToolbarHeight + 2, totalRect.width, totalRect.height - k_ToolbarHeight - k_Padding);
 


### PR DESCRIPTION
https://jira.unity3d.com/browse/MPT-1619

There things here:
- Fix case 1360115 - lost focus when trying to switch from notifications to different settings (like Player)
- Re-fix the bug that originally introduced this issue: https://github.com/Unity-Technologies/com.unity.mobile.notifications/pull/70
- Call base implementation in OnDeactivate, since that one is not empty

QA: check whether settings work fine (and get saved properly) after this, especially with play mode, which is being re-fixed here.