### PR TITLE
Add ShowInForeground boolean feature for Android notifications.

### DIFF
--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotification.cs
@@ -177,6 +177,11 @@ namespace Unity.Notifications.Android
             }
         }
 
+        /// <summary>
+        /// Set this notification to be shown when app is in the foreground.
+        /// </summary>
+        public bool ShowInForeground { get; set; }
+
         internal bool ShowCustomTimestamp { get; set; }
 
         private Color m_Color;
@@ -208,6 +213,7 @@ namespace Unity.Notifications.Android
             GroupAlertBehaviour = GroupAlertBehaviours.GroupAlertAll;
             ShowTimestamp = false;
             ShowCustomTimestamp = false;
+            ShowInForeground = true;
 
             m_RepeatInterval = (-1L).ToTimeSpan();
             m_Color = new Color(0, 0, 0, 0);

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -66,6 +66,7 @@ namespace Unity.Notifications.Android
         private static AndroidJavaObject KEY_REPEAT_INTERVAL;
         private static AndroidJavaObject KEY_NOTIFICATION;
         private static AndroidJavaObject KEY_SMALL_ICON;
+        private static AndroidJavaObject SHOW_IN_FOREGROUND;
 
         /// <summary>
         /// Initialize the AndroidNotificationCenter class.
@@ -115,6 +116,7 @@ namespace Unity.Notifications.Android
             KEY_REPEAT_INTERVAL = s_NotificationManagerClass.GetStatic<AndroidJavaObject>("KEY_REPEAT_INTERVAL");
             KEY_NOTIFICATION = s_NotificationManagerClass.GetStatic<AndroidJavaObject>("KEY_NOTIFICATION");
             KEY_SMALL_ICON = s_NotificationManagerClass.GetStatic<AndroidJavaObject>("KEY_SMALL_ICON");
+            SHOW_IN_FOREGROUND = s_NotificationManagerClass.GetStatic<AndroidJavaObject>("SHOW_IN_FOREGROUND");
 
             s_Initialized = true;
 #endif
@@ -467,6 +469,7 @@ namespace Unity.Notifications.Android
                 extras.Call("putInt", KEY_ID, id);
                 extras.Call("putLong", KEY_REPEAT_INTERVAL, notification.RepeatInterval.ToLong());
                 extras.Call("putLong", KEY_FIRE_TIME, fireTime);
+                extras.Call("putBoolean", SHOW_IN_FOREGROUND, notification.ShowInForeground);
                 if (!string.IsNullOrEmpty(notification.IntentData))
                     extras.Call("putString", KEY_INTENT_DATA, notification.IntentData);
             }
@@ -494,6 +497,7 @@ namespace Unity.Notifications.Android
                 notification.UsesStopwatch = extras.Call<bool>("getBoolean", Notification_EXTRA_SHOW_CHRONOMETER, false);
                 notification.FireTime = extras.Call<long>("getLong", KEY_FIRE_TIME, -1L).ToDatetime();
                 notification.RepeatInterval = extras.Call<long>("getLong", KEY_REPEAT_INTERVAL, -1L).ToTimeSpan();
+                notification.ShowInForeground = extras.Call<bool>("getBoolean", SHOW_IN_FOREGROUND, false);
 
                 if (extras.Call<bool>("containsKey", Notification_EXTRA_BIG_TEXT))
                     notification.Style = NotificationStyle.BigTextStyle;


### PR DESCRIPTION
Hi,

Android notification pop-ups are shown even when app is on the foreground if it is received on a notification channel with high priority. However, there can be cases that behaviour is wanted to be aligned with iOS. This was the case for our game teams. Therefore, we patched your code to have a "ShowInForeground" flag for local notifications as well and I wanted to share the solution with you here.

- With ShowInForeground option, it is possible not to show notification pop-ups if app is on the foreground
- Related callbacks about receiving notification will still be called

Similar PR was opened before but we couldn't maintain it because of reasons. Now, I am open for any feedback to improve and merge this PR.

Bests,
Seref