### PR TITLE
Android12 support

### DIFF
--- a/com.unity.mobile.notifications/Editor/AndroidNotificationPostProcessor.cs
+++ b/com.unity.mobile.notifications/Editor/AndroidNotificationPostProcessor.cs
@@ -130,6 +130,7 @@ namespace Unity.Notifications
                 applicationXmlNode.AppendChild(notificationRestartOnBootReceiver);
             }
             notificationRestartOnBootReceiver.SetAttribute("enabled", kAndroidNamespaceURI, "false");
+            notificationRestartOnBootReceiver.SetAttribute("exported", kAndroidNamespaceURI, "true");
         }
 
         internal static void AppendAndroidPermissionField(string manifestPath, XmlDocument xmlDoc, string name)

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -450,12 +450,23 @@ public class UnityNotificationManager extends BroadcastReceiver {
         return intent_data_list;
     }
 
+    private static boolean canScheduleExactAlarms(AlarmManager alarmManager) {
+        // The commented-out if below is the correct one and should replace the one further down
+        // However it requires compile SDK 31 to compile, cutting edge and not shipped with Unity at the moment of writing this
+        // It means exact timing for notifications is not supported on Android 12+ out of the box
+        //if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
+            //return alarmManager.canScheduleExactAlarms();
+        if (Build.VERSION.SDK_INT >= 31)
+            return false;
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M;
+    }
+
     // Call AlarmManager to set the broadcast intent with fire time and interval.
     protected static void scheduleNotificationIntentAlarm(Context context, long repeatInterval, long fireTime, PendingIntent broadcast) {
         AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
 
         if (repeatInterval <= 0) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && canScheduleExactAlarms(alarmManager)) {
                 alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, fireTime, broadcast);
             } else {
                 alarmManager.set(AlarmManager.RTC_WAKEUP, fireTime, broadcast);

--- a/project/androidnotifications/src/main/AndroidManifest.xml
+++ b/project/androidnotifications/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
     package="com.unity.androidnotifications" >
     <application>
         <receiver android:exported="true" android:name="com.unity.androidnotifications.UnityNotificationManager"/>
-        <receiver android:name="com.unity.androidnotifications.UnityNotificationRestartOnBootReceiver"
+        <receiver android:exported="true" android:name="com.unity.androidnotifications.UnityNotificationRestartOnBootReceiver"
             android:enabled="false">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED"></action>


### PR DESCRIPTION
case 1376849
Fix using package on Android 12:
* NotificationRestartOnBootReceiver needs to be exported
* Disable exact alarms on Android 12 until we can support them

The exact alarms have been disabled because since Android 12 it requires a special permission to be requested in order to use them. Also, we need to handle it in source code, which means using APIs introduced only in API 31, which in turn requires compiling using latest SDK which isn't the one that we ship with Unity...
For now it is more important to ship new version of package that works than to fully support it. So on Android 12 we'll use inexact alarm (like we do on pre-M Androids), so notification timing will be less accurate. Users who really need exact timing will have to manually edit out source code and handle the permission stuff.