### PR TITLE
Case 1373835 fix calendar notification for buddhist calendars and related improvements

### DIFF
--- a/com.unity.mobile.notifications/Editor/NotificationSettingsManager.cs
+++ b/com.unity.mobile.notifications/Editor/NotificationSettingsManager.cs
@@ -279,9 +279,9 @@ namespace Unity.Notifications
                 var scale = drawableResource.Type == NotificationIconType.Small ? 0.375f : 1;
 
                 var textXhdpi = TextureAssetUtils.ScaleTexture(texture, (int)(128 * scale), (int)(128 * scale));
-                var textHdpi  = TextureAssetUtils.ScaleTexture(texture, (int)(96 * scale), (int)(96 * scale));
-                var textMdpi  = TextureAssetUtils.ScaleTexture(texture, (int)(64 * scale), (int)(64 * scale));
-                var textLdpi  = TextureAssetUtils.ScaleTexture(texture, (int)(48 * scale), (int)(48 * scale));
+                var textHdpi = TextureAssetUtils.ScaleTexture(texture, (int)(96 * scale), (int)(96 * scale));
+                var textMdpi = TextureAssetUtils.ScaleTexture(texture, (int)(64 * scale), (int)(64 * scale));
+                var textLdpi = TextureAssetUtils.ScaleTexture(texture, (int)(48 * scale), (int)(48 * scale));
 
                 icons[string.Format("drawable-xhdpi-v11/{0}.png", drawableResource.Id)] = textXhdpi.EncodeToPNG();
                 icons[string.Format("drawable-hdpi-v11/{0}.png", drawableResource.Id)] = textHdpi.EncodeToPNG();

--- a/com.unity.mobile.notifications/Editor/NotificationSettingsProvider.cs
+++ b/com.unity.mobile.notifications/Editor/NotificationSettingsProvider.cs
@@ -21,7 +21,7 @@ namespace Unity.Notifications
         private readonly GUIContent k_IdentifierLabelText = new GUIContent("Identifier");
         private readonly GUIContent k_TypeLabelText = new GUIContent("Type");
 
-        private readonly string[] k_ToolbarStrings = {"Android", "iOS"};
+        private readonly string[] k_ToolbarStrings = { "Android", "iOS" };
         private const string k_InfoStringAndroid =
             "Only icons added to this list or manually added to the 'res/drawable' folder can be used for notifications.\n" +
             "Note, that not all devices support colored icons.\n\n" +

