### PR TITLE
Refactor Android notification scheduling to be cheaper

### DIFF
--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -383,7 +383,7 @@ namespace Unity.Notifications.Android
                 return null;
 
             var intent = s_CurrentActivity.Call<AndroidJavaObject>("getIntent");
-            var notification = intent.Call<AndroidJavaObject>("getParcelableExtra", KEY_NOTIFICATION);
+            var notification = s_NotificationManagerClass.CallStatic<AndroidJavaObject>("getNotificationFromIntent", s_CurrentActivity, intent);
             if (notification == null)
                 return null;
             return GetNotificationData(notification);

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -274,14 +274,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
             if (intent != null) {
                 UnityNotificationManager.saveNotification(mContext, notificationBuilder.build());
-
-                // rebuild here, because we're setting content intent (which can't be saved)
-                notification = buildNotificationForSending(mContext, mOpenActivity, notificationBuilder);
-                mScheduledNotifications.put(Integer.valueOf(id), notification);
-                intent.putExtra(KEY_NOTIFICATION_ID, id);
-
-                PendingIntent broadcast = getBroadcastPendingIntent(mContext, id, intent, PendingIntent.FLAG_UPDATE_CURRENT);
-                UnityNotificationManager.scheduleNotificationIntentAlarm(mContext, repeatInterval, fireTime, broadcast);
+                notification = scheduleAlarmWithNotification(notificationBuilder, intent, fireTime);
             }
         }
 
@@ -291,6 +284,21 @@ public class UnityNotificationManager extends BroadcastReceiver {
             }
             notify(mContext, id, notification);
         }
