### PR TITLE
Package Signature in CI

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -187,6 +187,8 @@ publish:
     type: Unity::VM
     image: package-ci/win10:stable
     flavor: b1.large
+  variables:
+    UPMCI_ENABLE_PACKAGE_SIGNING: 1
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     - upm-ci package publish --package-path com.unity.mobile.notifications


### PR DESCRIPTION
As part of the package signing initiative, we'd like bundled packages to be prepared for upcoming constraints regarding the need to have packages with a valid signature during APV testing.

Because of this, we are going through all bundled packages' repositories creating a PR that would enable package signing on your packages.

With signing enabled, upm-ci will perform an extra step where it will send each package to a signing service and then generate the final signed artifacts.
Internally, in an attempt to ensure that everything works, we are running yamato tests where all bundled packages (including yours) are signed and validated, proving that the packages in this repository should yield no errors. The validation step is also performed in all platforms.

In the case that any error does arise, this can be simply reverted back by removing the environment variable, UPMCI_ENABLE_PACKAGE_SIGNING in the publishing jobs.

For more information, please refer to: https://confluence.unity3d.com/display/PAK/Package+Signature

You can contact us through:
#team-pkd-176-internal-package-signing
@cassandra & @felipemunoz