### PR TITLE
Change exported attribute to false

### DIFF
--- a/com.unity.mobile.notifications/Editor/AndroidNotificationPostProcessor.cs
+++ b/com.unity.mobile.notifications/Editor/AndroidNotificationPostProcessor.cs
@@ -112,7 +112,7 @@ namespace Unity.Notifications
 
                 applicationXmlNode.AppendChild(notificationManagerReceiver);
             }
-            notificationManagerReceiver.SetAttribute("exported", kAndroidNamespaceURI, "true");
+            notificationManagerReceiver.SetAttribute("exported", kAndroidNamespaceURI, "false");
 
             // Create notification restart-on-boot receiver if necessary.
             if (notificationRestartOnBootReceiver == null)
@@ -130,7 +130,7 @@ namespace Unity.Notifications
                 applicationXmlNode.AppendChild(notificationRestartOnBootReceiver);
             }
             notificationRestartOnBootReceiver.SetAttribute("enabled", kAndroidNamespaceURI, "false");
-            notificationRestartOnBootReceiver.SetAttribute("exported", kAndroidNamespaceURI, "true");
+            notificationRestartOnBootReceiver.SetAttribute("exported", kAndroidNamespaceURI, "false");
         }
 
         internal static void AppendAndroidPermissionField(string manifestPath, XmlDocument xmlDoc, string name)


### PR DESCRIPTION
Change value for exported attribute to false.
This attribute has to be true for Activities/Receivers that are can be invoked by non-system stuff (other apps). The ones in notifications are system-only.