### PR TITLE
Android: fix rescheduling

### DIFF
--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -431,10 +431,16 @@ public class UnityNotificationManager extends BroadcastReceiver {
             SharedPreferences prefs = context.getSharedPreferences(getSharedPrefsNameByNotificationId(id), Context.MODE_PRIVATE);
             String serializedIntentData = prefs.getString("data", "");
 
+            boolean valid = false;
             if (serializedIntentData.length() > 1) {
                 Intent intent = UnityNotificationUtilities.deserializeNotificationIntent(context, serializedIntentData);
-                intent_data_list.add(intent);
-            } else {
+                if (intent != null) {
+                    intent_data_list.add(intent);
+                    valid = true;
+                }
+            }
+
+            if (!valid) {
                 idsMarkedForRemoval.add(id);
             }
         }

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -654,13 +654,17 @@ public class UnityNotificationManager extends BroadcastReceiver {
         }
     }
 
-    @SuppressWarnings("deprecation")
     public Notification.Builder createNotificationBuilder(String channelID) {
+        return createNotificationBuilder(mContext, channelID);
+    }
+
+    @SuppressWarnings("deprecation")
+    protected static Notification.Builder createNotificationBuilder(Context context, String channelID) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-            Notification.Builder notificationBuilder = new Notification.Builder(mContext);
+            Notification.Builder notificationBuilder = new Notification.Builder(context);
 
             // For device below Android O, we use the values from NotificationChannelWrapper to set visibility, priority etc.
-            NotificationChannelWrapper fakeNotificationChannel = getNotificationChannel(mContext, channelID);
+            NotificationChannelWrapper fakeNotificationChannel = getNotificationChannel(context, channelID);
 
             if (fakeNotificationChannel.vibrationPattern != null && fakeNotificationChannel.vibrationPattern.length > 0) {
                 notificationBuilder.setDefaults(Notification.DEFAULT_LIGHTS | Notification.DEFAULT_SOUND);
@@ -696,7 +700,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
             return notificationBuilder;
         } else {
-            return new Notification.Builder(mContext, channelID);
+            return new Notification.Builder(context, channelID);
         }
     }
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -52,6 +52,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
     protected static final String KEY_REPEAT_INTERVAL = "repeatInterval";
     protected static final String KEY_NOTIFICATION = "unityNotification";
     protected static final String KEY_SMALL_ICON = "smallIcon";
+    protected static final String KEY_CHANNEL_ID = "channelID";
 
     protected static final String NOTIFICATION_CHANNELS_SHARED_PREFS = "UNITY_NOTIFICATIONS";
     protected static final String NOTIFICATION_CHANNELS_SHARED_PREFS_KEY = "ChannelIDs";
@@ -691,6 +692,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
                     priority = Notification.PRIORITY_DEFAULT;
             }
             notificationBuilder.setPriority(priority);