--- a/com.unity.mobile.notifications/Editor/TextureAssetUtils.cs
+++ b/com.unity.mobile.notifications/Editor/TextureAssetUtils.cs
@@ -71,7 +71,7 @@ namespace Unity.Notifications
             if (type == NotificationIconType.Small)
             {
                 texture = new Texture2D(sourceTexture.width, sourceTexture.height, TextureFormat.RGBA32, true, false);
-                for (var i  = 0; i < sourceTexture.mipmapCount; i++)
+                for (var i = 0; i < sourceTexture.mipmapCount; i++)
                 {
                     var c_0 = sourceTexture.GetPixels(i);
                     var c_1 = texture.GetPixels(i);

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -44,7 +44,7 @@ namespace Unity.Notifications.Android
         /// <summary>
         /// Subscribe to this event to receive callbacks whenever a scheduled notification is shown to the user.
         /// </summary>
-        public static event NotificationReceivedCallback OnNotificationReceived = delegate {};
+        public static event NotificationReceivedCallback OnNotificationReceived = delegate { };
 
         private static AndroidJavaClass s_NotificationManagerClass;
         private static AndroidJavaObject s_NotificationManager;
@@ -495,7 +495,7 @@ namespace Unity.Notifications.Android
                 notification.Number = notificationObj.Get<int>("number");
                 notification.IntentData = extras.Call<string>("getString", KEY_INTENT_DATA);
                 notification.Group = notificationObj.Call<string>("getGroup");
-                notification.GroupSummary = 0 != (flags &  Notification_FLAG_GROUP_SUMMARY);
+                notification.GroupSummary = 0 != (flags & Notification_FLAG_GROUP_SUMMARY);
                 notification.SortKey = notificationObj.Call<string>("getSortKey");
                 notification.GroupAlertBehaviour = s_NotificationManagerClass.CallStatic<int>("getNotificationGroupAlertBehavior", notificationObj).ToGroupAlertBehaviours();
                 var showTimestamp = extras.Call<bool>("getBoolean", Notification_EXTRA_SHOW_WHEN, false);

--- a/com.unity.mobile.notifications/Runtime/iOS/AssemblyInfo.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Unity.Notifications.Tests")]
+[assembly: InternalsVisibleTo("Unity.iOS.Notifications.Tests")]

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.h
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.h
@@ -32,25 +32,34 @@ typedef struct iOSNotificationData
 
     // Trigger
     int triggerType;  //0 - time, 1 - calendar, 2 - location, 3 - push.
-    int repeats;
+    union
+    {
+        struct
+        {
+            int interval;
+            unsigned char repeats;
+        } timeInterval;
 
-    //Time trigger
-    int timeTriggerInterval;
+        struct
+        {
+            int year;
+            int month;
+            int day;
+            int hour;
+            int minute;
+            int second;
+            unsigned char repeats;
+        } calendar;
 
-    //Calendar trigger
-    int calendarTriggerYear;
-    int calendarTriggerMonth;
-    int calendarTriggerDay;
-    int calendarTriggerHour;
-    int calendarTriggerMinute;
-    int calendarTriggerSecond;
-
-    //Location trigger
-    float locationTriggerCenterX;
-    float locationTriggerCenterY;
-    float locationTriggerRadius;
-    int locationTriggerNotifyOnEntry;
-    int locationTriggerNotifyOnExit;
+        struct
+        {
+            float centerX;
+            float centerY;
+            float radius;
+            unsigned char notifyOnEntry;
+            unsigned char notifyOnExit;
+        } location;
+    } trigger;
 } iOSNotificationData;
 
 typedef struct iOSNotificationAuthorizationData

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.h
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.h
@@ -14,6 +14,7 @@ enum triggerType
     CALENDAR_TRIGGER = 10,
     LOCATION_TRIGGER = 20,
     PUSH_TRIGGER = 3,
+    UNKNOWN_TRIGGER = -1,
 };
 
 typedef struct iOSNotificationData

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
@@ -161,6 +161,8 @@ iOSNotificationData UNNotificationRequestToiOSNotificationData(UNNotificationReq
     {
         notificationData.triggerType = PUSH_TRIGGER;
     }
+    else
+        notificationData.triggerType = UNKNOWN_TRIGGER;
 
     parseCustomizedData(&notificationData, request);
     notificationData.attachments = (__bridge_retained void*)request.content.attachments;

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
@@ -125,8 +125,8 @@ iOSNotificationData UNNotificationRequestToiOSNotificationData(UNNotificationReq
         notificationData.triggerType = TIME_TRIGGER;
 
         UNTimeIntervalNotificationTrigger* timeTrigger = (UNTimeIntervalNotificationTrigger*)request.trigger;
-        notificationData.timeTriggerInterval = timeTrigger.timeInterval;
-        notificationData.repeats = timeTrigger.repeats;
+        notificationData.trigger.timeInterval.interval = timeTrigger.timeInterval;
+        notificationData.trigger.timeInterval.repeats = timeTrigger.repeats;
     }
     else if ([request.trigger isKindOfClass: [UNCalendarNotificationTrigger class]])
     {
@@ -135,12 +135,12 @@ iOSNotificationData UNNotificationRequestToiOSNotificationData(UNNotificationReq
         UNCalendarNotificationTrigger* calendarTrigger = (UNCalendarNotificationTrigger*)request.trigger;
         NSDateComponents* date = calendarTrigger.dateComponents;
 
-        notificationData.calendarTriggerYear = (int)date.year;
-        notificationData.calendarTriggerMonth = (int)date.month;
-        notificationData.calendarTriggerDay = (int)date.day;
-        notificationData.calendarTriggerHour = (int)date.hour;
-        notificationData.calendarTriggerMinute = (int)date.minute;
-        notificationData.calendarTriggerSecond = (int)date.second;
+        notificationData.trigger.calendar.year = (int)date.year;
+        notificationData.trigger.calendar.month = (int)date.month;
+        notificationData.trigger.calendar.day = (int)date.day;
+        notificationData.trigger.calendar.hour = (int)date.hour;
+        notificationData.trigger.calendar.minute = (int)date.minute;
+        notificationData.trigger.calendar.second = (int)date.second;
     }
     else if ([request.trigger isKindOfClass: [UNLocationNotificationTrigger class]])
     {
@@ -150,11 +150,11 @@ iOSNotificationData UNNotificationRequestToiOSNotificationData(UNNotificationReq
         UNLocationNotificationTrigger* locationTrigger = (UNLocationNotificationTrigger*)request.trigger;
         CLCircularRegion *region = (CLCircularRegion*)locationTrigger.region;
 
-        notificationData.locationTriggerCenterX = region.center.latitude;
-        notificationData.locationTriggerCenterY = region.center.longitude;
-        notificationData.locationTriggerRadius = region.radius;
-        notificationData.locationTriggerNotifyOnExit = region.notifyOnEntry;
-        notificationData.locationTriggerNotifyOnEntry = region.notifyOnExit;
+        notificationData.trigger.location.centerX = region.center.latitude;
+        notificationData.trigger.location.centerY = region.center.longitude;
+        notificationData.trigger.location.radius = region.radius;
+        notificationData.trigger.location.notifyOnExit = region.notifyOnEntry;
+        notificationData.trigger.location.notifyOnEntry = region.notifyOnExit;
 #endif
     }
     else if ([request.trigger isKindOfClass: [UNPushNotificationTrigger class]])

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -325,6 +325,9 @@ bool validateAuthorizationStatus(UnityNotificationManager* manager)
             date.minute = data->trigger.calendar.minute;
         if (data->trigger.calendar.second >= 0)
             date.second = data->trigger.calendar.second;
+        // From C# we get UTC time
+        date.calendar = [NSCalendar calendarWithIdentifier: NSCalendarIdentifierGregorian];
+        date.timeZone = [NSTimeZone timeZoneWithAbbreviation: @"UTC"];
 
         trigger = [UNCalendarNotificationTrigger triggerWithDateMatchingComponents: date repeats: data->trigger.calendar.repeats];
     }

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -308,35 +308,35 @@ bool validateAuthorizationStatus(UnityNotificationManager* manager)
     UNNotificationTrigger* trigger;
     if (data->triggerType == TIME_TRIGGER)
     {
-        trigger = [UNTimeIntervalNotificationTrigger triggerWithTimeInterval: data->timeTriggerInterval repeats: data->repeats];
+        trigger = [UNTimeIntervalNotificationTrigger triggerWithTimeInterval: data->trigger.timeInterval.interval repeats: data->trigger.timeInterval.repeats];
     }
     else if (data->triggerType == CALENDAR_TRIGGER)
     {
         NSDateComponents* date = [[NSDateComponents alloc] init];
-        if (data->calendarTriggerYear >= 0)
-            date.year = data->calendarTriggerYear;
-        if (data->calendarTriggerMonth >= 0)
-            date.month = data->calendarTriggerMonth;
-        if (data->calendarTriggerDay >= 0)
-            date.day = data->calendarTriggerDay;
-        if (data->calendarTriggerHour >= 0)
-            date.hour = data->calendarTriggerHour;
-        if (data->calendarTriggerMinute >= 0)
-            date.minute = data->calendarTriggerMinute;
-        if (data->calendarTriggerSecond >= 0)
-            date.second = data->calendarTriggerSecond;
+        if (data->trigger.calendar.year >= 0)
+            date.year = data->trigger.calendar.year;
+        if (data->trigger.calendar.month >= 0)
+            date.month = data->trigger.calendar.month;
+        if (data->trigger.calendar.day >= 0)
+            date.day = data->trigger.calendar.day;
+        if (data->trigger.calendar.hour >= 0)
+            date.hour = data->trigger.calendar.hour;
+        if (data->trigger.calendar.minute >= 0)
+            date.minute = data->trigger.calendar.minute;
+        if (data->trigger.calendar.second >= 0)
+            date.second = data->trigger.calendar.second;
 
-        trigger = [UNCalendarNotificationTrigger triggerWithDateMatchingComponents: date repeats: data->repeats];
+        trigger = [UNCalendarNotificationTrigger triggerWithDateMatchingComponents: date repeats: data->trigger.calendar.repeats];
     }
     else if (data->triggerType == LOCATION_TRIGGER)
     {
 #if UNITY_USES_LOCATION
-        CLLocationCoordinate2D center = CLLocationCoordinate2DMake(data->locationTriggerCenterX, data->locationTriggerCenterY);
+        CLLocationCoordinate2D center = CLLocationCoordinate2DMake(data->trigger.location.centerX, data->trigger.location.centerY);
 
         CLCircularRegion* region = [[CLCircularRegion alloc] initWithCenter: center
-                                    radius: data->locationTriggerRadius identifier: identifier];
-        region.notifyOnEntry = data->locationTriggerNotifyOnEntry;
-        region.notifyOnExit = data->locationTriggerNotifyOnExit;
+                                    radius: data->trigger.location.radius identifier: identifier];
+        region.notifyOnEntry = data->trigger.location.notifyOnEntry;
+        region.notifyOnExit = data->trigger.location.notifyOnExit;
 
         trigger = [UNLocationNotificationTrigger triggerWithRegion: region repeats: NO];
 #else

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
@@ -258,21 +258,22 @@ namespace Unity.Notifications.iOS
         {
             set
             {
-                if (value is iOSNotificationTimeIntervalTrigger)
+                switch (value.Type)
+                {
+                case iOSNotificationTriggerType.TimeInterval:
                 {
                     var trigger = (iOSNotificationTimeIntervalTrigger)value;
-                    data.triggerType = iOSNotificationTimeIntervalTrigger.Type;
                     data.trigger.timeInterval.interval = trigger.timeInterval;
 
                     if (trigger.Repeats && trigger.timeInterval < 60)
                         throw new ArgumentException("Time interval must be 60 seconds or greater for repeating notifications.");
 
                     data.trigger.timeInterval.repeats = trigger.Repeats;
+                    break;
                 }
-                else if (value is iOSNotificationCalendarTrigger)
+                case iOSNotificationTriggerType.Calendar:
                 {
                     var trigger = (iOSNotificationCalendarTrigger)value;
-                    data.triggerType = iOSNotificationCalendarTrigger.Type;
                     data.trigger.calendar.year = trigger.Year != null ? trigger.Year.Value : -1;
                     data.trigger.calendar.month = trigger.Month != null ? trigger.Month.Value : -1;
                     data.trigger.calendar.day = trigger.Day != null ? trigger.Day.Value : -1;
@@ -280,41 +281,39 @@ namespace Unity.Notifications.iOS
                     data.trigger.calendar.minute = trigger.Minute != null ? trigger.Minute.Value : -1;
                     data.trigger.calendar.second = trigger.Second != null ? trigger.Second.Value : -1;
                     data.trigger.calendar.repeats = (byte)(trigger.Repeats ? 1 : 0);
+                    break;
                 }
-                else if (value is iOSNotificationLocationTrigger)
+                case iOSNotificationTriggerType.Location:
                 {
                     var trigger = (iOSNotificationLocationTrigger)value;
-                    data.triggerType = iOSNotificationLocationTrigger.Type;
                     data.trigger.location.centerX = trigger.Center.x;
                     data.trigger.location.centerY = trigger.Center.y;
                     data.trigger.location.notifyOnEntry = (byte)(trigger.NotifyOnEntry ? 1 : 0);
                     data.trigger.location.notifyOnExit = (byte)(trigger.NotifyOnExit ? 1 : 0);
                     data.trigger.location.radius = trigger.Radius;
+                    break;
                 }
-                else if (value is iOSNotificationPushTrigger)
-                {
-                    data.triggerType = 3;
+                case iOSNotificationTriggerType.Push:
+                    break;
+                default:
+                    throw new Exception($"Unknown trigger type {value.Type}");
                 }
-                else
-                {
-                    throw new Exception($"Unknown trigger type {value}");
-                }
+
+                data.triggerType = (int)value.Type;
             }
 
             get
             {
-                iOSNotificationTrigger trigger;
-                if (data.triggerType == iOSNotificationTimeIntervalTrigger.Type)
+                switch ((iOSNotificationTriggerType)data.triggerType)
                 {
-                    trigger = new iOSNotificationTimeIntervalTrigger()
+                case iOSNotificationTriggerType.TimeInterval:
+                    return new iOSNotificationTimeIntervalTrigger()
                     {
                         timeInterval = data.trigger.timeInterval.interval,
                         Repeats = data.trigger.timeInterval.repeats
                     };
-                }
-                else if (data.triggerType == iOSNotificationCalendarTrigger.Type)
-                {
-                    trigger = new iOSNotificationCalendarTrigger()
+                case iOSNotificationTriggerType.Calendar:
+                    return new iOSNotificationCalendarTrigger()
                     {
                         Year = (data.trigger.calendar.year > 0) ? (int?)data.trigger.calendar.year : null,
                         Month = (data.trigger.calendar.month > 0) ? (int?)data.trigger.calendar.month : null,
@@ -324,26 +323,19 @@ namespace Unity.Notifications.iOS
                         Second = (data.trigger.calendar.second >= 0) ? (int?)data.trigger.calendar.second : null,
                         Repeats = data.trigger.calendar.repeats != 0
                     };
-                }
-                else if (data.triggerType == iOSNotificationLocationTrigger.Type)
-                {
-                    trigger = new iOSNotificationLocationTrigger()
+                case iOSNotificationTriggerType.Location:
+                    return new iOSNotificationLocationTrigger()
                     {
                         Center = new Vector2(data.trigger.location.centerX, data.trigger.location.centerY),
                         Radius = data.trigger.location.radius,
                         NotifyOnEntry = data.trigger.location.notifyOnEntry != 0,
                         NotifyOnExit = data.trigger.location.notifyOnExit != 0
                     };
-                }
-                else if (data.triggerType == iOSNotificationPushTrigger.Type)
-                {
-                    trigger = new iOSNotificationPushTrigger();
-                }
-                else
-                {
+                case iOSNotificationTriggerType.Push:
+                    return new iOSNotificationPushTrigger();
+                default:
                     throw new Exception($"Unknown trigger type {data.triggerType}");
                 }
-                return trigger;
             }
         }
 

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
@@ -36,7 +36,7 @@ namespace Unity.Notifications.iOS
     internal struct TimeTriggerData
     {
         public Int32 interval;
-        public bool repeats;
+        public Byte repeats;
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -268,7 +268,7 @@ namespace Unity.Notifications.iOS
                             if (trigger.Repeats && trigger.timeInterval < 60)
                                 throw new ArgumentException("Time interval must be 60 seconds or greater for repeating notifications.");
 
-                            data.trigger.timeInterval.repeats = trigger.Repeats;
+                            data.trigger.timeInterval.repeats = (byte)(trigger.Repeats ? 1 : 0);
                             break;
                         }
                     case iOSNotificationTriggerType.Calendar:
@@ -310,7 +310,7 @@ namespace Unity.Notifications.iOS
                         return new iOSNotificationTimeIntervalTrigger()
                         {
                             timeInterval = data.trigger.timeInterval.interval,
-                            Repeats = data.trigger.timeInterval.repeats
+                            Repeats = data.trigger.timeInterval.repeats != 0,
                         };
                     case iOSNotificationTriggerType.Calendar:
                         return new iOSNotificationCalendarTrigger()

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
@@ -260,43 +260,43 @@ namespace Unity.Notifications.iOS
             {
                 switch (value.Type)
                 {
-                case iOSNotificationTriggerType.TimeInterval:
-                {
-                    var trigger = (iOSNotificationTimeIntervalTrigger)value;
-                    data.trigger.timeInterval.interval = trigger.timeInterval;
+                    case iOSNotificationTriggerType.TimeInterval:
+                        {
+                            var trigger = (iOSNotificationTimeIntervalTrigger)value;
+                            data.trigger.timeInterval.interval = trigger.timeInterval;
 
-                    if (trigger.Repeats && trigger.timeInterval < 60)
-                        throw new ArgumentException("Time interval must be 60 seconds or greater for repeating notifications.");
+                            if (trigger.Repeats && trigger.timeInterval < 60)
+                                throw new ArgumentException("Time interval must be 60 seconds or greater for repeating notifications.");
 
-                    data.trigger.timeInterval.repeats = trigger.Repeats;
-                    break;
-                }
-                case iOSNotificationTriggerType.Calendar:
-                {
-                    var trigger = ((iOSNotificationCalendarTrigger)value).ToUtc();
-                    data.trigger.calendar.year = trigger.Year != null ? trigger.Year.Value : -1;
-                    data.trigger.calendar.month = trigger.Month != null ? trigger.Month.Value : -1;
-                    data.trigger.calendar.day = trigger.Day != null ? trigger.Day.Value : -1;
-                    data.trigger.calendar.hour = trigger.Hour != null ? trigger.Hour.Value : -1;
-                    data.trigger.calendar.minute = trigger.Minute != null ? trigger.Minute.Value : -1;
-                    data.trigger.calendar.second = trigger.Second != null ? trigger.Second.Value : -1;
-                    data.trigger.calendar.repeats = (byte)(trigger.Repeats ? 1 : 0);
-                    break;
-                }
-                case iOSNotificationTriggerType.Location:
-                {
-                    var trigger = (iOSNotificationLocationTrigger)value;
-                    data.trigger.location.centerX = trigger.Center.x;
-                    data.trigger.location.centerY = trigger.Center.y;
-                    data.trigger.location.notifyOnEntry = (byte)(trigger.NotifyOnEntry ? 1 : 0);
-                    data.trigger.location.notifyOnExit = (byte)(trigger.NotifyOnExit ? 1 : 0);
-                    data.trigger.location.radius = trigger.Radius;
-                    break;
-                }
-                case iOSNotificationTriggerType.Push:
-                    break;
-                default:
-                    throw new Exception($"Unknown trigger type {value.Type}");
+                            data.trigger.timeInterval.repeats = trigger.Repeats;
+                            break;
+                        }
+                    case iOSNotificationTriggerType.Calendar:
+                        {
+                            var trigger = ((iOSNotificationCalendarTrigger)value).ToUtc();
+                            data.trigger.calendar.year = trigger.Year != null ? trigger.Year.Value : -1;
+                            data.trigger.calendar.month = trigger.Month != null ? trigger.Month.Value : -1;
+                            data.trigger.calendar.day = trigger.Day != null ? trigger.Day.Value : -1;
+                            data.trigger.calendar.hour = trigger.Hour != null ? trigger.Hour.Value : -1;
+                            data.trigger.calendar.minute = trigger.Minute != null ? trigger.Minute.Value : -1;
+                            data.trigger.calendar.second = trigger.Second != null ? trigger.Second.Value : -1;
+                            data.trigger.calendar.repeats = (byte)(trigger.Repeats ? 1 : 0);
+                            break;
+                        }
+                    case iOSNotificationTriggerType.Location:
+                        {
+                            var trigger = (iOSNotificationLocationTrigger)value;
+                            data.trigger.location.centerX = trigger.Center.x;
+                            data.trigger.location.centerY = trigger.Center.y;
+                            data.trigger.location.notifyOnEntry = (byte)(trigger.NotifyOnEntry ? 1 : 0);
+                            data.trigger.location.notifyOnExit = (byte)(trigger.NotifyOnExit ? 1 : 0);
+                            data.trigger.location.radius = trigger.Radius;
+                            break;
+                        }
+                    case iOSNotificationTriggerType.Push:
+                        break;
+                    default:
+                        throw new Exception($"Unknown trigger type {value.Type}");
                 }
 
                 data.triggerType = (int)value.Type;
@@ -306,36 +306,36 @@ namespace Unity.Notifications.iOS
             {
                 switch ((iOSNotificationTriggerType)data.triggerType)
                 {
-                case iOSNotificationTriggerType.TimeInterval:
-                    return new iOSNotificationTimeIntervalTrigger()
-                    {
-                        timeInterval = data.trigger.timeInterval.interval,
-                        Repeats = data.trigger.timeInterval.repeats
-                    };
-                case iOSNotificationTriggerType.Calendar:
-                    return new iOSNotificationCalendarTrigger()
-                    {
-                        Year = (data.trigger.calendar.year > 0) ? (int?)data.trigger.calendar.year : null,
-                        Month = (data.trigger.calendar.month > 0) ? (int?)data.trigger.calendar.month : null,
-                        Day = (data.trigger.calendar.day > 0) ? (int?)data.trigger.calendar.day : null,
-                        Hour = (data.trigger.calendar.hour >= 0) ? (int?)data.trigger.calendar.hour : null,
-                        Minute = (data.trigger.calendar.minute >= 0) ? (int?)data.trigger.calendar.minute : null,
-                        Second = (data.trigger.calendar.second >= 0) ? (int?)data.trigger.calendar.second : null,
-                        UtcTime = true,
-                        Repeats = data.trigger.calendar.repeats != 0
-                    };
-                case iOSNotificationTriggerType.Location:
-                    return new iOSNotificationLocationTrigger()
-                    {
-                        Center = new Vector2(data.trigger.location.centerX, data.trigger.location.centerY),
-                        Radius = data.trigger.location.radius,
-                        NotifyOnEntry = data.trigger.location.notifyOnEntry != 0,
-                        NotifyOnExit = data.trigger.location.notifyOnExit != 0
-                    };
-                case iOSNotificationTriggerType.Push:
-                    return new iOSNotificationPushTrigger();
-                default:
-                    throw new Exception($"Unknown trigger type {data.triggerType}");
+                    case iOSNotificationTriggerType.TimeInterval:
+                        return new iOSNotificationTimeIntervalTrigger()
+                        {
+                            timeInterval = data.trigger.timeInterval.interval,
+                            Repeats = data.trigger.timeInterval.repeats
+                        };
+                    case iOSNotificationTriggerType.Calendar:
+                        return new iOSNotificationCalendarTrigger()
+                        {
+                            Year = (data.trigger.calendar.year > 0) ? (int?)data.trigger.calendar.year : null,
+                            Month = (data.trigger.calendar.month > 0) ? (int?)data.trigger.calendar.month : null,
+                            Day = (data.trigger.calendar.day > 0) ? (int?)data.trigger.calendar.day : null,
+                            Hour = (data.trigger.calendar.hour >= 0) ? (int?)data.trigger.calendar.hour : null,
+                            Minute = (data.trigger.calendar.minute >= 0) ? (int?)data.trigger.calendar.minute : null,
+                            Second = (data.trigger.calendar.second >= 0) ? (int?)data.trigger.calendar.second : null,
+                            UtcTime = true,
+                            Repeats = data.trigger.calendar.repeats != 0
+                        };
+                    case iOSNotificationTriggerType.Location:
+                        return new iOSNotificationLocationTrigger()
+                        {
+                            Center = new Vector2(data.trigger.location.centerX, data.trigger.location.centerY),
+                            Radius = data.trigger.location.radius,
+                            NotifyOnEntry = data.trigger.location.notifyOnEntry != 0,
+                            NotifyOnExit = data.trigger.location.notifyOnExit != 0
+                        };
+                    case iOSNotificationTriggerType.Push:
+                        return new iOSNotificationPushTrigger();
+                    default:
+                        throw new Exception($"Unknown trigger type {data.triggerType}");
                 }
             }
         }

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
@@ -273,6 +273,10 @@ namespace Unity.Notifications.iOS
                 {
                     data.triggerType = 3;
                 }
+                else
+                {
+                    throw new Exception($"Unknown trigger type {value}");
+                }
             }
 
             get
@@ -309,9 +313,13 @@ namespace Unity.Notifications.iOS
                         NotifyOnExit = data.locationTriggerNotifyOnExit
                     };
                 }
