### PR TITLE
[Android] improve tests

### DIFF
--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
@@ -149,7 +149,7 @@ class AndroidNotificationSendingTests
         var n = new AndroidNotification();
         n.Title = "Repeating Notification Title";
         n.Text = "Repeating Notification Text";
-        n.FireTime = System.DateTime.Now;
+        n.FireTime = System.DateTime.Now.AddSeconds(2);
         n.RepeatInterval = new System.TimeSpan(0, 0, 5); // interval needs to be quite big for test to be reliable
 
         Debug.LogWarning("ScheduleRepeatableNotification_NotificationsAreReceived sends notification");
@@ -158,8 +158,8 @@ class AndroidNotificationSendingTests
 
         // we use inexact scheduling, so repeated notification may take a while to appear
         // inexact also can group, so for test purposes we only check that it repeats at least once
-        yield return WaitForNotification(8.0f);
-        yield return WaitForNotification(30.0f);
+        yield return WaitForNotification(120.0f);
+        yield return WaitForNotification(120.0f);
         AndroidNotificationCenter.CancelScheduledNotification(originalId);
 
         Debug.LogWarning("ScheduleRepeatableNotification_NotificationsAreReceived completed");

--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSimpleTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSimpleTests.cs
@@ -209,7 +209,7 @@ class AndroidNotificationSimpleTests
         var configClass = new AndroidJavaClass("android.graphics.Bitmap$Config");
         var ARGB_8888 = configClass.GetStatic<AndroidJavaObject>("ARGB_8888");
         var bitmapClass = new AndroidJavaClass("android.graphics.Bitmap");
-        return bitmapClass.CallStatic<AndroidJavaObject>("createBitmap", 10000, 10000, ARGB_8888);
+        return bitmapClass.CallStatic<AndroidJavaObject>("createBitmap", 1000, 1000, ARGB_8888);
     }
 
     [Test]

--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSimpleTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSimpleTests.cs
@@ -259,7 +259,7 @@ class AndroidNotificationSimpleTests
         intent.Call<AndroidJavaObject>("putExtra", "unityNotification", javaNotif).Dispose();
         var utilsClass = new AndroidJavaClass("com.unity.androidnotifications.UnityNotificationUtilities");
 
-        var prefs = context.Call<AndroidJavaObject>("getSharedPreferences", "android.notification.test.key", context.GetStatic<int>("MODE_PRIVATE"));
+        var prefs = context.Call<AndroidJavaObject>("getSharedPreferences", "android.notification.test.key", 0 /* MODE_PRIVATE */);
         utilsClass.CallStatic("serializeNotificationIntent", prefs, intent);
 
         if (inBetween != null)

--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSimpleTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSimpleTests.cs
@@ -259,6 +259,7 @@ class AndroidNotificationSimpleTests
         intent.Call<AndroidJavaObject>("putExtra", "unityNotification", javaNotif).Dispose();
         var utilsClass = new AndroidJavaClass("com.unity.androidnotifications.UnityNotificationUtilities");
 
+        // context.GetStatic<int>("MODE_PRIVATE") fails on older android, did investigate why, simply using it's value from docs
         var prefs = context.Call<AndroidJavaObject>("getSharedPreferences", "android.notification.test.key", 0 /* MODE_PRIVATE */);
         utilsClass.CallStatic("serializeNotificationIntent", prefs, intent);
 


### PR DESCRIPTION
Use smaller bitmap to prevent occasional failures with out of memory.
Do not access MODE_PRIVATE property via JNI, cause that fails on lower android versions. Instead just use the value of the constant directly.
Attempt to make repeating notification more reliable. Also make that test always use alarm scheduling.