### PR TITLE
Add Android CI

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -177,6 +177,9 @@ test_trigger:
     {% for editor in ios_test_editors %}
     - .yamato/upm-ci.yml#test_iOS_{{ editor.version }}
     {% endfor %}
+    {% for editor in android_test_editors %}
+    - .yamato/upm-ci.yml#test_Android_{{ editor.version }}
+    {% endfor %}
 
 publish:
   name: Publish to Internal Registry

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -102,6 +102,9 @@ test_Android_{{ editor.version }}:
        set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
        start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
        utr.bat --testproject=.MyTestProject --editor-location=.Editor --suite=playmode --platform=android --scripting-backend=mono --artifacts_path=upm-ci~/test-results/android
+  after:
+    - start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+    - powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > upm-ci~/test-results/android/android_device_log.txt
   artifacts:
     packages:
       paths:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -101,7 +101,7 @@ test_Android_{{ editor.version }}:
     - |
        set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
        start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-       utr.bat --testproject=.MyTestProject --editor-location=.Editor --suite=playmode --platform=android --scripting-backend=mono --artifacts_path=upm-ci~/test-results/android
+       utr.bat --testproject=.MyTestProject --editor-location=.Editor --suite=playmode --platform=android --scripting-backend=mono --artifacts_path=upm-ci~/test-results/android --timeout=900
   after:
     - start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
     - powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > upm-ci~/test-results/android/android_device_log.txt

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -79,6 +79,37 @@ test_{{ platform.name }}_{{ editor.version }}:
 {% endfor %}
 {% endfor %}
 
+{% for editor in test_editors %}
+test_Android_{{ editor.version }}:
+  name: Test {{ editor.version }} on Android
+  agent:
+    type: Unity::mobile::shield
+    image: mobile/android-execution-r19:stable
+    flavor: b1.medium
+  commands:
+    - choco source add -n Unity -s {{ artifactory.production }}nuget/unity-choco-local
+    - choco install unity-config
+    - unity-config settings editor-path .Editor
+    - unity-config project create .MyTestProject
+{%- for dependency in mobile_dependencies -%}
+    - unity-config project add dependency {{dependency.name}}@{{dependency.version}} --project-path .MyTestProject
+{%- endfor -%}
+    - unity-config project add testable com.unity.mobile.notifications
+    - curl -s {{ utr.url_win }} --output utr.bat
+    - pip install unity-downloader-cli --index-url {{ artifactory.production }}pypi/pypi/simple --upgrade
+    - unity-downloader-cli -c Editor -c Android -u {{ editor.version }} --wait --fast
+    - |
+       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
+       start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+       utr.bat --testproject=.MyTestProject --editor-location=.Editor --suite=playmode --platform=android --scripting-backend=mono --artifacts_path=upm-ci~/test-results/android
+  artifacts:
+    packages:
+      paths:
+        - "upm-ci~/**/*"
+  dependencies:
+    - .yamato/upm-ci.yml#pack
+{% endfor %}
+
 {% for editor in ios_test_editors %}
 test_iOS_{{ editor.version }}:
   name: Test {{ editor.version }} on iOS

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -5,6 +5,13 @@ test_editors:
   - version: 2020.3
   - version: 2019.4
 
+# running test is currently broken in trunk
+android_test_editors:
+  - version: 2021.2
+  - version: 2021.1
+  - version: 2020.3
+  - version: 2019.4
+
 # Some issues with 2019.4 on iOS on Yamato, but passes locally
 ios_test_editors:
   - version: trunk
@@ -79,7 +86,7 @@ test_{{ platform.name }}_{{ editor.version }}:
 {% endfor %}
 {% endfor %}
 
-{% for editor in test_editors %}
+{% for editor in android_test_editors %}
 test_Android_{{ editor.version }}:
   name: Test {{ editor.version }} on Android
   agent:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -5,9 +5,8 @@ test_editors:
   - version: 2020.3
   - version: 2019.4
 
-# running test is currently broken in trunk
+# running test is currently broken in trunk and 2021.2
 android_test_editors:
-  - version: 2021.2
   - version: 2021.1
   - version: 2020.3
   - version: 2019.4

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -212,7 +212,10 @@ namespace Unity.Notifications.Android
             if (!Initialize())
                 return -1;
 
-            int id = Math.Abs(DateTime.Now.ToString("yyMMddHHmmssffffff").GetHashCode()) + (new System.Random().Next(10000));
+            // Now.ToString("yyMMddHHmmssffffff"), but avoiding any culture-related formatting or dependencies
+            var now = DateTime.UtcNow;
+            var nowFormatted = $"{now.Year}{now.Month}{now.Day}{now.Hour}{now.Minute}{now.Second}{now.Millisecond}";
+            int id = Math.Abs(nowFormatted.GetHashCode()) + (new System.Random().Next(10000));
             using (var builder = CreateNotificationBuilder(id, notification, channelId))
                 SendNotification(builder);
 

