### PR TITLE
[iOS] Handle boolean values in UserInfo

### DIFF
--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
@@ -21,6 +21,8 @@ static NSString* ParseNotificationDataObject(id obj)
     else if ([obj isKindOfClass: [NSNumber class]])
     {
         NSNumber* numberVal = obj;
+        if (CFBooleanGetTypeID() == CFGetTypeID((__bridge CFTypeRef)(obj)))
+            return numberVal.boolValue ? @"true" : @"false";
         return numberVal.stringValue;
     }
     else if ([NSJSONSerialization isValidJSONObject: obj])

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
@@ -13,6 +13,36 @@
 
 #import "UnityNotificationData.h"
 
+
+static NSString* ParseNotificationDataObject(id obj)
+{
+    if ([obj isKindOfClass: [NSString class]])
+        return obj;
+    else if ([obj isKindOfClass: [NSNumber class]])
+    {
+        NSNumber* numberVal = obj;
+        return numberVal.stringValue;
+    }
+    else if ([NSJSONSerialization isValidJSONObject: obj])
+    {
+        NSError* error;
+        NSData* data = [NSJSONSerialization dataWithJSONObject: obj options: NSJSONWritingPrettyPrinted error: &error];
+        if (data)
+        {
+            NSString* v = [[NSString alloc] initWithData: data encoding: NSUTF8StringEncoding];
+            return v;
+        }
+        else
+        {
+            NSLog(@"Failed parsing notification userInfo value: %@", error);
+        }
+    }
+    else
+        NSLog(@"Failed parsing notification userInfo value");
+
+    return nil;
+}
+
 NotificationSettingsData UNNotificationSettingsToNotificationSettingsData(UNNotificationSettings* settings)
 {
     NotificationSettingsData settingsData;
@@ -248,27 +278,11 @@ void _ReadNSDictionary(void* csDict, void* nsDict, void (*callback)(void* csDcit
     NSDictionary* dict = (__bridge NSDictionary*)nsDict;
     [dict enumerateKeysAndObjectsUsingBlock:^(id  _Nonnull key, id  _Nonnull obj, BOOL * _Nonnull stop) {
         NSString* k = key;
-        if ([obj isKindOfClass: [NSString class]])
-        {
-            NSString* v = obj;
+        NSString* v = ParseNotificationDataObject(obj);
+        if (v != nil)
             callback(csDict, k.UTF8String, v.UTF8String);
-        }
-        else if ([obj isKindOfClass: [NSNumber class]])
-        {
-            NSNumber* numberVal = (NSNumber*)obj;
-            NSString* str = numberVal.stringValue;
-            callback(csDict, k.UTF8String, str.UTF8String);
-        }
         else
-        {
-            NSError* error;
-            NSData* data = [NSJSONSerialization dataWithJSONObject: obj options: NSJSONWritingPrettyPrinted error: &error];
-            if (data)
-            {
-                NSString* v = [[NSString alloc] initWithData: data encoding: NSUTF8StringEncoding];
-                callback(csDict, k.UTF8String, v.UTF8String);
-            }
-        }
+            NSLog(@"Failed to parse value for key '%@'", key);
     }];
 }
 


### PR DESCRIPTION
When parsing UserInfo dictionary from push notification, boolean values are detected as numbers and get parsed as 1 or 0.
This PR fixes it to handle them as "true" or "false".
Additionally some refactoring done in parsing.

Tests to be added when we figure out how to test push notifications automatically.