-                else
+                else if (data.triggerType == iOSNotificationPushTrigger.Type)
                 {
                     trigger = new iOSNotificationPushTrigger();
+                }
+                else
+                {
+                    throw new Exception($"Unknown trigger type {data.triggerType}");
                 }
                 return trigger;
             }

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
@@ -33,6 +33,46 @@ namespace Unity.Notifications.iOS
     }
 
     [StructLayout(LayoutKind.Sequential)]
+    internal struct TimeTriggerData
+    {
+        public Int32 interval;
+        public bool repeats;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct CalendarTriggerData
+    {
+        public Int32 year;
+        public Int32 month;
+        public Int32 day;
+        public Int32 hour;
+        public Int32 minute;
+        public Int32 second;
+        public Byte repeats;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct LocationTriggerData
+    {
+        public float centerX;
+        public float centerY;
+        public float radius;
+        public Byte notifyOnEntry;
+        public Byte notifyOnExit;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    internal struct TriggerData
+    {
+        [FieldOffset(0)]
+        public TimeTriggerData timeInterval;
+        [FieldOffset(0)]
+        public CalendarTriggerData calendar;
+        [FieldOffset(0)]
+        public LocationTriggerData location;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
     internal struct iOSNotificationData
     {
         public string identifier;
@@ -48,25 +88,7 @@ namespace Unity.Notifications.iOS
 
         // Trigger
         public Int32 triggerType;
-        public bool repeats;
-
-        //Time trigger
-        public Int32 timeTriggerInterval;
-
-        //Calendar trigger
-        public Int32 calendarTriggerYear;
-        public Int32 calendarTriggerMonth;
-        public Int32 calendarTriggerDay;
-        public Int32 calendarTriggerHour;
-        public Int32 calendarTriggerMinute;
-        public Int32 calendarTriggerSecond;
-
-        //Location trigger
-        public float locationTriggerCenterX;
-        public float locationTriggerCenterY;
-        public float locationTriggerRadius;
-        public bool locationTriggerNotifyOnEntry;
-        public bool locationTriggerNotifyOnExit;
+        public TriggerData trigger;
     }
 
     /// <summary>
@@ -240,34 +262,34 @@ namespace Unity.Notifications.iOS
                 {
                     var trigger = (iOSNotificationTimeIntervalTrigger)value;
                     data.triggerType = iOSNotificationTimeIntervalTrigger.Type;
-                    data.timeTriggerInterval = trigger.timeInterval;
+                    data.trigger.timeInterval.interval = trigger.timeInterval;
 
                     if (trigger.Repeats && trigger.timeInterval < 60)
                         throw new ArgumentException("Time interval must be 60 seconds or greater for repeating notifications.");
 
-                    data.repeats = trigger.Repeats;
+                    data.trigger.timeInterval.repeats = trigger.Repeats;
                 }
                 else if (value is iOSNotificationCalendarTrigger)
                 {
                     var trigger = (iOSNotificationCalendarTrigger)value;
                     data.triggerType = iOSNotificationCalendarTrigger.Type;
-                    data.calendarTriggerYear = trigger.Year != null ? trigger.Year.Value : -1;
-                    data.calendarTriggerMonth = trigger.Month != null ? trigger.Month.Value : -1;
-                    data.calendarTriggerDay = trigger.Day != null ? trigger.Day.Value : -1;
-                    data.calendarTriggerHour = trigger.Hour != null ? trigger.Hour.Value : -1;
-                    data.calendarTriggerMinute = trigger.Minute != null ? trigger.Minute.Value : -1;
-                    data.calendarTriggerSecond = trigger.Second != null ? trigger.Second.Value : -1;
-                    data.repeats = trigger.Repeats;
+                    data.trigger.calendar.year = trigger.Year != null ? trigger.Year.Value : -1;
+                    data.trigger.calendar.month = trigger.Month != null ? trigger.Month.Value : -1;
+                    data.trigger.calendar.day = trigger.Day != null ? trigger.Day.Value : -1;
+                    data.trigger.calendar.hour = trigger.Hour != null ? trigger.Hour.Value : -1;
+                    data.trigger.calendar.minute = trigger.Minute != null ? trigger.Minute.Value : -1;
+                    data.trigger.calendar.second = trigger.Second != null ? trigger.Second.Value : -1;
+                    data.trigger.calendar.repeats = (byte)(trigger.Repeats ? 1 : 0);
                 }
                 else if (value is iOSNotificationLocationTrigger)
                 {
                     var trigger = (iOSNotificationLocationTrigger)value;
                     data.triggerType = iOSNotificationLocationTrigger.Type;
-                    data.locationTriggerCenterX = trigger.Center.x;
-                    data.locationTriggerCenterY = trigger.Center.y;
-                    data.locationTriggerNotifyOnEntry = trigger.NotifyOnEntry;
-                    data.locationTriggerNotifyOnExit = trigger.NotifyOnExit;
-                    data.locationTriggerRadius = trigger.Radius;
+                    data.trigger.location.centerX = trigger.Center.x;
+                    data.trigger.location.centerY = trigger.Center.y;
+                    data.trigger.location.notifyOnEntry = (byte)(trigger.NotifyOnEntry ? 1 : 0);
+                    data.trigger.location.notifyOnExit = (byte)(trigger.NotifyOnExit ? 1 : 0);
+                    data.trigger.location.radius = trigger.Radius;
                 }
                 else if (value is iOSNotificationPushTrigger)
                 {
@@ -286,31 +308,31 @@ namespace Unity.Notifications.iOS
                 {
                     trigger = new iOSNotificationTimeIntervalTrigger()
                     {
-                        timeInterval = data.timeTriggerInterval,
-                        Repeats = data.repeats
+                        timeInterval = data.trigger.timeInterval.interval,
+                        Repeats = data.trigger.timeInterval.repeats
                     };
                 }
                 else if (data.triggerType == iOSNotificationCalendarTrigger.Type)
                 {
                     trigger = new iOSNotificationCalendarTrigger()
                     {
-                        Year = (data.calendarTriggerYear > 0) ? (int?)data.calendarTriggerYear : null,
-                        Month = (data.calendarTriggerMonth > 0) ? (int?)data.calendarTriggerMonth : null,
-                        Day = (data.calendarTriggerDay > 0) ? (int?)data.calendarTriggerDay : null,
-                        Hour = (data.calendarTriggerHour >= 0) ? (int?)data.calendarTriggerHour : null,
-                        Minute = (data.calendarTriggerMinute >= 0) ? (int?)data.calendarTriggerMinute : null,
-                        Second = (data.calendarTriggerSecond >= 0) ? (int?)data.calendarTriggerSecond : null,
-                        Repeats = data.repeats
+                        Year = (data.trigger.calendar.year > 0) ? (int?)data.trigger.calendar.year : null,
+                        Month = (data.trigger.calendar.month > 0) ? (int?)data.trigger.calendar.month : null,
+                        Day = (data.trigger.calendar.day > 0) ? (int?)data.trigger.calendar.day : null,
+                        Hour = (data.trigger.calendar.hour >= 0) ? (int?)data.trigger.calendar.hour : null,
+                        Minute = (data.trigger.calendar.minute >= 0) ? (int?)data.trigger.calendar.minute : null,
+                        Second = (data.trigger.calendar.second >= 0) ? (int?)data.trigger.calendar.second : null,
+                        Repeats = data.trigger.calendar.repeats != 0
                     };
                 }
                 else if (data.triggerType == iOSNotificationLocationTrigger.Type)
                 {
                     trigger = new iOSNotificationLocationTrigger()
                     {
-                        Center = new Vector2(data.locationTriggerCenterX, data.locationTriggerCenterY),
-                        Radius = data.locationTriggerRadius,
-                        NotifyOnEntry = data.locationTriggerNotifyOnEntry,
-                        NotifyOnExit = data.locationTriggerNotifyOnExit
+                        Center = new Vector2(data.trigger.location.centerX, data.trigger.location.centerY),
+                        Radius = data.trigger.location.radius,
+                        NotifyOnEntry = data.trigger.location.notifyOnEntry != 0,
+                        NotifyOnExit = data.trigger.location.notifyOnExit != 0
                     };
                 }
                 else if (data.triggerType == iOSNotificationPushTrigger.Type)
@@ -353,25 +375,6 @@ namespace Unity.Notifications.iOS
             data.threadIdentifier = "";
 
             data.triggerType = -1;
-            data.repeats = false;
-
-            //Time trigger
-            data.timeTriggerInterval = -1;
-
-            //Calendar trigger
-            data.calendarTriggerYear = -1;
-            data.calendarTriggerMonth = -1;
-            data.calendarTriggerDay = -1;
-            data.calendarTriggerHour = -1;
-            data.calendarTriggerMinute = -1;
-            data.calendarTriggerSecond = -1;
-
-            //Location trigger
-            data.locationTriggerCenterX = 0f;
-            data.locationTriggerCenterY = 0f;
-            data.locationTriggerRadius = 2f;
-            data.locationTriggerNotifyOnEntry = true;
-            data.locationTriggerNotifyOnExit = false;
 
             data.userInfo = IntPtr.Zero;
             userInfo = new Dictionary<string, string>();

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
@@ -273,7 +273,7 @@ namespace Unity.Notifications.iOS
                 }
                 case iOSNotificationTriggerType.Calendar:
                 {
-                    var trigger = (iOSNotificationCalendarTrigger)value;
+                    var trigger = ((iOSNotificationCalendarTrigger)value).ToUtc();
                     data.trigger.calendar.year = trigger.Year != null ? trigger.Year.Value : -1;
                     data.trigger.calendar.month = trigger.Month != null ? trigger.Month.Value : -1;
                     data.trigger.calendar.day = trigger.Day != null ? trigger.Day.Value : -1;
@@ -321,6 +321,7 @@ namespace Unity.Notifications.iOS
                         Hour = (data.trigger.calendar.hour >= 0) ? (int?)data.trigger.calendar.hour : null,
                         Minute = (data.trigger.calendar.minute >= 0) ? (int?)data.trigger.calendar.minute : null,
                         Second = (data.trigger.calendar.second >= 0) ? (int?)data.trigger.calendar.second : null,
+                        UtcTime = true,
                         Repeats = data.trigger.calendar.repeats != 0
                     };
                 case iOSNotificationTriggerType.Location:

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCenter.cs
@@ -36,7 +36,7 @@ namespace Unity.Notifications.iOS
         }
 
         private static bool s_OnNotificationReceivedCallbackSet;
-        private static event NotificationReceivedCallback s_OnNotificationReceived = delegate {};
+        private static event NotificationReceivedCallback s_OnNotificationReceived = delegate { };
 
         /// <summary>
         /// Subscribe to this event to receive a callback whenever a remote notification is received while the app is in foreground,
@@ -64,7 +64,7 @@ namespace Unity.Notifications.iOS
         }
 
         private static bool s_OnRemoteNotificationReceivedCallbackSet;
-        private static event NotificationReceivedCallback s_OnRemoteNotificationReceived = delegate {};
+        private static event NotificationReceivedCallback s_OnRemoteNotificationReceived = delegate { };
 
         internal delegate void AuthorizationRequestCompletedCallback(iOSAuthorizationRequestData data);
 

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationTriggers.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationTriggers.cs
@@ -179,8 +179,72 @@ namespace Unity.Notifications.iOS
         public int? Second { get; set; }
 
         /// <summary>
+        /// Are Date and Time field in UTC time. When false, use local time.
+        /// </summary>
+        public bool UtcTime { get; set; }
+
+        /// <summary>
         /// Indicate whether the notification is repeated every defined time period. For instance if hour and minute fields are set the notification will be triggered every day at the specified hour and minute.
         /// </summary>
         public bool Repeats { get; set; }
+
+        /// <summary>
+        /// Converts this trigger into the one using UTC time.
+        /// </summary>
+        /// <returns>A new trigger with UtcTime set to true and other field adjusted accordingly.</returns>
+        public iOSNotificationCalendarTrigger ToUtc()
+        {
+            if (UtcTime)
+                return this;
+
+            var notificationTime = AssignDateTimeComponents(DateTime.Now).ToUniversalTime();
+            iOSNotificationCalendarTrigger result = this;
+            result.UtcTime = true;
+            result.AssignNonEmptyComponents(notificationTime);
+            return result;
+        }
+
+        /// <summary>
+        /// Converts this trigger into the one using local time.
+        /// </summary>
+        /// <returns>A new trigger with UtcTime set to false and other field adjusted accordingly.</returns>
+        public iOSNotificationCalendarTrigger ToLocal()
+        {
+            if (!UtcTime)
+                return this;
+
+            var notificationTime = AssignDateTimeComponents(DateTime.UtcNow).ToLocalTime();
+            iOSNotificationCalendarTrigger result = this;
+            result.UtcTime = false;
+            result.AssignNonEmptyComponents(notificationTime);
+            return result;
+        }
+
+        internal DateTime AssignDateTimeComponents(DateTime dt)
+        {
+            int year = Year != null ? Year.Value : dt.Year;
+            int month = Month != null ? Month.Value : dt.Month;
+            int day = Day != null ? Day.Value : dt.Day;
+            int hour = Hour != null ? Hour.Value : dt.Hour;
+            int minute = Minute != null ? Minute.Value : dt.Minute;
+            int second = Second != null ? Second.Value : dt.Second;
+            return new DateTime(year, month, day, hour, minute, second, dt.Kind);
+        }
+
+        internal void AssignNonEmptyComponents(DateTime dt)
+        {
+            if (Year != null)
+                Year = dt.Year;
+            if (Month != null)
+                Month = dt.Month;
+            if (Day != null)
+                Day = dt.Day;
+            if (Hour != null)
+                Hour = dt.Hour;
+            if (Minute != null)
+                Minute = dt.Minute;
+            if (Second != null)
+                Second = dt.Second;
+        }
     }
 }

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationTriggers.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationTriggers.cs
@@ -3,19 +3,43 @@ using UnityEngine;
 
 namespace Unity.Notifications.iOS
 {
-    internal enum NotificationTriggerType
+    /// <summary>
+    /// Describes notification trigger type
+    /// </summary>
+    public enum iOSNotificationTriggerType
     {
-        TimeTrigger = 0,
-        CalendarTrigger = 10,
-        LocationTrigger = 20,
-        PushTrigger = 3,
+        /// <summary>
+        /// Time interval trigger
+        /// </summary>
+        TimeInterval = 0,
+        /// <summary>
+        /// Calendar trigger
+        /// </summary>
+        Calendar = 10,
+        /// <summary>
+        /// Location trigger
+        /// </summary>
+        Location = 20,
+        /// <summary>
+        /// Push notification trigger
+        /// </summary>
+        Push = 3,
+        /// <summary>
+        /// Trigger, that is not known to this version of notifications package
+        /// </summary>
         Unknown = -1,
     }
 
     /// <summary>
     /// iOSNotificationTrigger interface is implemented by notification trigger types representing an event that triggers the delivery of a notification.
     /// </summary>
-    public interface iOSNotificationTrigger {}
+    public interface iOSNotificationTrigger
+    {
+        /// <summary>
+        /// Returns the trigger type for this trigger.
+        /// </summary>
+        iOSNotificationTriggerType Type { get; }
+    }
 
     /// <summary>
     /// A trigger condition that causes a notification to be delivered when the user's device enters or exits the specified geographic region.
@@ -33,7 +57,7 @@ namespace Unity.Notifications.iOS
         /// <summary>
         /// The type of notification trigger.
         /// </summary>
-        public static int Type { get { return (int)NotificationTriggerType.LocationTrigger; } }
+        public iOSNotificationTriggerType Type { get { return iOSNotificationTriggerType.Location; } }
 
         /// <summary>
         /// The center point of the geographic area.
@@ -72,7 +96,7 @@ namespace Unity.Notifications.iOS
         /// <summary>
         /// The type of notification trigger.
         /// </summary>
-        public static int Type { get { return (int)NotificationTriggerType.PushTrigger; } }
+        public iOSNotificationTriggerType Type { get { return iOSNotificationTriggerType.Push; } }
     }
 
     /// <summary>