--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
@@ -76,9 +76,9 @@ class AndroidNotificationSendingTests
     }
 
     [UnityTest]
+    [UnityPlatform(RuntimePlatform.Android)]
     public IEnumerator SendNotificationExplicitID_NotificationIsReceived()
     {
-#if !UNITY_EDITOR
         int originalId = 456;
 
         var n = new AndroidNotification();
@@ -98,15 +98,12 @@ class AndroidNotificationSendingTests
         Assert.AreEqual(1, currentHandler.receivedNotificationCount);
         Assert.AreEqual(originalId, currentHandler.lastNotification.Id);
         Assert.AreEqual(n.Group, currentHandler.lastNotification.Notification.Group);
-#else
-        yield break;
-#endif
     }
 
     [UnityTest]
+    [UnityPlatform(RuntimePlatform.Android)]
     public IEnumerator SendNotification_NotificationIsReceived()
     {
-#if !UNITY_EDITOR
         var n = new AndroidNotification();
         n.Title = "SendNotification_NotificationIsReceived";
         n.Text = "SendNotification_NotificationIsReceived Text";
@@ -121,15 +118,12 @@ class AndroidNotificationSendingTests
 
         Assert.AreEqual(1, currentHandler.receivedNotificationCount);
         Assert.AreEqual(originalId, currentHandler.lastNotification.Id);
-#else
-        yield break;
-#endif
     }
 
     [UnityTest]
+    [UnityPlatform(RuntimePlatform.Android)]
     public IEnumerator SendNotificationAndCancelNotification_NotificationIsNotReceived()
     {
-#if !UNITY_EDITOR
         var n = new AndroidNotification();
         n.Title = "SendNotificationAndCancelNotification_NotificationIsNotReceived";
         n.Text = "SendNotificationAndCancelNotification_NotificationIsNotReceived Text";
@@ -146,15 +140,12 @@ class AndroidNotificationSendingTests
         Debug.LogWarning("SendNotificationAndCancelNotification_NotificationIsNotReceived completed.");
 
         Assert.AreEqual(0, currentHandler.receivedNotificationCount);
-#else
-        yield break;
-#endif
     }
 
     [UnityTest]
+    [UnityPlatform(RuntimePlatform.Android)]
     public IEnumerator ScheduleRepeatableNotification_NotificationsAreReceived()
     {
-#if !UNITY_EDITOR
         var n = new AndroidNotification();
         n.Title = "Repeating Notification Title";
         n.Text = "Repeating Notification Text";
@@ -174,15 +165,12 @@ class AndroidNotificationSendingTests
         Debug.LogWarning("ScheduleRepeatableNotification_NotificationsAreReceived completed");
 
         Assert.GreaterOrEqual(currentHandler.receivedNotificationCount, 2);
-#else
-        yield break;
-#endif
     }
 
     [UnityTest]
+    [UnityPlatform(RuntimePlatform.Android)]
     public IEnumerator NotificationIsScheduled_NotificationStatusIsCorrectlyReported()
     {
-#if !UNITY_EDITOR
         var n = new AndroidNotification();
         n.Title = "NotificationStatusIsCorrectlyReported";
         n.Text = "NotificationStatusIsCorrectlyReported";
@@ -207,15 +195,12 @@ class AndroidNotificationSendingTests
         Assert.AreEqual(NotificationStatus.Unknown, status);
 
         Debug.LogWarning("NotificationIsScheduled_NotificationStatusIsCorrectlyReported completed");
-#else
-        yield break;
-#endif
     }
 
     [Test]
+    [UnityPlatform(RuntimePlatform.Android)]
     public void CreateNotificationChannelWithInitializedSettings_ChannelSettingsAreSaved()
     {
-#if !UNITY_EDITOR
         var chOrig = new AndroidNotificationChannel();
         chOrig.Id = "test_channel_settings_are_saved_0";
         chOrig.Name = "spam Channel";
@@ -239,13 +224,12 @@ class AndroidNotificationSendingTests
         Assert.AreEqual(chOrig.EnableLights, ch.EnableLights);
         Assert.AreEqual(chOrig.EnableVibration, ch.EnableVibration);
         //Assert.AreEqual(chOrig.LockScreenVisibility, ch.LockScreenVisibility);
-#endif
     }
 
     [UnityTest]
+    [UnityPlatform(RuntimePlatform.Android)]
     public IEnumerator SendNotification_NotificationIsReceived_CallMainThread()
     {
-#if !UNITY_EDITOR
         var gameObjects = new GameObject[1];
 
         AndroidNotificationCenter.NotificationReceivedCallback receivedNotificationHandler =
@@ -275,15 +259,12 @@ class AndroidNotificationSendingTests
         Assert.AreEqual(1, currentHandler.receivedNotificationCount);
         Assert.AreEqual(originalId, currentHandler.lastNotification.Id);
         Assert.IsNotNull(gameObjects[0]);
-#else
-        yield break;
-#endif
     }
 
     [UnityTest]