+            notificationBuilder.getExtras().putString(KEY_CHANNEL_ID, channelID);
 
             return notificationBuilder;
         } else {

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
@@ -40,7 +40,9 @@ public class UnityNotificationRestartOnBootReceiver extends BroadcastReceiver {
 
                     PendingIntent pendingIntent = PendingIntent.getActivity(context, id, openAppIntent, 0);
                     Intent intent = UnityNotificationManager.buildNotificationIntent(context);
-                    Notification.Builder notificationBuilder = Notification.Builder.recoverBuilder(context, notification);
+                    Notification.Builder notificationBuilder = UnityNotificationUtilities.recoverBuilder(context, notification);
+                    if (notificationBuilder == null)
+                        continue;
                     notificationBuilder.setContentIntent(pendingIntent);
                     UnityNotificationManager.finalizeNotificationForDisplay(context, notificationBuilder);
                     notification = notificationBuilder.build();

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationUtilities.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationUtilities.java
@@ -481,46 +481,50 @@ public class UnityNotificationUtilities {
             return Notification.Builder.recoverBuilder(context, notification);
         }
         else {
-            String channelID = notification.extras.getString(KEY_CHANNEL_ID);
-            Notification.Builder builder = UnityNotificationManager.createNotificationBuilder(context, channelID);
-            UnityNotificationManager.setNotificationIcon(builder, KEY_SMALL_ICON, notification.extras.getString(KEY_SMALL_ICON));
-            String largeIcon = notification.extras.getString(KEY_LARGE_ICON);
-            if (largeIcon != null && !largeIcon.isEmpty())
-                UnityNotificationManager.setNotificationIcon(builder, KEY_LARGE_ICON, largeIcon);
-            builder.setContentTitle(notification.extras.getString(Notification.EXTRA_TITLE));
-            builder.setContentText(notification.extras.getString(Notification.EXTRA_TEXT));
-            builder.setAutoCancel(0 != (notification.flags & Notification.FLAG_AUTO_CANCEL));
-            if (notification.number >= 0)
-                builder.setNumber(notification.number);
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                String bigText = notification.extras.getString(Notification.EXTRA_BIG_TEXT);
-                if (bigText != null)
-                    builder.setStyle(new Notification.BigTextStyle().bigText(bigText));
-            }
-
-            builder.setWhen(notification.when);
-            String group = notification.getGroup();
-            if (group != null && !group.isEmpty())
-                builder.setGroup(group);
-            builder.setGroupSummary(0 != (notification.flags & Notification.FLAG_GROUP_SUMMARY));
-            String sortKey = notification.getSortKey();
-            if (sortKey != null && !sortKey.isEmpty())
-                builder.setSortKey(sortKey);
-            builder.setShowWhen(notification.extras.getBoolean(Notification.EXTRA_SHOW_WHEN, false));
-            Integer color = UnityNotificationManager.getNotificationColor(notification);
-            if (color != null)
-                UnityNotificationManager.setNotificationColor(builder, color);
-            UnityNotificationManager.setNotificationUsesChronometer(builder, notification.extras.getBoolean(Notification.EXTRA_SHOW_CHRONOMETER, false));
-            UnityNotificationManager.setNotificationGroupAlertBehavior(builder, UnityNotificationManager.getNotificationGroupAlertBehavior(notification));
-
-            builder.getExtras().putInt(KEY_ID, notification.extras.getInt(KEY_ID, 0));
-            builder.getExtras().putLong(KEY_REPEAT_INTERVAL, notification.extras.getLong(KEY_REPEAT_INTERVAL, 0));
-            builder.getExtras().putLong(KEY_FIRE_TIME, notification.extras.getLong(KEY_FIRE_TIME, 0));
-            String intentData = notification.extras.getString(KEY_INTENT_DATA);
-            if (intentData != null && !intentData.isEmpty())
-                builder.getExtras().putString(KEY_INTENT_DATA, intentData);
-
-            return builder;
+            return recoverBuilderPreNougat(context, notification);
         }
+    }
+
+    private static Notification.Builder recoverBuilderPreNougat(Context context, Notification notification) {
+        String channelID = notification.extras.getString(KEY_CHANNEL_ID);
+        Notification.Builder builder = UnityNotificationManager.createNotificationBuilder(context, channelID);
+        UnityNotificationManager.setNotificationIcon(builder, KEY_SMALL_ICON, notification.extras.getString(KEY_SMALL_ICON));
+        String largeIcon = notification.extras.getString(KEY_LARGE_ICON);
+        if (largeIcon != null && !largeIcon.isEmpty())
+            UnityNotificationManager.setNotificationIcon(builder, KEY_LARGE_ICON, largeIcon);
+        builder.setContentTitle(notification.extras.getString(Notification.EXTRA_TITLE));
+        builder.setContentText(notification.extras.getString(Notification.EXTRA_TEXT));
+        builder.setAutoCancel(0 != (notification.flags & Notification.FLAG_AUTO_CANCEL));
+        if (notification.number >= 0)
+            builder.setNumber(notification.number);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            String bigText = notification.extras.getString(Notification.EXTRA_BIG_TEXT);
+            if (bigText != null)
+                builder.setStyle(new Notification.BigTextStyle().bigText(bigText));
+        }
+
+        builder.setWhen(notification.when);
+        String group = notification.getGroup();
+        if (group != null && !group.isEmpty())
+            builder.setGroup(group);
+        builder.setGroupSummary(0 != (notification.flags & Notification.FLAG_GROUP_SUMMARY));
+        String sortKey = notification.getSortKey();
+        if (sortKey != null && !sortKey.isEmpty())
+            builder.setSortKey(sortKey);
+        builder.setShowWhen(notification.extras.getBoolean(Notification.EXTRA_SHOW_WHEN, false));
+        Integer color = UnityNotificationManager.getNotificationColor(notification);
+        if (color != null)
+            UnityNotificationManager.setNotificationColor(builder, color);
+        UnityNotificationManager.setNotificationUsesChronometer(builder, notification.extras.getBoolean(Notification.EXTRA_SHOW_CHRONOMETER, false));
+        UnityNotificationManager.setNotificationGroupAlertBehavior(builder, UnityNotificationManager.getNotificationGroupAlertBehavior(notification));
+
+        builder.getExtras().putInt(KEY_ID, notification.extras.getInt(KEY_ID, 0));
+        builder.getExtras().putLong(KEY_REPEAT_INTERVAL, notification.extras.getLong(KEY_REPEAT_INTERVAL, 0));
+        builder.getExtras().putLong(KEY_FIRE_TIME, notification.extras.getLong(KEY_FIRE_TIME, 0));
+        String intentData = notification.extras.getString(KEY_INTENT_DATA);
+        if (intentData != null && !intentData.isEmpty())
+            builder.getExtras().putString(KEY_INTENT_DATA, intentData);
+
+        return builder;
     }
 }

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationUtilities.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationUtilities.java
@@ -20,6 +20,7 @@ import android.os.Parcelable;
 import android.util.Base64;
 import android.util.Log;
 