@@ -86,7 +110,7 @@ namespace Unity.Notifications.iOS
         /// <summary>
         /// The type of notification trigger.
         /// </summary>
-        public static int Type { get { return (int)NotificationTriggerType.TimeTrigger; } }
+        public iOSNotificationTriggerType Type { get { return iOSNotificationTriggerType.TimeInterval; } }
 
         internal int timeInterval;
 
@@ -122,7 +146,7 @@ namespace Unity.Notifications.iOS
         /// <summary>
         /// The type of notification trigger.
         /// </summary>
-        public static int Type { get { return (int)NotificationTriggerType.CalendarTrigger; } }
+        public iOSNotificationTriggerType Type { get { return iOSNotificationTriggerType.Calendar; } }
 
         /// <summary>
         /// Year

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationTriggers.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationTriggers.cs
@@ -8,7 +8,8 @@ namespace Unity.Notifications.iOS
         TimeTrigger = 0,
         CalendarTrigger = 10,
         LocationTrigger = 20,
-        PushTrigger = 3
+        PushTrigger = 3,
+        Unknown = -1,
     }
 
     /// <summary>

--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
@@ -93,7 +93,7 @@ class AndroidNotificationSendingTests
 
         yield return WaitForNotification(8.0f);
 
-        Debug.LogWarning("SendNotificationExplicitID_NotificationIsReceived completed. Received notifications: "  + currentHandler.receivedNotificationCount);
+        Debug.LogWarning("SendNotificationExplicitID_NotificationIsReceived completed. Received notifications: " + currentHandler.receivedNotificationCount);
 
         Assert.AreEqual(1, currentHandler.receivedNotificationCount);
         Assert.AreEqual(originalId, currentHandler.lastNotification.Id);
