### PR TITLE
Reinitialize manager if gone (domain reload)

### DIFF
--- a/com.unity.mobile.notifications/Editor/NotificationSettingsProvider.cs
+++ b/com.unity.mobile.notifications/Editor/NotificationSettingsProvider.cs
@@ -221,6 +221,9 @@ namespace Unity.Notifications
 
         public override void OnGUI(string searchContext)
         {
+            if (m_SettingsManager == null)
+                Initialize();
+
             // This has to be called to sync all the changes between m_SettingsManager and m_SettingsManagerObject.
             if (m_SettingsManagerObject.targetObject != null)
                 m_SettingsManagerObject.Update();


### PR DESCRIPTION
If you build player with Notification Settings open, after domain reload m_SettingsManager will be null and needs to be reinitialized.