### PR TITLE
Add APIs to open notification settings

### DIFF
--- a/TestProjects/com.unity.mobile-notifications-sample/Scripts/AndroidTest.cs
+++ b/TestProjects/com.unity.mobile-notifications-sample/Scripts/AndroidTest.cs
@@ -114,6 +114,10 @@ namespace Unity.Notifications.Tests.Sample
 
             m_groups["General"] = new OrderedDictionary();
             m_groups["General"]["Clear Log"] = new Action(() => { m_LOGGER.Clear(); });
+            m_groups["General"]["Open Settings"] = new Action(() =>
+            {
+                AndroidNotificationCenter.OpenNotificationSettings();
+            });
 
             m_groups["Modify"] = new OrderedDictionary();
             //m_groups["Modify"]["Create notification preset"] = new Action(() => {  });
@@ -195,6 +199,10 @@ namespace Unity.Notifications.Tests.Sample
                         VibrationPattern = new long[] { 0L, 1L, 2L }
                     }
                 );
+            });
+            m_groups["Channels"]["Open settings for secondary"] = new Action(() =>
+            {
+                AndroidNotificationCenter.OpenNotificationSettings("secondary_channel");
             });
             m_groups["Channels"]["Delete All Channels"] = new Action(() => { DeleteAllChannels(); });
 

--- a/TestProjects/com.unity.mobile-notifications-sample/Scripts/iOSTest.cs
+++ b/TestProjects/com.unity.mobile-notifications-sample/Scripts/iOSTest.cs
@@ -206,6 +206,7 @@ namespace Unity.Notifications.Tests.Sample
             {
                 ClearBadge();
             });
+            m_groups["General"]["Open settings"] = new Action(iOSNotificationCenter.OpenNotificationSettings);
 
             m_groups["Schedule"] = new OrderedDictionary();
             foreach (iOSNotificationTemplateTimeTrigger template in Resources.LoadAll("iOSNotifications/TimeIntervalTrigger", typeof(iOSNotificationTemplateTimeTrigger)))

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -390,6 +390,21 @@ namespace Unity.Notifications.Android
         }
 
         /// <summary>
+        /// Opens settings.
+        /// On Android versions lower than 8.0 opens settings for the application.
+        /// On Android 8.0 and later opens notification settings for the specified channel, or for the application, if channelId is null.
+        /// Note, that opening settings will suspend the application and switch to settings app.
+        /// </summary>
+        /// <param name="channelId">ID for the channel to open or null to open notification settings for the application.</param>
+        public static void OpenNotificationSettings(string channelId = null)
+        {
+            if (!Initialize())
+                return;
+
+            s_NotificationManager.Call("showNotificationSettings", channelId);
+        }
+
+        /// <summary>
         /// Create Notification.Builder.
         /// Will automatically generate the ID for notification.
         /// <see cref="CreateNotificationBuilder(int, AndroidNotification, string)"/>

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -13,9 +13,11 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.SharedPreferences;
 import android.graphics.BitmapFactory;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.BadParcelableException;
+import android.provider.Settings;
 import android.service.notification.StatusBarNotification;
 import android.util.Log;
 
@@ -719,5 +721,26 @@ public class UnityNotificationManager extends BroadcastReceiver {
         }
 
         return null;
+    }
+
+    public void showNotificationSettings(String channelId) {
+        Intent settingsIntent;
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            settingsIntent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+            Uri uri = Uri.fromParts("package", mContext.getPackageName(), null);
+            settingsIntent.setData(uri);
+        } else {
+            if (channelId != null && channelId.length() > 0) {
+                settingsIntent = new Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS);
+                settingsIntent.putExtra(Settings.EXTRA_CHANNEL_ID, channelId);
+            } else {
+                settingsIntent = new Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS);
+            }
+
+            settingsIntent.putExtra(Settings.EXTRA_APP_PACKAGE, mContext.getPackageName());
+        }
+
+        settingsIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        mActivity.startActivity(settingsIntent);
     }
 }

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationWrapper.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationWrapper.m
@@ -303,4 +303,12 @@ void _SetNotificationCategories(void* categorySet)
     [UNUserNotificationCenter.currentNotificationCenter setNotificationCategories: categories];
 }
 
+void _OpenNotificationSettings()
+{
+    NSURL* url = [NSURL URLWithString: UIApplicationOpenSettingsURLString];
+    UIApplication* app = [UIApplication sharedApplication];
+    if ([app canOpenURL: url])
+        [app openURL: url options: @{} completionHandler: nil];
+}
+
 #endif

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCenter.cs
@@ -237,5 +237,17 @@ namespace Unity.Notifications.iOS
             var notification = new iOSNotification(data);
             s_OnNotificationReceived(notification);
         }
+
+        /// <summary>
+        /// Opens Settings.
+        /// On iOS there is no way to open notification settings specifically, but you can open settings app with current application settings.
+        /// Note, that application will be suspended, since opening settings is switching to different application.
+        /// </summary>
+        public static void OpenNotificationSettings()
+        {
+#if !UNITY_EDITOR
+            iOSNotificationsWrapper._OpenNotificationSettings();
+#endif
+        }
     }
 }

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationsWrapper.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationsWrapper.cs
@@ -124,6 +124,9 @@ namespace Unity.Notifications.iOS
         [DllImport("__Internal")]
         private static extern IntPtr _AddStringToNSArray(IntPtr array, string str, int capacity);
 
+        [DllImport("__Internal")]
+        internal static extern void _OpenNotificationSettings();
+
         private delegate void AuthorizationRequestCallback(IntPtr request, iOSAuthorizationRequestData data);
         private delegate void NotificationReceivedCallback(iOSNotificationData notificationData);
         private delegate void ReceiveNSDictionaryKeyValueCallback(IntPtr dict, string key, string value);


### PR DESCRIPTION
https://jira.unity3d.com/browse/MPT-626

Adds APIs to open notification settings.
On iOS there is no way to open notification settings specifically, so we open app settings (as close enough).
Likewise on pre-Oreo (8.0) Androids.
On Android 8 and later the API opens notification setting for the app or for a specific channel, if not null.