@@ -114,7 +114,7 @@ class AndroidNotificationSendingTests
 
         yield return WaitForNotification(8.0f);
 
-        Debug.LogWarning("SendNotification_NotificationIsReceived completed. Received notifications: "  + currentHandler.receivedNotificationCount);
+        Debug.LogWarning("SendNotification_NotificationIsReceived completed. Received notifications: " + currentHandler.receivedNotificationCount);
 
         Assert.AreEqual(1, currentHandler.receivedNotificationCount);
         Assert.AreEqual(originalId, currentHandler.lastNotification.Id);
@@ -233,7 +233,7 @@ class AndroidNotificationSendingTests
         var gameObjects = new GameObject[1];
 
         AndroidNotificationCenter.NotificationReceivedCallback receivedNotificationHandler =
-            delegate(AndroidNotificationIntentData data)
+            delegate (AndroidNotificationIntentData data)
         {
             gameObjects[0] = new GameObject();
             gameObjects[0].name = "Hello_World";

--- a/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
@@ -143,4 +143,150 @@ class iOSNotificationTests
         Assert.IsTrue(lastReceivedNotification.UserInfo.ContainsKey("key1"));
         Assert.AreEqual("value1", lastReceivedNotification.UserInfo["key1"]);
     }
+
+    [Test]
+    public void iOSNotificationCalendarTrigger_ToUtc_DoesNotConvertUtcTrigger()
+    {
+        var trigger = new iOSNotificationCalendarTrigger()
+        {
+            Hour = 5,
+            Minute = 5,
+            UtcTime = true,
+        };
+
+        var utcTrigger = trigger.ToUtc();
+
+        Assert.AreEqual(5, utcTrigger.Hour);
+        Assert.AreEqual(5, utcTrigger.Minute);
+    }
+
+    [Test]
+    public void iOSNotificationCalendarTrigger_ToUtc_ConvertsLocalTrigger()
+    {
+        var localTime = DateTime.Now;
+        var utcTime = localTime.ToUniversalTime();
+        if (DateTime.Compare(localTime, utcTime) == 0)
+            return; // running test in GMT time zode
+
+        var trigger = new iOSNotificationCalendarTrigger()
+        {
+            Hour = localTime.Hour,
+            Minute = localTime.Minute,
+            UtcTime = false,
+        };
+
+        var utcTrigger = trigger.ToUtc();
+
+        Assert.AreEqual(utcTime.Hour, utcTrigger.Hour);
+        Assert.AreEqual(utcTime.Minute, utcTrigger.Minute);
+    }
+
+    [Test]
+    public void iOSNotificationCalendarTrigger_ToLocal_DoesNotConvertLocalTrigger()
+    {
+        var trigger = new iOSNotificationCalendarTrigger()
+        {
+            Hour = 5,
+            Minute = 5,
+            UtcTime = false,
+        };
+
+        var localTrigger = trigger.ToLocal();
+
+        Assert.AreEqual(5, localTrigger.Hour);
+        Assert.AreEqual(5, localTrigger.Minute);
+    }
+
+    [Test]
+    public void iOSNotificationCalendarTrigger_ToLocal_ConvertsUtcTrigger()
+    {
+        var localTime = DateTime.Now;
+        var utcTime = localTime.ToUniversalTime();
+        if (DateTime.Compare(localTime, utcTime) == 0)
+            return; // running test in GMT time zode
+
+        var trigger = new iOSNotificationCalendarTrigger()
+        {
+            Hour = utcTime.Hour,
+            Minute = utcTime.Minute,
+            UtcTime = true,
+        };
+
+        var localTrigger = trigger.ToLocal();
+
+        Assert.AreEqual(localTime.Hour, localTrigger.Hour);
+        Assert.AreEqual(localTime.Minute, localTrigger.Minute);
+    }
+
+    [Test]
+    public void iOSNotificationCalendarTrigger_AssignDateTimeComponents_OnlyChangesNonNullFields()
+    {
+        var dt = new DateTime(2025, 5, 5, 6, 6 ,6);
+
+        var trigger = new iOSNotificationCalendarTrigger()
+        {
+            Year = 2020,
+            Month = 10,
+            Day = 8,
+        };
+
+        var check = trigger.AssignDateTimeComponents(dt);
+        Assert.AreEqual(2020, check.Year);
+        Assert.AreEqual(10, check.Month);
+        Assert.AreEqual(8, check.Day);
+        Assert.AreEqual(6, check.Hour);
+        Assert.AreEqual(6, check.Minute);
+        Assert.AreEqual(6, check.Second);
+
+        trigger = new iOSNotificationCalendarTrigger()
+        {
+            Hour = 3,
+            Minute = 4,
+            Second = 20,
+        };
+
+        check = trigger.AssignDateTimeComponents(dt);
+        Assert.AreEqual(2025, check.Year);
+        Assert.AreEqual(5, check.Month);
+        Assert.AreEqual(5, check.Day);
+        Assert.AreEqual(3, check.Hour);
+        Assert.AreEqual(4, check.Minute);
+        Assert.AreEqual(20, check.Second);
+    }
+
+    [Test]
+    public void OSNotificationCalendarTrigger_AssignNonEmptyComponents_Works()
+    {
+        var dt = new DateTime(2025, 1, 2, 3, 4, 5);
+
+        var trigger = new iOSNotificationCalendarTrigger()
+        {
+            Year = 2020,
+            Month = 10,
+            Day = 10,
+        };
+
+        trigger.AssignNonEmptyComponents(dt);
+        Assert.AreEqual(2025, trigger.Year);
+        Assert.AreEqual(1, trigger.Month);
+        Assert.AreEqual(2, trigger.Day);
+        Assert.IsTrue(null == trigger.Hour);
+        Assert.IsTrue(null == trigger.Minute);
+        Assert.IsTrue(null == trigger.Second);
+
+        trigger = new iOSNotificationCalendarTrigger()
+        {
+            Hour = 10,
+            Minute = 10,
+            Second = 10,
+        };
+
+        trigger.AssignNonEmptyComponents(dt);
+        Assert.IsTrue(null == trigger.Year);
+        Assert.IsTrue(null == trigger.Month);
+        Assert.IsTrue(null == trigger.Day);
+        Assert.AreEqual(3, trigger.Hour);
+        Assert.AreEqual(4, trigger.Minute);
+        Assert.AreEqual(5, trigger.Second);
+    }
 }

