### PR TITLE
Update CI versions

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -5,13 +5,6 @@ test_editors:
   - version: 2020.3
   - version: 2019.4
 
-android_test_editors:
-  - version: trunk
-  - version: 2022.1
-  - version: 2021.2
-  - version: 2020.3
-  - version: 2019.4
-
 # 2019.4 fails due to issue unrelated to package
 ios_test_editors:
   - version: trunk
@@ -86,7 +79,7 @@ test_{{ platform.name }}_{{ editor.version }}:
 {% endfor %}
 {% endfor %}
 
-{% for editor in android_test_editors %}
+{% for editor in test_editors %}
 test_Android_{{ editor.version }}:
   name: Test {{ editor.version }} on Android
   agent:
@@ -178,12 +171,10 @@ test_trigger:
     {% for platform in test_platforms %}
     - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
     {% endfor %}
+    - .yamato/upm-ci.yml#test_Android_{{ editor.version }}
     {% endfor %}
     {% for editor in ios_test_editors %}
     - .yamato/upm-ci.yml#test_iOS_{{ editor.version }}
-    {% endfor %}
-    {% for editor in android_test_editors %}
-    - .yamato/upm-ci.yml#test_Android_{{ editor.version }}
     {% endfor %}
 
 publish:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -105,10 +105,11 @@ test_Android_{{ editor.version }}:
     - curl -s {{ utr.url_win }} --output utr.bat
     - pip install unity-downloader-cli --index-url {{ artifactory.production }}pypi/pypi/simple --upgrade
     - unity-downloader-cli -c Editor -c Android -u {{ editor.version }} --wait --fast
+    - utr.bat --testproject=.MyTestProject --editor-location=.Editor --suite=playmode --platform=android --scripting-backend=mono --artifacts_path=upm-ci~/test-results/android --timeout=900  --extra-editor-arg="-upmNoDefaultPackages" --player-save-path=build/players --build-only
     - |
        set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
        start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-       utr.bat --testproject=.MyTestProject --editor-location=.Editor --suite=playmode --platform=android --scripting-backend=mono --artifacts_path=upm-ci~/test-results/android --timeout=900  --extra-editor-arg="-upmNoDefaultPackages"
+       utr.bat --testproject=.MyTestProject --editor-location=.Editor --suite=playmode --platform=android --scripting-backend=mono --artifacts_path=upm-ci~/test-results/android --timeout=900 --player-load-path=build/players
   after:
     - start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
     - powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > upm-ci~/test-results/android/android_device_log.txt
@@ -140,7 +141,8 @@ test_iOS_{{ editor.version }}:
     - chmod u+x utr
     - pip install unity-downloader-cli --index-url {{ artifactory.production }}pypi/pypi/simple --upgrade
     - unity-downloader-cli -c Editor -c iOS -u {{ editor.version }} --wait --fast
-    - ./utr --testproject=.MyTestProject --editor-location=.Editor --suite=playmode --platform=ios --artifacts_path=upm-ci~/test-results/ios --extra-editor-arg="-playerHeartbeatTimeout 900"  --timeout=900 --extra-editor-arg="-upmNoDefaultPackages"
+    - ./utr --testproject=.MyTestProject --editor-location=.Editor --suite=playmode --platform=ios --artifacts_path=upm-ci~/test-results/ios --timeout=900 --extra-editor-arg="-upmNoDefaultPackages" --player-save-path=build/players --build-only
+    - ./utr --testproject=.MyTestProject --editor-location=.Editor --suite=playmode --platform=ios --artifacts_path=upm-ci~/test-results/ios --timeout=900 --player-load-path=build/players
   artifacts:
     packages:
       paths:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,22 +1,23 @@
 test_editors:
   - version: trunk
+  - version: 2022.1
   - version: 2021.2
-  - version: 2021.1
   - version: 2020.3
   - version: 2019.4
 
-# running test is currently broken in trunk and 2021.2
 android_test_editors:
-  - version: 2021.1
+  - version: trunk
+  - version: 2022.1
+  - version: 2021.2
   - version: 2020.3
   - version: 2019.4
 
-# Some issues with 2019.4 on iOS on Yamato, but passes locally
 ios_test_editors:
   - version: trunk
+  - version: 2022.1
   - version: 2021.2
-  - version: 2021.1
   - version: 2020.3
+  - version: 2019.4
 
 test_platforms:
   - name: mac

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -128,6 +128,8 @@ test_iOS_{{ editor.version }}:
     type: Unity::mobile::iPhone
     image: mobile/macos-10.13-testing:stable
     flavor: b1.medium
+  variables:
+    IOS_SIMULATOR_SDK: 1
   commands:
     - brew tap --force-auto-update unity/unity git@github.cds.internal.unity3d.com:unity/homebrew-unity.git
     - brew install unity-config

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -108,7 +108,7 @@ test_Android_{{ editor.version }}:
     - |
        set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
        start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-       utr.bat --testproject=.MyTestProject --editor-location=.Editor --suite=playmode --platform=android --scripting-backend=mono --artifacts_path=upm-ci~/test-results/android --timeout=900
+       utr.bat --testproject=.MyTestProject --editor-location=.Editor --suite=playmode --platform=android --scripting-backend=mono --artifacts_path=upm-ci~/test-results/android --timeout=900  --extra-editor-arg="-upmNoDefaultPackages"
   after:
     - start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
     - powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > upm-ci~/test-results/android/android_device_log.txt
@@ -140,7 +140,7 @@ test_iOS_{{ editor.version }}:
     - chmod u+x utr
     - pip install unity-downloader-cli --index-url {{ artifactory.production }}pypi/pypi/simple --upgrade
     - unity-downloader-cli -c Editor -c iOS -u {{ editor.version }} --wait --fast
-    - ./utr --testproject=.MyTestProject --editor-location=.Editor --suite=playmode --platform=ios --artifacts_path=upm-ci~/test-results/ios --extra-editor-arg="-playerHeartbeatTimeout 900" --extra-editor-arg="-upmNoDefaultPackages"
+    - ./utr --testproject=.MyTestProject --editor-location=.Editor --suite=playmode --platform=ios --artifacts_path=upm-ci~/test-results/ios --extra-editor-arg="-playerHeartbeatTimeout 900"  --timeout=900 --extra-editor-arg="-upmNoDefaultPackages"
   artifacts:
     packages:
       paths:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -12,12 +12,12 @@ android_test_editors:
   - version: 2020.3
   - version: 2019.4
 
+# 2019.4 fails due to issue unrelated to package
 ios_test_editors:
   - version: trunk
   - version: 2022.1
   - version: 2021.2
   - version: 2020.3
-  - version: 2019.4
 
 test_platforms:
   - name: mac

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -125,9 +125,9 @@ test_Android_{{ editor.version }}:
 test_iOS_{{ editor.version }}:
   name: Test {{ editor.version }} on iOS
   agent:
-    type: Unity::mobile::iPhone
-    image: mobile/macos-10.13-testing:stable
-    flavor: b1.medium
+    type: Unity::VM::osx
+    image: mobile/ios-macos-10.15:latest
+    flavor: i1.large
   variables:
     IOS_SIMULATOR_SDK: 1
   commands:


### PR DESCRIPTION
- Update Unity versions we test on.
- Split build and run for Android, otherwise it fails on 21.2 and newer.
- No longer need separate version list for Android.
- Change the builder for iOS to newer and without iOS device, since we run on simulator anyway
- Split build and run on iOS (required for tests to work)
- iOS on 19.4 fails due to issues unrelated to package, will go out of support soon anyway