### PR TITLE
Min android api update

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -3,9 +3,7 @@ test_editors:
   - version: 2022.1
   - version: 2021.2
   - version: 2020.3
-  - version: 2019.4
 
-# 2019.4 fails due to issue unrelated to package
 ios_test_editors:
   - version: trunk
   - version: 2022.1

--- a/TestProjects/NotificationSamples_2019_3/ProjectSettings/ProjectSettings.asset
+++ b/TestProjects/NotificationSamples_2019_3/ProjectSettings/ProjectSettings.asset
@@ -172,7 +172,7 @@ PlayerSettings:
     iPhone: com.unity3d.mobilenotificationtests
   buildNumber: {}
   AndroidBundleVersionCode: 1
-  AndroidMinSdkVersion: 20
+  AndroidMinSdkVersion: 21
   AndroidTargetSdkVersion: 0
   AndroidPreferredInstallLocation: 1
   aotOptions: nimt-trampolines=1024

--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to this package will be documented in this file.
 - [Android] Added API which allows you to change notification icons in Editor.
 - [iOS] Correctly handle boolean values in UserInfo, previously boolean values were detected as numbers and get parsed as 1 or 0, now they will be correctly handled as 'true' and 'false'
 - [Android] Fixed notification package for Android 12 - NotificationRestartOnBootReceiver needs to be marked as exported in manifest file, disable exact alarms because they require special permissions.
+- [iOS] Fix NotificationSettings.iOSSettings.DefaultAuthorizationOptions having incorrect return type (was PresentationOption, now AuthorizationOption).
+- [iOS] Mobile Notifications 2.0.0: iOSNotificationTrigger.Type is no longer static and returns iOSNotificationTriggerType instead of int.
 
 ## [1.4.2] - 2021-07-22
 

--- a/com.unity.mobile.notifications/Documentation~/index.md
+++ b/com.unity.mobile.notifications/Documentation~/index.md
@@ -5,7 +5,7 @@ The Unity Mobile Notifications package adds support for scheduling local one-tim
 ### Requirements
 
 - Compatible with Unity 2019.4 or above.
-- Compatible with Android 4.4+ (API 19) and iOS 10.0+.
+- Compatible with Android 5 (API 21) and iOS 10.0+.
 
 ### Supported features
 

--- a/com.unity.mobile.notifications/Editor/AndroidNotificationPostProcessor.cs
+++ b/com.unity.mobile.notifications/Editor/AndroidNotificationPostProcessor.cs
@@ -15,9 +15,23 @@ namespace Unity.Notifications
 
         public void OnPostGenerateGradleAndroidProject(string projectPath)
         {
+            MinSdkCheck();
+
             CopyNotificationResources(projectPath);
 
             InjectAndroidManifest(projectPath);
+        }
+
+        private void MinSdkCheck()
+        {
+#if !UNITY_2020_2_OR_NEWER
+        // API level 21 not supported since 2020.2, need to check for prior releases
+        const AndroidSdkVersions kMinAndroidSdk = AndroidSdkVersions.AndroidApiLevel21;
+
+        if (PlayerSettings.Android.minSdkVersion < AndroidSdkVersions.AndroidApiLevel21)
+                throw new NotSupportedException(string.Format("Minimum Android API level supported by notifications package is {0}, your Player Settings have it set to {1}",
+                    (int)kMinAndroidSdk, PlayerSettings.Android.minSdkVersion));
+#endif
         }
 
         private void CopyNotificationResources(string projectPath)


### PR DESCRIPTION
The minimum Android API supported by package is 21, but that was missed when releasing 2.0.0.
Also, a couple of changes were missed to and were written to Unity release notes when verifying.