### PR TITLE
Properly set intent immutable flag after reboot

### DIFF
--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
@@ -38,7 +38,7 @@ public class UnityNotificationRestartOnBootReceiver extends BroadcastReceiver {
                     Intent openAppIntent = UnityNotificationManager.buildOpenAppIntent(context, UnityNotificationUtilities.getOpenAppActivity(context, true));
                     openAppIntent.putExtra(KEY_NOTIFICATION, notification);
 
-                    PendingIntent pendingIntent = PendingIntent.getActivity(context, id, openAppIntent, 0);
+                    PendingIntent pendingIntent = UnityNotificationManager.getActivityPendingIntent(context, id, openAppIntent, 0);
                     Intent intent = UnityNotificationManager.buildNotificationIntent(context);
                     Notification.Builder notificationBuilder = UnityNotificationUtilities.recoverBuilder(context, notification);
                     if (notificationBuilder == null)


### PR DESCRIPTION
Duplicate reports:
https://github.com/Unity-Technologies/com.unity.mobile.notifications/issues/160
case 1410927

Android 12 requires Pending intents to have immutable flag, one place was missed: rechedule after reboot.
Tested fix on Asus ROG Phone (Android 8.1).

QA: try before and after fix. Note, that on some phones rescheduling is not reliable, for example on Asus ROG I had to start the app immediately after reboot for it to actually get a reschedule. It's expected that on Android 12 rescheduling will not work either way prior this fix (exception thrown, but retrieving logcat is difficult), but should work after the fix. Test project in this repo is suitable (has a button specifically for this).