+import static com.unity.androidnotifications.UnityNotificationManager.KEY_CHANNEL_ID;
 import static com.unity.androidnotifications.UnityNotificationManager.KEY_FIRE_TIME;
 import static com.unity.androidnotifications.UnityNotificationManager.KEY_ID;
 import static com.unity.androidnotifications.UnityNotificationManager.KEY_INTENT_DATA;
@@ -473,5 +474,53 @@ public class UnityNotificationUtilities {
         }
 
         return activityClass;
+    }
+
+    protected static Notification.Builder recoverBuilder(Context context, Notification notification) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            return Notification.Builder.recoverBuilder(context, notification);
+        }
+        else {
+            String channelID = notification.extras.getString(KEY_CHANNEL_ID);
+            Notification.Builder builder = UnityNotificationManager.createNotificationBuilder(context, channelID);
+            UnityNotificationManager.setNotificationIcon(builder, KEY_SMALL_ICON, notification.extras.getString(KEY_SMALL_ICON));
+            String largeIcon = notification.extras.getString(KEY_LARGE_ICON);
+            if (largeIcon != null && !largeIcon.isEmpty())
+                UnityNotificationManager.setNotificationIcon(builder, KEY_LARGE_ICON, largeIcon);
+            builder.setContentTitle(notification.extras.getString(Notification.EXTRA_TITLE));
+            builder.setContentText(notification.extras.getString(Notification.EXTRA_TEXT));
+            builder.setAutoCancel(0 != (notification.flags & Notification.FLAG_AUTO_CANCEL));
+            if (notification.number >= 0)
+                builder.setNumber(notification.number);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                String bigText = notification.extras.getString(Notification.EXTRA_BIG_TEXT);
+                if (bigText != null)
+                    builder.setStyle(new Notification.BigTextStyle().bigText(bigText));
+            }
+
+            builder.setWhen(notification.when);
+            String group = notification.getGroup();
+            if (group != null && !group.isEmpty())
+                builder.setGroup(group);
+            builder.setGroupSummary(0 != (notification.flags & Notification.FLAG_GROUP_SUMMARY));
+            String sortKey = notification.getSortKey();
+            if (sortKey != null && !sortKey.isEmpty())
+                builder.setSortKey(sortKey);
+            builder.setShowWhen(notification.extras.getBoolean(Notification.EXTRA_SHOW_WHEN, false));
+            Integer color = UnityNotificationManager.getNotificationColor(notification);
+            if (color != null)
+                UnityNotificationManager.setNotificationColor(builder, color);
+            UnityNotificationManager.setNotificationUsesChronometer(builder, notification.extras.getBoolean(Notification.EXTRA_SHOW_CHRONOMETER, false));
+            UnityNotificationManager.setNotificationGroupAlertBehavior(builder, UnityNotificationManager.getNotificationGroupAlertBehavior(notification));
+
+            builder.getExtras().putInt(KEY_ID, notification.extras.getInt(KEY_ID, 0));
+            builder.getExtras().putLong(KEY_REPEAT_INTERVAL, notification.extras.getLong(KEY_REPEAT_INTERVAL, 0));
+            builder.getExtras().putLong(KEY_FIRE_TIME, notification.extras.getLong(KEY_FIRE_TIME, 0));
+            String intentData = notification.extras.getString(KEY_INTENT_DATA);
+            if (intentData != null && !intentData.isEmpty())
+                builder.getExtras().putString(KEY_INTENT_DATA, intentData);
+
+            return builder;
+        }
     }
 }


### PR DESCRIPTION
Fix notification rescheduling after boot on Android pre-N:
https://github.com/Unity-Technologies/com.unity.mobile.notifications/issues/139
Fix possible null exception:
https://github.com/Unity-Technologies/com.unity.mobile.notifications/issues/140