### PR TITLE
Fix publishing to google play

### DIFF
--- a/com.unity.mobile.notifications/Editor/AndroidNotificationPostProcessor.cs
+++ b/com.unity.mobile.notifications/Editor/AndroidNotificationPostProcessor.cs
@@ -119,6 +119,7 @@ namespace Unity.Notifications
             {
                 notificationRestartOnBootReceiver = manifestXmlDoc.CreateElement("receiver");
                 notificationRestartOnBootReceiver.SetAttribute("name", kAndroidNamespaceURI, kNotificationRestartOnBootName);
+                notificationRestartOnBootReceiver.SetAttribute("exported", kAndroidNamespaceURI, "true");
 
                 var intentFilterNode = manifestXmlDoc.CreateElement("intent-filter");
 

--- a/com.unity.mobile.notifications/Editor/AndroidNotificationPostProcessor.cs
+++ b/com.unity.mobile.notifications/Editor/AndroidNotificationPostProcessor.cs
@@ -119,7 +119,7 @@ namespace Unity.Notifications
             {
                 notificationRestartOnBootReceiver = manifestXmlDoc.CreateElement("receiver");
                 notificationRestartOnBootReceiver.SetAttribute("name", kAndroidNamespaceURI, kNotificationRestartOnBootName);
-                notificationRestartOnBootReceiver.SetAttribute("exported", kAndroidNamespaceURI, "true");
+                notificationRestartOnBootReceiver.SetAttribute("exported", kAndroidNamespaceURI, "false");
 
                 var intentFilterNode = manifestXmlDoc.CreateElement("intent-filter");
 


### PR DESCRIPTION
Recent builds get rejected by Google Play with an error:
"You uploaded an APK or Android App Bundle which has an activity, activity alias, service or broadcast receiver with intent filter, but without 'android:exported' property set. This file can't be installed on Android 12 or higher. See: developer.android.com/about/versions/12/behavior-changes-12#exported"

This MR fixes this error by adding needed attribute to notificationRestartOnBootReceiver