### PR TITLE
Fixes an issue where app hangs on startup with both Unity notifications and Firebase in the project

### DIFF
--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityAppController+Notifications.mm
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityAppController+Notifications.mm
@@ -46,10 +46,13 @@
              [UnityNotificationManager sharedInstance].lastReceivedNotification = NULL;
          }];
 
-        [nc addObserverForName: UIApplicationDidFinishLaunchingNotification
+        [nc addObserverForName: kUnityWillFinishLaunchingWithOptions
          object: nil
          queue: [NSOperationQueue mainQueue]
          usingBlock:^(NSNotification *notification) {
+
+             [UNUserNotificationCenter currentNotificationCenter].delegate = [UnityNotificationManager sharedInstance];
+
              BOOL authorizeOnLaunch = [[[NSBundle mainBundle] objectForInfoDictionaryKey: @"UnityNotificationRequestAuthorizationOnAppLaunch"] boolValue];
              BOOL supportsPushNotification = [[[NSBundle mainBundle] objectForInfoDictionaryKey: @"UnityAddRemoteNotificationCapability"] boolValue];
              BOOL registerRemoteOnLaunch = supportsPushNotification == YES ?
@@ -68,9 +71,6 @@
                  [manager requestAuthorization: defaultAuthorizationOptions withRegisterRemote: registerRemoteOnLaunch forRequest: NULL];
                  manager.remoteNotificationForegroundPresentationOptions = remoteForegroundPresentationOptions;
              }
-            
-            UNUserNotificationCenter* center = [UNUserNotificationCenter currentNotificationCenter];
-            center.delegate = [UnityNotificationManager sharedInstance];
          }];
 
         [nc addObserverForName: kUnityDidRegisterForRemoteNotificationsWithDeviceToken

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityAppController+Notifications.mm
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityAppController+Notifications.mm
@@ -17,9 +17,6 @@
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         [UnityNotificationLifeCycleManager sharedInstance];
-
-        UNUserNotificationCenter* center = [UNUserNotificationCenter currentNotificationCenter];
-        center.delegate = [UnityNotificationManager sharedInstance];
     });
 }
 
@@ -71,6 +68,9 @@
                  [manager requestAuthorization: defaultAuthorizationOptions withRegisterRemote: registerRemoteOnLaunch forRequest: NULL];
                  manager.remoteNotificationForegroundPresentationOptions = remoteForegroundPresentationOptions;
              }
+            
+            UNUserNotificationCenter* center = [UNUserNotificationCenter currentNotificationCenter];
+            center.delegate = [UnityNotificationManager sharedInstance];
          }];
 
         [nc addObserverForName: kUnityDidRegisterForRemoteNotificationsWithDeviceToken

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -215,7 +215,7 @@
 - (void)updateScheduledNotificationList
 {
     UNUserNotificationCenter* center = [UNUserNotificationCenter currentNotificationCenter];
-    [center getPendingNotificationRequestsWithCompletionHandler:^(NSArray<UNNotificationRequest *> *     _Nonnull requests) {
+    [center getPendingNotificationRequestsWithCompletionHandler:^(NSArray<UNNotificationRequest *> * _Nonnull requests) {
         self.cachedPendingNotificationRequests = requests;
     }];
 }

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -215,7 +215,7 @@
 - (void)updateScheduledNotificationList
 {
     UNUserNotificationCenter* center = [UNUserNotificationCenter currentNotificationCenter];
-    [center getPendingNotificationRequestsWithCompletionHandler:^(NSArray<UNNotificationRequest *> * _Nonnull requests) {
+    [center getPendingNotificationRequestsWithCompletionHandler:^(NSArray<UNNotificationRequest *> *     _Nonnull requests) {
         self.cachedPendingNotificationRequests = requests;
     }];
 }


### PR DESCRIPTION
https://fogbugz.unity3d.com/f/cases/1375744/

We need to move the setting of a delegate out of the load method in order to fix the above case.