+    }
+
+    Notification scheduleAlarmWithNotification(Notification.Builder notificationBuilder, Intent intent, long fireTime) {
+        Bundle extras = notificationBuilder.getExtras();
+        int id = extras.getInt(KEY_ID, -1);
+        long repeatInterval = extras.getLong(KEY_REPEAT_INTERVAL, -1);
+        // fireTime not taken from notification, because we may have adjusted it
+
+        Notification notification = buildNotificationForSending(mContext, mOpenActivity, notificationBuilder);
+        mScheduledNotifications.put(Integer.valueOf(id), notification);
+        intent.putExtra(KEY_NOTIFICATION_ID, id);
+
+        PendingIntent broadcast = getBroadcastPendingIntent(mContext, id, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+        UnityNotificationManager.scheduleNotificationIntentAlarm(mContext, repeatInterval, fireTime, broadcast);
+        return notification;
     }
 
     protected static Notification buildNotificationForSending(Context context, Class openActivity, Notification.Builder builder) {

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -301,6 +301,15 @@ public class UnityNotificationManager extends BroadcastReceiver {
         return notification;
     }
 
+    static void scheduleAlarmWithNotification(Notification.Builder notificationBuilder, Context context) {
+        if (mUnityNotificationManager == null)
+            return;
+
+        long fireTime = notificationBuilder.getExtras().getLong(KEY_FIRE_TIME, 0L);
+        Intent intent = buildNotificationIntent(context);
+        mUnityNotificationManager.scheduleAlarmWithNotification(notificationBuilder, intent, fireTime);
+    }
+
     protected static Notification buildNotificationForSending(Context context, Class openActivity, Notification.Builder builder) {
         int id = builder.getExtras().getInt(KEY_ID, -1);
         Intent openAppIntent = buildOpenAppIntent(context, openActivity);

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -435,18 +435,24 @@ public class UnityNotificationManager extends BroadcastReceiver {
     }
 
     // Load all the notification intents from SharedPreferences.
-    protected static synchronized List<Intent> loadNotificationIntents(Context context) {
+    protected static synchronized List<Notification.Builder> loadSavedNotifications(Context context) {
         Set<String> ids = getScheduledNotificationIDs(context);
 
-        List<Intent> intent_data_list = new ArrayList<Intent>();
+        List<Notification.Builder> intent_data_list = new ArrayList();
         Set<String> idsMarkedForRemoval = new HashSet<String>();
 
         for (String id : ids) {
             SharedPreferences prefs = context.getSharedPreferences(getSharedPrefsNameByNotificationId(id), Context.MODE_PRIVATE);
+            Notification.Builder builder = null;
             Intent intent = UnityNotificationUtilities.deserializeNotificationIntent(context, prefs);
+            if (intent != null) {
+                Notification notification = intent.getParcelableExtra(KEY_NOTIFICATION);
+                if (notification != null)
+                    builder = UnityNotificationUtilities.recoverBuilder(context, notification);
+            }
 
-            if (intent != null)
-                intent_data_list.add(intent);
+            if (builder != null)
+                intent_data_list.add(builder);
             else
                 idsMarkedForRemoval.add(id);
         }

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -277,7 +277,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
             if (intent != null) {
                 if (this.mRescheduleOnRestart) {
                     intent.putExtra(KEY_NOTIFICATION, notification);
-                    UnityNotificationManager.saveNotificationIntent(mContext, intent);
+                    UnityNotificationManager.saveNotification(mContext, notification);
                 }
 
                 // content intent can't and shouldn't be saved, set it now and rebuild
@@ -421,12 +421,10 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
     // Save the notification intent to SharedPreferences if reschedule_on_restart is true,
     // which will be consumed by UnityNotificationRestartOnBootReceiver for device reboot.
-    protected static synchronized void saveNotificationIntent(Context context, Intent intent) {
-        Notification notification = intent.getParcelableExtra(KEY_NOTIFICATION);
+    protected static synchronized void saveNotification(Context context, Notification notification) {
         String notification_id = Integer.toString(notification.extras.getInt(KEY_ID, -1));
         SharedPreferences prefs = context.getSharedPreferences(getSharedPrefsNameByNotificationId(notification_id), Context.MODE_PRIVATE);
-
-        UnityNotificationUtilities.serializeNotificationIntent(prefs, intent);
+        UnityNotificationUtilities.serializeNotification(prefs, notification);
     }
 
     protected static String getSharedPrefsNameByNotificationId(String id)
@@ -444,12 +442,9 @@ public class UnityNotificationManager extends BroadcastReceiver {
         for (String id : ids) {
             SharedPreferences prefs = context.getSharedPreferences(getSharedPrefsNameByNotificationId(id), Context.MODE_PRIVATE);
             Notification.Builder builder = null;
-            Intent intent = UnityNotificationUtilities.deserializeNotificationIntent(context, prefs);
-            if (intent != null) {
-                Notification notification = intent.getParcelableExtra(KEY_NOTIFICATION);
-                if (notification != null)
-                    builder = UnityNotificationUtilities.recoverBuilder(context, notification);
-            }
+            Notification notification = UnityNotificationUtilities.deserializeNotification(context, prefs);
+            if (notification != null)
+                builder = UnityNotificationUtilities.recoverBuilder(context, notification);
 
             if (builder != null)
                 intent_data_list.add(builder);

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
@@ -1,7 +1,6 @@
 package com.unity.androidnotifications;
 
 import android.app.Notification;
-import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -12,8 +11,6 @@ import java.util.Date;
 import java.util.List;
 
 import static com.unity.androidnotifications.UnityNotificationManager.KEY_FIRE_TIME;
-import static com.unity.androidnotifications.UnityNotificationManager.KEY_ID;
-import static com.unity.androidnotifications.UnityNotificationManager.KEY_NOTIFICATION;
 import static com.unity.androidnotifications.UnityNotificationManager.KEY_REPEAT_INTERVAL;
 
 public class UnityNotificationRestartOnBootReceiver extends BroadcastReceiver {
@@ -35,22 +32,10 @@ public class UnityNotificationRestartOnBootReceiver extends BroadcastReceiver {
             Date currentDate = Calendar.getInstance().getTime();
             Date fireTimeDate = new Date(fireTime);
 
-            int id = extras.getInt(KEY_ID, -1);
             boolean isRepeatable = repeatInterval > 0;
 
             if (fireTimeDate.after(currentDate) || isRepeatable) {
-                Intent openAppIntent = UnityNotificationManager.buildOpenAppIntent(context, UnityNotificationUtilities.getOpenAppActivity(context, true));
-                openAppIntent.putExtra(KEY_NOTIFICATION, notificationBuilder.build());
-
-                PendingIntent pendingIntent = PendingIntent.getActivity(context, id, openAppIntent, 0);
-                Intent intent = UnityNotificationManager.buildNotificationIntent(context);
-                notificationBuilder.setContentIntent(pendingIntent);
-                UnityNotificationManager.finalizeNotificationForDisplay(context, notificationBuilder);
-                Notification notification = notificationBuilder.build();
-                intent.putExtra(KEY_NOTIFICATION, notification);
-
-                PendingIntent broadcast = UnityNotificationManager.getBroadcastPendingIntent(context, id, intent, PendingIntent.FLAG_UPDATE_CURRENT);
-                UnityNotificationManager.scheduleNotificationIntentAlarm(context, repeatInterval, fireTime, broadcast);
+                UnityNotificationManager.scheduleAlarmWithNotification(notificationBuilder, context);
             }
         }
     }

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
@@ -50,10 +50,6 @@ public class UnityNotificationRestartOnBootReceiver extends BroadcastReceiver {
 
                     PendingIntent broadcast = UnityNotificationManager.getBroadcastPendingIntent(context, id, intent, PendingIntent.FLAG_UPDATE_CURRENT);
                     UnityNotificationManager.scheduleNotificationIntentAlarm(context, repeatInterval, fireTime, broadcast);
-                } else {
-                    String idStr = String.valueOf(id);
-                    UnityNotificationManager.removeScheduledNotificationID(context, idStr);
-                    UnityNotificationManager.deleteExpiredNotificationIntent(context, idStr);
                 }
             }
         }

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationUtilities.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationUtilities.java
@@ -82,9 +82,9 @@ public class UnityNotificationUtilities {
                 fallback = Base64.encodeToString(bytes, 0, bytes.length, 0);
             }
             data.reset();
-            Bundle bundle = new Bundle();
-            bundle.putParcelable(KEY_NOTIFICATION, notification);
-            if (serializeNotificationParcel(bundle, out)) {
+            Intent intent = new Intent();
+            intent.putExtra(KEY_NOTIFICATION, notification);
+            if (serializeNotificationParcel(intent, out)) {
                 out.close();
                 byte[] bytes = data.toByteArray();
                 serialized = Base64.encodeToString(bytes, 0, bytes.length, 0);
@@ -101,9 +101,9 @@ public class UnityNotificationUtilities {
         }
     }
 
-    private static boolean serializeNotificationParcel(Bundle bundle, DataOutputStream out) {
+    private static boolean serializeNotificationParcel(Intent intent, DataOutputStream out) {
         try {
-            byte[] bytes = serializeParcelable(bundle);
+            byte[] bytes = serializeParcelable(intent);
             if (bytes == null || bytes.length == 0)
                 return false;
             out.write(UNITY_MAGIC_NUMBER_PARCELLED);
@@ -248,8 +248,8 @@ public class UnityNotificationUtilities {
             int version = in.readInt();
             if (version <0 || version > INTENT_SERIALIZATION_VERSION)
                 return null;
-            Bundle bundle = deserializeParcelable(in);
-            Notification notification = bundle.getParcelable(KEY_NOTIFICATION);
+            Intent intent = deserializeParcelable(in);
+            Notification notification = intent.getParcelableExtra(KEY_NOTIFICATION);
             return notification;
         } catch (Exception e) {
             Log.e(TAG_UNITY, "Failed to deserialize notification intent", e);

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationUtilities.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationUtilities.java
@@ -506,7 +506,10 @@ public class UnityNotificationUtilities {
 
     protected static Notification.Builder recoverBuilder(Context context, Notification notification) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            return Notification.Builder.recoverBuilder(context, notification);
+            Notification.Builder builder = Notification.Builder.recoverBuilder(context, notification);
+            // extras not recovered, transfer manually
+            builder.setExtras(notification.extras);
+            return builder;
         }
         else {
             return recoverBuilderPreNougat(context, notification);

--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
@@ -301,8 +301,10 @@ class AndroidNotificationSendingTests
         var rebootClass = new AndroidJavaClass("com.unity.androidnotifications.UnityNotificationRestartOnBootReceiver");
         AndroidJavaObject context;
         using (var unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer"))
+        {
             using (var activity = unityPlayer.GetStatic<AndroidJavaObject>("currentActivity"))
                 context = activity.Call<AndroidJavaObject>("getApplicationContext");
+        }
 
         var n = new AndroidNotification();
         n.Title = "SendNotification_CanReschedule";

--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
@@ -184,7 +184,7 @@ class AndroidNotificationSendingTests
         var status = AndroidNotificationCenter.CheckScheduledNotificationStatus(originalId);
         Assert.AreEqual(NotificationStatus.Scheduled, status);
 
-        yield return WaitForNotification(8.0f);
+        yield return WaitForNotification(120.0f);
         status = AndroidNotificationCenter.CheckScheduledNotificationStatus(originalId);
         Assert.AreEqual(NotificationStatus.Delivered, status);
 

--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
@@ -185,6 +185,7 @@ class AndroidNotificationSendingTests
         Assert.AreEqual(NotificationStatus.Scheduled, status);
 
         yield return WaitForNotification(120.0f);
+        yield return new WaitForSeconds(1.0f);  // give some time for Status Bar to update
         status = AndroidNotificationCenter.CheckScheduledNotificationStatus(originalId);
         Assert.AreEqual(NotificationStatus.Delivered, status);
 

--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSimpleTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSimpleTests.cs
@@ -6,15 +6,15 @@ using Unity.Notifications.Android;
 
 class AndroidNotificationSimpleTests
 {
-    const string kChannelId = "SerializeDeserializeNotificationIntentChannel";
+    const string kChannelId = "SerializeDeserializeNotificationChannel";
 
     [OneTimeSetUp]
     public void BeforeAllTests()
     {
         var c = new AndroidNotificationChannel();
         c.Id = kChannelId;
-        c.Name = "SerializeDeserializeNotificationIntent channel";
-        c.Description = "SerializeDeserializeNotificationIntent channel";
+        c.Name = "SerializeDeserializeNotification channel";
+        c.Description = "SerializeDeserializeNotification channel";
         c.Importance = Importance.High;
         AndroidNotificationCenter.RegisterNotificationChannel(c);
     }
@@ -240,56 +240,51 @@ class AndroidNotificationSimpleTests
         Assert.AreEqual(original.FireTime.ToString(), deserializedData.Notification.FireTime.ToString());
     }
 
-    AndroidNotificationIntentData SerializeDeserializeNotificationIntent(AndroidNotification original, int notificationId, Action<AndroidJavaObject> inBetween = null)
+    AndroidNotificationIntentData SerializeDeserializeNotification(AndroidNotification original, int notificationId, Action<AndroidJavaObject> inBetween = null)
     {
         using (var builder = AndroidNotificationCenter.CreateNotificationBuilder(notificationId, original, kChannelId))
         {
-            return SerializeDeserializeNotificationIntent(builder, inBetween);
+            return SerializeDeserializeNotification(builder, inBetween);
         }
     }
 
-    AndroidNotificationIntentData SerializeDeserializeNotificationIntent(AndroidJavaObject builder, Action<AndroidJavaObject> inBetween = null)
+    AndroidNotificationIntentData SerializeDeserializeNotification(AndroidJavaObject builder, Action<AndroidJavaObject> inBetween = null)
     {
         var managerClass = new AndroidJavaClass("com.unity.androidnotifications.UnityNotificationManager");
         var unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer");
         var activity = unityPlayer.GetStatic<AndroidJavaObject>("currentActivity");
         var context = activity.Call<AndroidJavaObject>("getApplicationContext");
-        var intent = new AndroidJavaObject("android.content.Intent", context, managerClass);
         var javaNotif = builder.Call<AndroidJavaObject>("build");
-        intent.Call<AndroidJavaObject>("putExtra", "unityNotification", javaNotif).Dispose();
         var utilsClass = new AndroidJavaClass("com.unity.androidnotifications.UnityNotificationUtilities");
 
-        // context.GetStatic<int>("MODE_PRIVATE") fails on older android, did investigate why, simply using it's value from docs
         var prefs = context.Call<AndroidJavaObject>("getSharedPreferences", "android.notification.test.key", 0 /* MODE_PRIVATE */);
-        utilsClass.CallStatic("serializeNotificationIntent", prefs, intent);
+        utilsClass.CallStatic("serializeNotification", prefs, javaNotif);
 
         if (inBetween != null)
             inBetween(prefs);
 
-        var deserializedIntent = utilsClass.CallStatic<AndroidJavaObject>("deserializeNotificationIntent", context, prefs);
-        Assert.IsNotNull(deserializedIntent);
+        var deserializedNotification = utilsClass.CallStatic<AndroidJavaObject>("deserializeNotification", context, prefs);
         // don't dispose notification, it is kept in AndroidNotificationIntentData
-        var deserializedNotification = deserializedIntent.Call<AndroidJavaObject>("getParcelableExtra", "unityNotification");
         Assert.IsNotNull(deserializedNotification);
         return AndroidNotificationCenter.GetNotificationData(deserializedNotification);
     }
 
     [Test]
     [UnityPlatform(RuntimePlatform.Android)]
-    public void NotificationIntentSerialization_SimpleNotification()
+    public void NotificationSerialization_SimpleNotification()
     {
         const int notificationId = 1234;
 
         var original = new AndroidNotification();
         original.FireTime = DateTime.Now.AddSeconds(2);
 
-        var deserializedData = SerializeDeserializeNotificationIntent(original, notificationId);
+        var deserializedData = SerializeDeserializeNotification(original, notificationId);
         Assert.AreEqual(original.FireTime.ToString(), deserializedData.Notification.FireTime.ToString());
     }
 
     [Test]
     [UnityPlatform(RuntimePlatform.Android)]
-    public void NotificationIntentSerialization_NotificationWithBinderObject()
+    public void NotificationSerialization_NotificationWithBinderObject()
     {
         const int notificationId = 1234;
 
@@ -302,7 +297,7 @@ class AndroidNotificationSimpleTests
         Assert.IsNotNull(bitmap);
         extras.Call("putParcelable", "binder_item", bitmap);
 
-        var deserializedData = SerializeDeserializeNotificationIntent(builder);
+        var deserializedData = SerializeDeserializeNotification(builder);
 
         Assert.AreEqual(original.FireTime.ToString(), deserializedData.Notification.FireTime.ToString());
         var deserializedExtras = deserializedData.NativeNotification.Get<AndroidJavaObject>("extras");
@@ -355,9 +350,7 @@ class AndroidNotificationSimpleTests
         var serialized = parcel.Call<AndroidJavaObject>("marshall");
         Assert.IsNotNull(serialized);
 
-        var deserialized = utilsClass.CallStatic<AndroidJavaObject>("deserializeNotificationIntent", context, serialized);
-        Assert.IsNotNull(deserialized);
-        var deserializedNotification = deserialized.Call<AndroidJavaObject>("getParcelableExtra", "unityNotification");
+        var deserializedNotification = utilsClass.CallStatic<AndroidJavaObject>("deserializeNotification", context, serialized);
         Assert.IsNotNull(deserializedNotification);
         var notificationData = AndroidNotificationCenter.GetNotificationData(deserializedNotification);
         Assert.IsNotNull(notificationData);
@@ -439,7 +432,7 @@ class AndroidNotificationSimpleTests
         original.FireTime = DateTime.Now;
         original.LargeIcon = "large_icon";
 
-        var deserializedData = SerializeDeserializeNotificationIntent(original, notificationId, (prefs) =>
+        var deserializedData = SerializeDeserializeNotification(original, notificationId, (prefs) =>
         {
             var data = prefs.Call<string>("getString", "data", "");
             // corrupt data

--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSimpleTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSimpleTests.cs
@@ -136,9 +136,13 @@ class AndroidNotificationSimpleTests
         {
             var dataStream = new AndroidJavaObject("java.io.DataInputStream", byteStream);
             // don't dispose notification, it is kept in AndroidNotificationIntentData
-            var deserializedNotification = utilsClass.CallStatic<AndroidJavaObject>("deserializeNotificationCustom", dataStream);
-            Assert.IsNotNull(deserializedNotification);
-            return AndroidNotificationCenter.GetNotificationData(deserializedNotification);
+            using (var deserializedNotificationBuilder = utilsClass.CallStatic<AndroidJavaObject>("deserializeNotificationCustom", dataStream))
+            {
+                Assert.IsNotNull(deserializedNotificationBuilder);
+                var deserializedNotification = deserializedNotificationBuilder.Call<AndroidJavaObject>("build");
+                Assert.IsNotNull(deserializedNotification);
+                return AndroidNotificationCenter.GetNotificationData(deserializedNotification);
+            }
         }
     }
 
@@ -263,8 +267,10 @@ class AndroidNotificationSimpleTests
         if (inBetween != null)
             inBetween(prefs);
 
-        var deserializedNotification = utilsClass.CallStatic<AndroidJavaObject>("deserializeNotification", context, prefs);
+        var deserializedNotificationBuilder = utilsClass.CallStatic<AndroidJavaObject>("deserializeNotification", context, prefs);
         // don't dispose notification, it is kept in AndroidNotificationIntentData
+        Assert.IsNotNull(deserializedNotificationBuilder);
+        var deserializedNotification = deserializedNotificationBuilder.Call<AndroidJavaObject>("build");
         Assert.IsNotNull(deserializedNotification);
         return AndroidNotificationCenter.GetNotificationData(deserializedNotification);
     }
@@ -350,7 +356,9 @@ class AndroidNotificationSimpleTests
         var serialized = parcel.Call<AndroidJavaObject>("marshall");
         Assert.IsNotNull(serialized);
 
-        var deserializedNotification = utilsClass.CallStatic<AndroidJavaObject>("deserializeNotification", context, serialized);
+        var deserializedNotificationBuilder = utilsClass.CallStatic<AndroidJavaObject>("deserializeNotification", context, serialized);
+        Assert.IsNotNull(deserializedNotificationBuilder);
+        var deserializedNotification = deserializedNotificationBuilder.Call<AndroidJavaObject>("build");
         Assert.IsNotNull(deserializedNotification);
         var notificationData = AndroidNotificationCenter.GetNotificationData(deserializedNotification);
         Assert.IsNotNull(notificationData);


### PR DESCRIPTION
Few issues related to this:
https://fogbugz.unity3d.com/f/cases/1404251/
https://github.com/Unity-Technologies/com.unity.mobile.notifications/issues/144

The problem is that current design saves Notification object in Intent that is passed to alarm manger and then back to app and then sent to notification manager carrying a copy of itself in intent. For notifications with more stuff in them (like larger icons) on some devices we hit limitation and notification is rejected by OS.
The main change is that now we cache notifications in our notification manager and only pass around ID.
Other changes:
- deserialization now returns an Object which either Notification or Notification.Builder (depending on which code path was actually hit). Previously we always returned Intent with Notification in it, which meant that sometimes we would deserialize the builder, build notification and put it into newly created intent, while the calling code actually needs builder and needs to recover it from notification; now it is a bit more complicated, but also more efficient (we don't build notification when calling code does not need it).
- much more code reuse (for example rescheduling after boot now is very trivial)
- expanded tests to cover more (not everything is possible, but at least we cover more of what we can)

Notes for QA:
- Android only
- changes affect notification sending/(re)scheduling; different notification types unlikely to be affected, what matters is whether we actually get notifications
- important to check Android versions older than 8, since there is important difference in code at 8 (different internal implementation due to API availibility)
- try playing around with target and min SDK, changing those can have impact
- it's entirely certain, which devices have problems with heavy notifications, but older weaker devices is a better bet; a bug reproduces with Samsung Galaxy S7 (Android 7.0), but users report that some Android 12 devices are affected too
Tested by developer:
- I did not use project from case 1404251, instead had my own which sends notification and checked that it no longer reproduces on Galaxy S7 (actually it's a simple notification with large icon, icon used from issue 151); recommended to reproduce it and then check if fixed
- Manually checked the sample project from package on Nokia 7 Plus (10.0), Asus ROG (8.1) and Galaxy S7 (7.0)
- Ran automated suite on same 3 devices + Yamato
- Added automated test that "simulates" reboot: it cancels notifications on Android side and triggers the rescheduling code, should roughly simulate what happens during actual reboot, though still not the real reboot