### PR TITLE
Increase timeouts, cause test randomly fail too often

### DIFF
--- a/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
@@ -117,7 +117,7 @@ class iOSNotificationTests
 
         iOSNotificationCenter.ScheduleNotification(notification);
 
-        yield return WaitForNotification(6.0f);
+        yield return WaitForNotification(10.0f);
         Assert.AreEqual(1, receivedNotificationCount);
     }
 
@@ -148,7 +148,7 @@ class iOSNotificationTests
 
         iOSNotificationCenter.ScheduleNotification(notification);
 
-        yield return WaitForNotification(6.0f);
+        yield return WaitForNotification(10.0f);
         Assert.AreEqual(1, receivedNotificationCount);
         Assert.IsNotNull(lastReceivedNotification);
         Assert.IsTrue(lastReceivedNotification.UserInfo.ContainsKey("key1"));
@@ -180,7 +180,7 @@ class iOSNotificationTests
         };
 
         iOSNotificationCenter.ScheduleNotification(notification);
-        yield return WaitForNotification(5.0f);
+        yield return WaitForNotification(10.0f);
         Assert.AreEqual(1, receivedNotificationCount);
         Assert.IsNotNull(lastReceivedNotification);
         Assert.AreEqual(text, lastReceivedNotification.Title);


### PR DESCRIPTION
Looks like timeout when waiting for notification is a bit too low. Most of the time tests succeed, but random failure is not uncommon.