--- a/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
@@ -155,6 +155,51 @@ class iOSNotificationTests
         Assert.AreEqual("value1", lastReceivedNotification.UserInfo["key1"]);
     }
 
+    IEnumerator SendNotificationUsingCalendarTrigger_NotificationIsReceived(string text, bool useUtc)
+    {
+        var dateTime = useUtc ? DateTime.UtcNow : DateTime.Now;
+        var dt = dateTime.AddSeconds(3);
+        var trigger = new iOSNotificationCalendarTrigger()
+        {
+            Year = dt.Year,
+            Month = dt.Month,
+            Day = dt.Day,
+            Hour = dt.Hour,
+            Minute = dt.Minute,
+            Second = dt.Second,
+            UtcTime = useUtc,
+        };
+
+        var notification = new iOSNotification()
+        {
+            Title = text,
+            Body = text,
+            ShowInForeground = true,
+            ForegroundPresentationOption = PresentationOption.Alert,
+            Trigger = trigger,
+        };
+
+        iOSNotificationCenter.ScheduleNotification(notification);
+        yield return WaitForNotification(5.0f);
+        Assert.AreEqual(1, receivedNotificationCount);
+        Assert.IsNotNull(lastReceivedNotification);
+        Assert.AreEqual(text, lastReceivedNotification.Title);
+    }
+
+    [UnityTest]
+    [UnityPlatform(RuntimePlatform.IPhonePlayer)]
+    public IEnumerator SendNotificationUsingCalendarTriggerLocalTime_NotificationIsReceived()
+    {
+        yield return SendNotificationUsingCalendarTrigger_NotificationIsReceived("SendNotificationUsingCalendarTriggerLocalTime_NotificationIsReceived", false);
+    }
+
+    [UnityTest]
+    [UnityPlatform(RuntimePlatform.IPhonePlayer)]
+    public IEnumerator SendNotificationUsingCalendarTriggerUtcTime_NotificationIsReceived()
+    {
+        yield return SendNotificationUsingCalendarTrigger_NotificationIsReceived("SendNotificationUsingCalendarTriggerUtcTime_NotificationIsReceived", true);
+    }
+
     [Test]
     public void iOSNotificationCalendarTrigger_ToUtc_DoesNotConvertUtcTrigger()
     {

--- a/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
@@ -277,7 +277,7 @@ class iOSNotificationTests
     [Test]
     public void iOSNotificationCalendarTrigger_AssignDateTimeComponents_OnlyChangesNonNullFields()
     {
-        var dt = new DateTime(2025, 5, 5, 6, 6 ,6);
+        var dt = new DateTime(2025, 5, 5, 6, 6, 6);
 
         var trigger = new iOSNotificationCalendarTrigger()
         {

--- a/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
@@ -77,6 +77,17 @@ class iOSNotificationTests
     }
 #endif
 
+    IEnumerator WaitForNotification(float timeout)
+    {
+        var startCount = receivedNotificationCount;
+        float timePassed = 0;
+        while (receivedNotificationCount == startCount && timePassed < timeout)
+        {
+            yield return null;
+            timePassed += Time.deltaTime;
+        }
+    }
+
     [UnityTest]
     [UnityPlatform(RuntimePlatform.IPhonePlayer)]
     public IEnumerator SendSimpleNotification_NotificationIsReceived()
@@ -106,7 +117,7 @@ class iOSNotificationTests
 
         iOSNotificationCenter.ScheduleNotification(notification);
 
-        yield return new WaitForSeconds(6.0f);
+        yield return WaitForNotification(6.0f);
         Assert.AreEqual(1, receivedNotificationCount);
     }
 
@@ -137,7 +148,7 @@ class iOSNotificationTests
 
         iOSNotificationCenter.ScheduleNotification(notification);
 
-        yield return new WaitForSeconds(6.0f);
+        yield return WaitForNotification(6.0f);
         Assert.AreEqual(1, receivedNotificationCount);
         Assert.IsNotNull(lastReceivedNotification);
         Assert.IsTrue(lastReceivedNotification.UserInfo.ContainsKey("key1"));


### PR DESCRIPTION
https://jira.unity3d.com/browse/MPT-1731

Fix calendar notifications on iOS on devices with buddhist calendar and related changes:
- Refactored notification data struct to be more compact
- Refactored triggers by making Type property instance to avoid typechecks; this is technically a breaking change, but previous static properties were completely useless to users, unlikely anyone used them (and we already had a breaking change in the package since last release, good opportunity for another minor one)
- On native side we now use UTC calendar; on managed side we still default to local, but give users option to use UTC too
- Added tests