+    [UnityPlatform(RuntimePlatform.Android)]
     public IEnumerator SendNotification_CanAccessNativeBuilder()
     {
-#if !UNITY_EDITOR
         var n = new AndroidNotification();
         n.Title = "SendNotification_CanAccessNativeBuilder";
         n.Text = "SendNotification_CanAccessNativeBuilder Text";
@@ -310,8 +291,5 @@ class AndroidNotificationSendingTests
         {
             Assert.AreEqual("TheTest", extras.Call<string>("getString", "notification.test.string"));
         }
-#else
-        yield break;
-#endif
     }
 }

--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSimpleTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSimpleTests.cs
@@ -1,6 +1,7 @@
 using System;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.TestTools;
 using Unity.Notifications.Android;
 
 class AndroidNotificationSimpleTests
@@ -19,9 +20,9 @@ class AndroidNotificationSimpleTests
     }
 
     [Test]
+    [UnityPlatform(RuntimePlatform.Android)]
     public void CreateNotificationChannel_NotificationChannelIsCreated()
     {
-#if !UNITY_EDITOR
         var testChannelId = "default_test_channel_10";
         AndroidNotificationCenter.DeleteNotificationChannel(testChannelId);
         Assert.AreNotEqual("default_test_channel_10", AndroidNotificationCenter.GetNotificationChannel(testChannelId).Id);
@@ -36,13 +37,12 @@ class AndroidNotificationSimpleTests
         currentChannelCount++;
 
         Assert.AreEqual(currentChannelCount, AndroidNotificationCenter.GetNotificationChannels().Length);
-#endif
     }
 
     [Test]
+    [UnityPlatform(RuntimePlatform.Android)]
     public void DeleteNotificationChannel_NotificationChannelIsDeleted()
     {
-#if !UNITY_EDITOR
         var ch = new AndroidNotificationChannel();
         ch.Id = "default_test_channel_0";
         ch.Name = "Default Channel";
@@ -54,7 +54,6 @@ class AndroidNotificationSimpleTests
         AndroidNotificationCenter.DeleteNotificationChannel(ch.Id);
 
         Assert.AreEqual(numChannels - 1, AndroidNotificationCenter.GetNotificationChannels().Length);
-#endif
     }
 
     [Test]
@@ -78,6 +77,7 @@ class AndroidNotificationSimpleTests
     }
 
     [Test]
+    [UnityPlatform(RuntimePlatform.Android)]
     public void BasicSerializeDeserializeNotification_AllParameters()
     {
         const int notificationId = 123;
@@ -165,6 +165,7 @@ class AndroidNotificationSimpleTests
     }
 
     [Test]
+    [UnityPlatform(RuntimePlatform.Android)]
     public void BasicSerializeDeserializeNotification_MinimumParameters()
     {
         const int notificationId = 124;
@@ -180,6 +181,7 @@ class AndroidNotificationSimpleTests
     }
 
     [Test]
+    [UnityPlatform(RuntimePlatform.Android)]
     public void BasicSerializeDeserializeNotification_CanPutSimpleExtras()
     {
         const int notificationId = 125;
@@ -211,6 +213,7 @@ class AndroidNotificationSimpleTests
     }
 
     [Test]
+    [UnityPlatform(RuntimePlatform.Android)]
     public void BasicSerializeDeserializeNotification_WorksWithBinderExtras()
     {
         const int notificationId = 126;
@@ -268,6 +271,7 @@ class AndroidNotificationSimpleTests
     }
 
     [Test]
+    [UnityPlatform(RuntimePlatform.Android)]
     public void NotificationIntentSerialization_SimpleNotification()
     {
         const int notificationId = 1234;
@@ -280,6 +284,7 @@ class AndroidNotificationSimpleTests
     }
 
     [Test]
+    [UnityPlatform(RuntimePlatform.Android)]
     public void NotificationIntentSerialization_NotificationWithBinderObject()
     {
         const int notificationId = 1234;
@@ -303,6 +308,7 @@ class AndroidNotificationSimpleTests
     }
 
     [Test]
+    [UnityPlatform(RuntimePlatform.Android)]
     public void OldTypeSerializedNotificationCanBedeserialized()
     {
         const int notificationId = 12345;


### PR DESCRIPTION
Add CI to run tests on Android. Currently trunk and 2021.2 are excluded, since running playmode test in these is broken for Android.
Couple not related small changes in this PR:
- Refactored Android tests to use attributes instead of defines
- Remove dependency on current culture when generating notification ID (breaks on Arabic).