### PR TITLE
Android safer deserialization

### DIFF
--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -409,10 +409,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         String notification_id = Integer.toString(notification.extras.getInt(KEY_ID, -1));
         SharedPreferences prefs = context.getSharedPreferences(getSharedPrefsNameByNotificationId(notification_id), Context.MODE_PRIVATE);
 
-        SharedPreferences.Editor editor = prefs.edit().clear();
-        String data = UnityNotificationUtilities.serializeNotificationIntent(intent);
-        editor.putString("data", data);
-        editor.apply();
+        UnityNotificationUtilities.serializeNotificationIntent(prefs, intent);
     }
 
     protected static String getSharedPrefsNameByNotificationId(String id)
@@ -429,20 +426,12 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
         for (String id : ids) {
             SharedPreferences prefs = context.getSharedPreferences(getSharedPrefsNameByNotificationId(id), Context.MODE_PRIVATE);
-            String serializedIntentData = prefs.getString("data", "");
+            Intent intent = UnityNotificationUtilities.deserializeNotificationIntent(context, prefs);
 
-            boolean valid = false;
-            if (serializedIntentData.length() > 1) {
-                Intent intent = UnityNotificationUtilities.deserializeNotificationIntent(context, serializedIntentData);
-                if (intent != null) {
-                    intent_data_list.add(intent);
-                    valid = true;
-                }
-            }
-
-            if (!valid) {
+            if (intent != null)
+                intent_data_list.add(intent);
+            else
                 idsMarkedForRemoval.add(id);
-            }
         }
 
         if (idsMarkedForRemoval.size() > 0) {

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationUtilities.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationUtilities.java
@@ -10,6 +10,7 @@ import java.nio.charset.StandardCharsets;
 import android.app.Notification;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
@@ -65,11 +66,12 @@ public class UnityNotificationUtilities {
        - fallback 1: serialize our known properties + serialize extras as is
        - fallback 2: serialize our known stuff
     */
-    protected static String serializeNotificationIntent(Intent intent) {
+    protected static void serializeNotificationIntent(SharedPreferences prefs, Intent intent) {
         try {
+            String serialized = null;
             Notification notification = intent.getParcelableExtra(KEY_NOTIFICATION);
             if (notification == null)
-                return null;
+                return;
             ByteArrayOutputStream data = new ByteArrayOutputStream();
             DataOutputStream out = new DataOutputStream(data);
             boolean success = serializeNotificationParcel(intent, out);
@@ -80,13 +82,15 @@ public class UnityNotificationUtilities {
             if (success) {
                 out.close();
                 byte[] bytes = data.toByteArray();
-                return Base64.encodeToString(bytes, 0, bytes.length, 0);
+                serialized = Base64.encodeToString(bytes, 0, bytes.length, 0);
             }
+
+            SharedPreferences.Editor editor = prefs.edit().clear();
+            editor.putString("data", serialized);
+            editor.apply();
         } catch (Exception e) {
             Log.e(TAG_UNITY, "Failed to serialize notification", e);
         }
-
-        return null;
     }
 
     private static boolean serializeNotificationParcel(Intent intent, DataOutputStream out) {
@@ -178,8 +182,11 @@ public class UnityNotificationUtilities {
         }
     }
 
-    protected static Intent deserializeNotificationIntent(Context context, String src) {
-        byte[] bytes = Base64.decode(src, 0);
+    protected static Intent deserializeNotificationIntent(Context context, SharedPreferences prefs) {
+        String serializedIntentData = prefs.getString("data", "");
+        if (null == serializedIntentData || serializedIntentData.length() <= 0)
+            return null;
+        byte[] bytes = Base64.decode(serializedIntentData, 0);
         return deserializeNotificationIntent(context, bytes);
     }
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationUtilities.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationUtilities.java
@@ -68,6 +68,8 @@ public class UnityNotificationUtilities {
        - serialize as is
        - fallback 1: serialize our known properties + serialize extras as is
        - fallback 2: serialize our known stuff
+       When notification is serialized as-is, it may contain references to resources and in case
+       of app update may fail to deserialize due to resources now missing, hence always save fallback version.
     */
     protected static void serializeNotificationIntent(SharedPreferences prefs, Intent intent) {
         try {
@@ -78,14 +80,11 @@ public class UnityNotificationUtilities {
             ByteArrayOutputStream data = new ByteArrayOutputStream();
             DataOutputStream out = new DataOutputStream(data);
             if (serializeNotificationCustom(notification, out)) {
-                out.close();
+                out.flush();
                 byte[] bytes = data.toByteArray();
                 fallback = Base64.encodeToString(bytes, 0, bytes.length, 0);
-                data = new ByteArrayOutputStream();
-                out = new DataOutputStream(data);
             }
-            else
-                data.reset();
+            data.reset();
             if (serializeNotificationParcel(intent, out)) {
                 out.close();
                 byte[] bytes = data.toByteArray();

--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSimpleTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSimpleTests.cs
@@ -259,10 +259,11 @@ class AndroidNotificationSimpleTests
         intent.Call<AndroidJavaObject>("putExtra", "unityNotification", javaNotif).Dispose();
         var utilsClass = new AndroidJavaClass("com.unity.androidnotifications.UnityNotificationUtilities");
 
-        var serializedString = utilsClass.CallStatic<AndroidJavaObject>("serializeNotificationIntent", intent);
-        Assert.IsNotNull(serializedString);
+        var prefs = context.Call<AndroidJavaObject>("getSharedPreferences", "android.notification.test.key", context.GetStatic<int>("MODE_PRIVATE"));
 
-        var deserializedIntent = utilsClass.CallStatic<AndroidJavaObject>("deserializeNotificationIntent", context, serializedString);
+        utilsClass.CallStatic("serializeNotificationIntent", prefs, intent);
+
+        var deserializedIntent = utilsClass.CallStatic<AndroidJavaObject>("deserializeNotificationIntent", context, prefs);
         Assert.IsNotNull(deserializedIntent);
         // don't dispose notification, it is kept in AndroidNotificationIntentData
         var deserializedNotification = deserializedIntent.Call<AndroidJavaObject>("getParcelableExtra", "unityNotification");

--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSimpleTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSimpleTests.cs
@@ -438,7 +438,8 @@ class AndroidNotificationSimpleTests
         original.FireTime = DateTime.Now;
         original.LargeIcon = "large_icon";
 
-        var deserializedData = SerializeDeserializeNotificationIntent(original, notificationId, (prefs) => {
+        var deserializedData = SerializeDeserializeNotificationIntent(original, notificationId, (prefs) =>
+        {
             var data = prefs.Call<string>("getString", "data", "");
             // corrupt data
             using (var editor = prefs.Call<AndroidJavaObject>("edit"))


### PR DESCRIPTION
https://github.com/Unity-Technologies/com.unity.mobile.notifications/issues/147
Notification can have references to resources (icons). If application is updated on device, those references can become invalid due to resource changed. In such case a serialized (parcelled) notification would fail to deserialize.
Our custom notification serialization does not have such issue, but it is lossy, since we only serialize things that we know. We use this system as a backup for case when parcel fails, so this PR extends it to be used as a backup serialization for cases when parcel deserialization fails.