### PR TITLE
Optimize android notification saving

### DIFF
--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -309,7 +309,7 @@ namespace Unity.Notifications.Android
         public static void CancelScheduledNotification(int id)
         {
             if (Initialize())
-                s_NotificationManager.Call("cancelPendingNotificationIntent", id);
+                s_NotificationManager.Call("cancelPendingNotification", id);
         }
 
         /// <summary>

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -440,7 +440,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         int[] ids = this.getScheduledNotificationIDs();
 
         for (int id : ids) {
-            cancelPendingNotificationIntent(id);
+            cancelPendingNotification(id);
         }
     }
 
@@ -472,7 +472,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
     }
 
     // Cancel a pending notification by id.
-    public void cancelPendingNotificationIntent(int id) {
+    public void cancelPendingNotification(int id) {
         synchronized (UnityNotificationManager.class) {
             UnityNotificationManager.cancelPendingNotificationIntent(mContext, id);
             if (this.mRescheduleOnRestart) {

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -358,12 +358,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
         String data = UnityNotificationUtilities.serializeNotificationIntent(intent);
         editor.putString("data", data);
         editor.apply();
-
-        // Add the id to notification ids SharedPreferences.
-        Set<String> ids = new HashSet<String>(getScheduledNotificationIDs(context));
-        ids.add(notification_id);
-
-        saveScheduledNotificationIDs(context, ids);
     }
 
     protected static String getSharedPrefsNameByNotificationId(String id)

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -299,7 +299,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
     protected static synchronized Intent buildNotificationIntent(Context context, int notificationId) {
         Intent intent = new Intent(context, UnityNotificationManager.class);
 
-        HashSet<String> ids = new HashSet<String>(getScheduledNotificationIDs(context));
+        Set<String> ids = getScheduledNotificationIDs(context);
 
         Set<String> validNotificationIds = new HashSet<String>();
         for (String id : ids) {

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -442,11 +442,16 @@ public class UnityNotificationManager extends BroadcastReceiver {
             saveScheduledNotificationIDs(mContext, new HashSet<>());
         }
 
-        for (String id : ids) {
-            cancelPendingNotificationIntent(mContext, Integer.valueOf(id));
-            if (this.mRescheduleOnRestart) {
-                deleteExpiredNotificationIntent(mContext, id);
-            }
+        if (ids.size() > 0) {
+            Context context = mContext;
+            new Thread(() -> {
+                for (String id : ids) {
+                    cancelPendingNotificationIntent(context, Integer.valueOf(id));
+                    if (this.mRescheduleOnRestart) {
+                        deleteExpiredNotificationIntent(context, id);
+                    }
+                }
+            }).start();
         }
     }
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -297,7 +297,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
     // Build a notification Intent to store the PendingIntent.
     private static synchronized Intent buildNotificationIntentUpdateList(Context context, int notificationId) {
-        Intent intent = buildNotificationIntent(context, notificationId);
+        Intent intent = buildNotificationIntent(context);
 
         Set<String> ids = getScheduledNotificationIDs(context);
 
@@ -327,7 +327,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         return intent;
     }
 
-    protected static Intent buildNotificationIntent(Context context, int notificationId) {
+    protected static Intent buildNotificationIntent(Context context) {
         Intent intent = new Intent(context, UnityNotificationManager.class);
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
         return intent;

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -268,7 +268,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
             fireTime += repeatInterval;
         }
 
-        Intent intent = buildNotificationIntent(mContext, id);
+        Intent intent = buildNotificationIntentUpdateList(mContext, id);
 
         if (intent != null) {
             if (this.mRescheduleOnRestart) {
@@ -296,8 +296,8 @@ public class UnityNotificationManager extends BroadcastReceiver {
     }
 
     // Build a notification Intent to store the PendingIntent.
-    protected static synchronized Intent buildNotificationIntent(Context context, int notificationId) {
-        Intent intent = new Intent(context, UnityNotificationManager.class);
+    private static synchronized Intent buildNotificationIntentUpdateList(Context context, int notificationId) {
+        Intent intent = buildNotificationIntent(context, notificationId);
 
         Set<String> ids = getScheduledNotificationIDs(context);
 
@@ -320,11 +320,16 @@ public class UnityNotificationManager extends BroadcastReceiver {
             intent = null;
         } else {
             validNotificationIds.add(Integer.toString(notificationId));
-            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
         }
 
         saveScheduledNotificationIDs(context, validNotificationIds);
 
+        return intent;
+    }
+
+    protected static Intent buildNotificationIntent(Context context, int notificationId) {
+        Intent intent = new Intent(context, UnityNotificationManager.class);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
         return intent;
     }
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -40,6 +40,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
     protected Class mOpenActivity = null;
     protected boolean mRescheduleOnRestart = false;
 
+    protected static final int SAMSUNG_NOTIFICATION_LIMIT = 500;
     protected static final String TAG_UNITY = "UnityNotifications";
 
     protected static final String KEY_FIRE_TIME = "fireTime";
@@ -300,11 +301,12 @@ public class UnityNotificationManager extends BroadcastReceiver {
     // Build a notification Intent to store the PendingIntent.
     private static synchronized Intent buildNotificationIntentUpdateList(Context context, int notificationId) {
         Set<String> ids = getScheduledNotificationIDs(context);
-        if (android.os.Build.MANUFACTURER.equals("samsung") && ids.size() >= 499) {
+        if (android.os.Build.MANUFACTURER.equals("samsung") && ids.size() >= (SAMSUNG_NOTIFICATION_LIMIT - 1)) {
             // There seems to be a limit of 500 concurrently scheduled alarms on Samsung devices.
             // Attempting to schedule more than that might cause the app to crash.
-            Log.w(TAG_UNITY, "Attempting to schedule more than 500 notifications. There is a limit of 500 concurrently scheduled Alarms on Samsung devices" +
-                    " either wait for the currently scheduled ones to be triggered or cancel them if you wish to schedule additional notifications.");
+            Log.w(TAG_UNITY, String.format("Attempting to schedule more than %1$d notifications. There is a limit of %1$d concurrently scheduled Alarms on Samsung devices" +
+                    " either wait for the currently scheduled ones to be triggered or cancel them if you wish to schedule additional notifications.",
+                    SAMSUNG_NOTIFICATION_LIMIT));
             return null;
         }
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -475,14 +475,16 @@ public class UnityNotificationManager extends BroadcastReceiver {
     public void cancelPendingNotification(int id) {
         synchronized (UnityNotificationManager.class) {
             UnityNotificationManager.cancelPendingNotificationIntent(mContext, id);
+            String idStr = String.valueOf(id);
+            removeScheduledNotificationID(mContext, idStr);
             if (this.mRescheduleOnRestart) {
-                UnityNotificationManager.deleteExpiredNotificationIntent(mContext, Integer.toString(id));
+                UnityNotificationManager.deleteExpiredNotificationIntent(mContext, idStr);
             }
         }
     }
 
     // Cancel a pending notification by id.
-    protected static synchronized void cancelPendingNotificationIntent(Context context, int id) {
+    protected static void cancelPendingNotificationIntent(Context context, int id) {
         Intent intent = new Intent(context, UnityNotificationManager.class);
         PendingIntent broadcast = getBroadcastPendingIntent(context, id, intent, PendingIntent.FLAG_NO_CREATE);
 
@@ -493,8 +495,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
             }
             broadcast.cancel();
         }
-
-        removeScheduledNotificationID(context, String.valueOf(id));
     }
 
     protected static synchronized void removeScheduledNotificationID(Context context, String id) {

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
@@ -49,7 +49,9 @@ public class UnityNotificationRestartOnBootReceiver extends BroadcastReceiver {
                     PendingIntent broadcast = UnityNotificationManager.getBroadcastPendingIntent(context, id, intent, PendingIntent.FLAG_UPDATE_CURRENT);
                     UnityNotificationManager.scheduleNotificationIntentAlarm(context, repeatInterval, fireTime, broadcast);
                 } else {
-                    UnityNotificationManager.deleteExpiredNotificationIntent(context, Integer.toString(id));
+                    String idStr = String.valueOf(id);
+                    UnityNotificationManager.removeScheduledNotificationID(context, idStr);
+                    UnityNotificationManager.deleteExpiredNotificationIntent(context, idStr);
                 }
             }
         }

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
@@ -39,7 +39,7 @@ public class UnityNotificationRestartOnBootReceiver extends BroadcastReceiver {
                     openAppIntent.putExtra(KEY_NOTIFICATION, notification);
 
                     PendingIntent pendingIntent = PendingIntent.getActivity(context, id, openAppIntent, 0);
-                    Intent intent = UnityNotificationManager.buildNotificationIntent(context, id);
+                    Intent intent = UnityNotificationManager.buildNotificationIntent(context);
                     Notification.Builder notificationBuilder = Notification.Builder.recoverBuilder(context, notification);
                     notificationBuilder.setContentIntent(pendingIntent);
                     UnityNotificationManager.finalizeNotificationForDisplay(context, notificationBuilder);


### PR DESCRIPTION
Optimizes notification scheduling and cancelling by optimizing/multithreading saving of data. The issues:
https://github.com/Unity-Technologies/com.unity.mobile.notifications/issues/113
https://github.com/Unity-Technologies/com.unity.mobile.notifications/issues/112

The key changes are to do less redundant stuff and to offload some of the work to other threads. For user there should be no behavior changes.
Some numbers (Nokia 7 Plus):
- Scheduling 100 notifications from ~1500ms when down to ~500ms
- Cancelling all 100 notifications from ~130ms when down to ~1ms (almost all work moved to other thread)

Sending notifications could be improved further, but the best approach for that is to performance-wise improve the core AndroidJNI first.