### PR TITLE
Backport fixes to 1.4

### DIFF
--- a/TestProjects/com.unity.mobile-notifications-sample/Scripts/AndroidTest.cs
+++ b/TestProjects/com.unity.mobile-notifications-sample/Scripts/AndroidTest.cs
@@ -77,6 +77,7 @@ namespace Unity.Notifications.Tests.Sample
             ((Action)m_groups["Channels"]["Create Secondary Simple Channel"]).Invoke();
             ((Action)m_groups["Channels"]["Create Fancy Channel"]).Invoke();
             m_LOGGER.Clear().White("Welcome!");
+            HandleLastNotificationIntent();
         }
 
         void OnApplicationPause(bool isPaused)

--- a/com.unity.mobile.notifications/Editor/NotificationSettingsManager.cs
+++ b/com.unity.mobile.notifications/Editor/NotificationSettingsManager.cs
@@ -279,9 +279,9 @@ namespace Unity.Notifications
                 var scale = drawableResource.Type == NotificationIconType.Small ? 0.375f : 1;
 
                 var textXhdpi = TextureAssetUtils.ScaleTexture(texture, (int)(128 * scale), (int)(128 * scale));
-                var textHdpi  = TextureAssetUtils.ScaleTexture(texture, (int)(96 * scale), (int)(96 * scale));
-                var textMdpi  = TextureAssetUtils.ScaleTexture(texture, (int)(64 * scale), (int)(64 * scale));
-                var textLdpi  = TextureAssetUtils.ScaleTexture(texture, (int)(48 * scale), (int)(48 * scale));
+                var textHdpi = TextureAssetUtils.ScaleTexture(texture, (int)(96 * scale), (int)(96 * scale));
+                var textMdpi = TextureAssetUtils.ScaleTexture(texture, (int)(64 * scale), (int)(64 * scale));
+                var textLdpi = TextureAssetUtils.ScaleTexture(texture, (int)(48 * scale), (int)(48 * scale));
 
                 icons[string.Format("drawable-xhdpi-v11/{0}.png", drawableResource.Id)] = textXhdpi.EncodeToPNG();
                 icons[string.Format("drawable-hdpi-v11/{0}.png", drawableResource.Id)] = textHdpi.EncodeToPNG();

--- a/com.unity.mobile.notifications/Editor/NotificationSettingsProvider.cs
+++ b/com.unity.mobile.notifications/Editor/NotificationSettingsProvider.cs
@@ -20,7 +20,7 @@ namespace Unity.Notifications
         private readonly GUIContent k_IdentifierLabelText = new GUIContent("Identifier");
         private readonly GUIContent k_TypeLabelText = new GUIContent("Type");
 
-        private readonly string[] k_ToolbarStrings = {"Android", "iOS"};
+        private readonly string[] k_ToolbarStrings = { "Android", "iOS" };
         private const string k_InfoStringAndroid =
             "Only icons added to this list or manually added to the 'res/drawable' folder can be used for notifications.\n" +
             "Note, that not all devices support colored icons.\n\n" +

--- a/com.unity.mobile.notifications/Editor/TextureAssetUtils.cs
+++ b/com.unity.mobile.notifications/Editor/TextureAssetUtils.cs
@@ -71,7 +71,7 @@ namespace Unity.Notifications
             if (type == NotificationIconType.Small)
             {
                 texture = new Texture2D(sourceTexture.width, sourceTexture.height, TextureFormat.RGBA32, true, false);
-                for (var i  = 0; i < sourceTexture.mipmapCount; i++)
+                for (var i = 0; i < sourceTexture.mipmapCount; i++)
                 {
                     var c_0 = sourceTexture.GetPixels(i);
                     var c_1 = texture.GetPixels(i);

--- a/com.unity.mobile.notifications/QAReport.md
+++ b/com.unity.mobile.notifications/QAReport.md
@@ -8,7 +8,7 @@
 ## Test strategy
 
 Project is getting tested every months or so manually by doing exploratory testing or TestRails driven testing
-Most recent TestRails testing (2020-10-14): https://qatestrail.hq.unity3d.com/index.php?/runs/view/26024&group_by=cases:section_id&group_id=78000&group_order=asc <br/> 
+Most recent TestRails testing (2020-10-14): https://qatestrail.hq.unity3d.com/index.php?/runs/view/26024&group_by=cases:section_id&group_id=78000&group_order=asc <br/>
 Current issues: <br/>
 public: https://github.com/Unity-Technologies/com.unity.mobile.notifications/issues <br/>
 Internal: https://fogbugz.unity3d.com/f/search/?sSearchFor=mobile+notifications+status%3Aactive+category%3ABug <br/>
@@ -20,9 +20,9 @@ https://docs.google.com/document/d/1B9RfS0kEuYLAvveg2oviXdaPKbtBuo5m6BlzrtPqkQ4/
 ## Package Status
 
  Quality status: good
- 
+
  Still has a number of issues, but for the most part the package is able to serve it's purpose
  The project could also benefit from automated tests.
- 
- 
+
+
  Related project: notification samples (extra samples that can be imported to Unity for the users to better grasp the workflow of Notifications): https://github.com/Unity-Technologies/NotificationsSamples

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotification.cs
@@ -186,6 +186,9 @@ namespace Unity.Notifications.Android
         /// <summary>
         /// Create a notification struct with all optional fields set to default values.
         /// </summary>
+        /// <param name="title">Notification title</param>
+        /// <param name="text">Text to show on notification</param>
+        /// <param name="fireTime">Date and time when to show, can be DateTime.Now to show right away</param>
         public AndroidNotification(string title, string text, DateTime fireTime)
         {
             Title = title;
@@ -214,6 +217,10 @@ namespace Unity.Notifications.Android
         /// <summary>
         /// Create a repeatable notification struct with all optional fields set to default values.
         /// </summary>
+        /// <param name="title">Notification title</param>
+        /// <param name="text">Text to show on notification</param>
+        /// <param name="fireTime">Date and time when to show, can be DateTime.Now to show right away</param>
+        /// <param name="repeatInterval">Makes notification repeatable with this time interval</param>
         /// <remarks>
         /// There is a minimum period of 1 minute for repeating notifications.
         /// </remarks>
@@ -226,6 +233,11 @@ namespace Unity.Notifications.Android
         /// <summary>
         /// Create a notification struct with a custom small icon and all optional fields set to default values.
         /// </summary>
+        /// <param name="title">Notification title</param>
+        /// <param name="text">Text to show on notification</param>
+        /// <param name="fireTime">Date and time when to show, can be DateTime.Now to show right away</param>
+        /// <param name="repeatInterval">Makes notification repeatable with this time interval</param>
+        /// <param name="smallIcon">Name of the small icon to be shown on notification</param>
         public AndroidNotification(string title, string text, DateTime fireTime, TimeSpan repeatInterval, string smallIcon)
             : this(title, text, fireTime, repeatInterval)
         {

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCallback.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCallback.cs
@@ -10,7 +10,7 @@ namespace Unity.Notifications.Android
 
         public void onSentNotification(AndroidJavaObject notificationIntent)
         {
-            AndroidReceivedNotificationMainThreadDispatcher.EnqueueReceivedNotification(notificationIntent);
+            AndroidReceivedNotificationMainThreadDispatcher.GetInstance().EnqueueReceivedNotification(notificationIntent);
         }
     }
 }

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -44,7 +44,7 @@ namespace Unity.Notifications.Android
         /// <summary>
         /// Subscribe to this event to receive callbacks whenever a scheduled notification is shown to the user.
         /// </summary>
-        public static event NotificationReceivedCallback OnNotificationReceived = delegate {};
+        public static event NotificationReceivedCallback OnNotificationReceived = delegate { };
 
         private static AndroidJavaClass s_NotificationManagerClass;
         private static AndroidJavaObject s_NotificationManager;

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -54,7 +54,9 @@ namespace Unity.Notifications.Android
 
         /// <summary>
         /// Initialize the AndroidNotificationCenter class.
+        /// Can be safely called multiple times
         /// </summary>
+        /// <returns>True if has been successfully initialized</returns>
         public static bool Initialize()
         {
             if (s_Initialized)
@@ -93,6 +95,7 @@ namespace Unity.Notifications.Android
         ///  On older Android versions settings set on the notification channel struct will still be applied to the notification
         ///  if they are supported to by the Android version the app is running on.
         /// </summary>
+        /// <param name="channel">Channel parameters</param>
         /// <remarks>
         ///  When a channel is deleted and recreated, all of the previous settings are restored. In order to change any settings
         ///  besides the name or description an entirely new channel (with a different channel ID) must be created.
@@ -133,6 +136,8 @@ namespace Unity.Notifications.Android
         /// Returns the notification channel with the specified id.
         /// The notification channel struct fields might not be identical to the channel struct used to initially register the channel if they were changed by the user.
         /// </summary>
+        /// <param name="channelId">ID of the channel to retrieve</param>
+        /// <returns>Channel with given ID or empty struct if such channel does not exist</returns>
         public static AndroidNotificationChannel GetNotificationChannel(string channelId)
         {
             return GetNotificationChannels().SingleOrDefault(channel => channel.Id == channelId);
@@ -141,6 +146,7 @@ namespace Unity.Notifications.Android
         /// <summary>
         /// Returns all notification channels that were created by the app.
         /// </summary>
+        /// <returns>All existing channels</returns>
         public static AndroidNotificationChannel[] GetNotificationChannels()
         {
             if (!Initialize())
@@ -173,6 +179,7 @@ namespace Unity.Notifications.Android
         /// <summary>
         /// Delete the specified notification channel.
         /// </summary>
+        /// <param name="channelId">ID of the channel to delete</param>
         public static void DeleteNotificationChannel(string channelId)
         {
             if (Initialize())
@@ -183,6 +190,9 @@ namespace Unity.Notifications.Android
         /// Schedule a notification which will be shown at the time specified in the notification struct.
         /// The returned id can later be used to update the notification before it's triggered, it's current status can be tracked using CheckScheduledNotificationStatus.
         /// </summary>
+        /// <param name="notification">Data for the notification</param>
+        /// <param name="channelId">ID of the channel to send notification to</param>
+        /// <returns>The generated ID for the notification</returns>
         public static int SendNotification(AndroidNotification notification, string channelId)
         {
             if (!Initialize())
@@ -198,6 +208,9 @@ namespace Unity.Notifications.Android
         /// Schedule a notification which will be shown at the time specified in the notification struct.
         /// The specified id can later be used to update the notification before it's triggered, it's current status can be tracked using CheckScheduledNotificationStatus.
         /// </summary>
+        /// <param name="notification">Data for the notification</param>
+        /// <param name="channelId">ID of the channel to send notification to</param>
+        /// <param name="id">A unique ID for the notification</param>
         public static void SendNotificationWithExplicitID(AndroidNotification notification, string channelId, int id)
         {
             if (Initialize())
@@ -208,6 +221,9 @@ namespace Unity.Notifications.Android
         /// Update an already scheduled notification.
         /// If a notification with the specified id was already scheduled it will be overridden with the information from the passed notification struct.
         /// </summary>
+        /// <param name="id">ID of the notification to update</param>
+        /// <param name="notification">Data for the notification</param>
+        /// <param name="channelId">ID of the channel to send notification to</param>
         public static void UpdateScheduledNotification(int id, AndroidNotification notification, string channelId)
         {
             if (!Initialize())
@@ -221,6 +237,7 @@ namespace Unity.Notifications.Android
         /// Cancel a scheduled or previously shown notification.
         /// The notification will no longer be displayed on it's scheduled time. If it's already delivered it will be removed from the status bar.
         /// </summary>
+        /// <param name="id">ID of the notification to cancel</param>
         public static void CancelNotification(int id)
         {
             if (!Initialize())
@@ -234,6 +251,7 @@ namespace Unity.Notifications.Android
         /// Cancel a scheduled notification.
         /// The notification will no longer be displayed on it's scheduled time. It it will not be removed from the status bar if it's already delivered.
         /// </summary>
+        /// <param name="id">ID of the notification to cancel</param>
         public static void CancelScheduledNotification(int id)
         {
             if (Initialize())
@@ -244,6 +262,7 @@ namespace Unity.Notifications.Android
         /// Cancel a previously shown notification.
         /// The notification will be removed from the status bar.
         /// </summary>
+        /// <param name="id">ID of the notification to cancel</param>
         public static void CancelDisplayedNotification(int id)
         {
             if (Initialize())
@@ -287,6 +306,8 @@ namespace Unity.Notifications.Android
         /// Return the status of a scheduled notification.
         /// Only available in API  23 and above.
         /// </summary>
+        /// <param name="id">ID of the notification to check</param>
+        /// <returns>The status of the notification</returns>
         public static NotificationStatus CheckScheduledNotificationStatus(int id)
         {
             if (!Initialize())

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationChannel.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationChannel.cs
@@ -132,6 +132,10 @@ namespace Unity.Notifications.Android
         /// <summary>
         /// Create a notification channel struct with all optional fields set to default values.
         /// </summary>
+        /// <param name="id">ID for the channel</param>
+        /// <param name="name">Channel name</param>
+        /// <param name="description">Channel description</param>
+        /// <param name="importance">Importance of the channel</param>
         public AndroidNotificationChannel(string id, string name, string description, Importance importance)
         {
             Id = id;

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationIntentData.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationIntentData.cs
@@ -25,6 +25,9 @@ namespace Unity.Notifications.Android
         /// <summary>
         /// Create an AndroidNotificationIntentData with AndroidNotification, id, and channel id.
         /// </summary>
+        /// <param name="id">Notification id</param>
+        /// <param name="channelId">ID of the notification channel</param>
+        /// <param name="notification">Data of the received notification</param>
         public AndroidNotificationIntentData(int id, string channelId, AndroidNotification notification)
         {
             Id = id;

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidReceivedNotificationMainThreadDispatcher.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidReceivedNotificationMainThreadDispatcher.cs
@@ -10,15 +10,15 @@ namespace Unity.Notifications.Android
     {
         private static AndroidReceivedNotificationMainThreadDispatcher instance = null;
 
-        private static List<AndroidJavaObject> s_ReceivedNotificationQueue = new List<AndroidJavaObject>();
+        private List<AndroidJavaObject> m_ReceivedNotificationQueue = new List<AndroidJavaObject>();
 
-        private static List<AndroidJavaObject> s_ReceivedNotificationList = new List<AndroidJavaObject>();
+        private List<AndroidJavaObject> m_ReceivedNotificationList = new List<AndroidJavaObject>();
 
-        internal static void EnqueueReceivedNotification(AndroidJavaObject intent)
+        internal void EnqueueReceivedNotification(AndroidJavaObject intent)
         {
-            lock (instance)
+            lock (this)
             {
-                s_ReceivedNotificationQueue.Add(intent);
+                m_ReceivedNotificationQueue.Add(intent);
             }
         }
 
@@ -34,19 +34,19 @@ namespace Unity.Notifications.Android
         {
             // Note: Don't call callbacks while locking receivedNotificationQueue, otherwise there's a risk
             //       that callback might introduce an operations which would create a deadlock
-            lock (instance)
+            lock (this)
             {
-                var temp = s_ReceivedNotificationQueue;
-                s_ReceivedNotificationQueue = s_ReceivedNotificationList;
-                s_ReceivedNotificationList = temp;
+                var temp = m_ReceivedNotificationQueue;
+                m_ReceivedNotificationQueue = m_ReceivedNotificationList;
+                m_ReceivedNotificationList = temp;
             }
 
-            foreach (var notification in s_ReceivedNotificationList)
+            foreach (var notification in m_ReceivedNotificationList)
             {
                 AndroidNotificationCenter.ReceivedNotificationCallback(notification);
             }
 
-            s_ReceivedNotificationList.Clear();
+            m_ReceivedNotificationList.Clear();
         }
 
         void Awake()

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidReceivedNotificationMainThreadDispatcher.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidReceivedNotificationMainThreadDispatcher.cs
@@ -36,6 +36,8 @@ namespace Unity.Notifications.Android
             //       that callback might introduce an operations which would create a deadlock
             lock (this)
             {
+                if (m_ReceivedNotificationQueue.Count == 0)
+                    return;
                 var temp = m_ReceivedNotificationQueue;
                 m_ReceivedNotificationQueue = m_ReceivedNotificationList;
                 m_ReceivedNotificationList = temp;

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCenter.cs
@@ -94,6 +94,7 @@ namespace Unity.Notifications.iOS
         /// <summary>
         /// Schedules a local notification for delivery.
         /// </summary>
+        /// <param name="notification">Notification to schedule</param>
         public static void ScheduleNotification(iOSNotification notification)
         {
             if (!Initialize())
@@ -105,6 +106,7 @@ namespace Unity.Notifications.iOS
         /// <summary>
         /// Returns all notifications that are currently scheduled.
         /// </summary>
+        /// <returns>Array of scheduled notifications</returns>
         public static iOSNotification[] GetScheduledNotifications()
         {
             return NotificationDataToNotifications(iOSNotificationsWrapper.GetScheduledNotificationData());
@@ -113,6 +115,7 @@ namespace Unity.Notifications.iOS
         /// <summary>
         /// Returns all of the app's delivered notifications that are currently shown in the Notification Center.
         /// </summary>
+        /// <returns>Array of delivered notifications</returns>
         public static iOSNotification[] GetDeliveredNotifications()
         {
             return NotificationDataToNotifications(iOSNotificationsWrapper.GetDeliveredNotificationData());
@@ -147,6 +150,7 @@ namespace Unity.Notifications.iOS
         /// <summary>
         /// Unschedules the specified notification.
         /// </summary>
+        /// <param name="identifier">Identifier for the notification to be removed</param>
         public static void RemoveScheduledNotification(string identifier)
         {
             if (Initialize())
@@ -156,6 +160,7 @@ namespace Unity.Notifications.iOS
         /// <summary>
         /// Removes the specified notification from Notification Center.
         /// </summary>
+        /// <param name="identifier">Identifier for the notification to be removed</param>
         public static void RemoveDeliveredNotification(string identifier)
         {
             if (Initialize())
@@ -183,6 +188,7 @@ namespace Unity.Notifications.iOS
         /// <summary>
         /// Get the notification settings for this app.
         /// </summary>
+        /// <returns>Notification settings</returns>
         public static iOSNotificationSettings GetNotificationSettings()
         {
             return iOSNotificationsWrapper.GetNotificationSettings();

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCenter.cs
@@ -36,7 +36,7 @@ namespace Unity.Notifications.iOS
         }
 
         private static bool s_OnNotificationReceivedCallbackSet;
-        private static event NotificationReceivedCallback s_OnNotificationReceived = delegate {};
+        private static event NotificationReceivedCallback s_OnNotificationReceived = delegate { };
 
         /// <summary>
         /// Subscribe to this event to receive a callback whenever a remote notification is received while the app is in foreground,
@@ -64,7 +64,7 @@ namespace Unity.Notifications.iOS
         }
 
         private static bool s_OnRemoteNotificationReceivedCallbackSet;
-        private static event NotificationReceivedCallback s_OnRemoteNotificationReceived = delegate {};
+        private static event NotificationReceivedCallback s_OnRemoteNotificationReceived = delegate { };
 
         internal delegate void AuthorizationRequestCompletedCallback(iOSAuthorizationRequestData data);
 

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationTriggers.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationTriggers.cs
@@ -14,7 +14,7 @@ namespace Unity.Notifications.iOS
     /// <summary>
     /// iOSNotificationTrigger interface is implemented by notification trigger types representing an event that triggers the delivery of a notification.
     /// </summary>
-    public interface iOSNotificationTrigger {}
+    public interface iOSNotificationTrigger { }
 
     /// <summary>
     /// A trigger condition that causes a notification to be delivered when the user's device enters or exits the specified geographic region.

--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationTests.cs
@@ -81,7 +81,7 @@ class AndroidNotificationTests
 
 
         AndroidNotificationCenter.NotificationReceivedCallback receivedNotificationHandler =
-            delegate(AndroidNotificationIntentData data)
+            delegate (AndroidNotificationIntentData data)
         {
             receivedNotificationCount += 1;
             Assert.AreEqual(originalId, data.Id);
@@ -93,7 +93,7 @@ class AndroidNotificationTests
 
         yield return new WaitForSeconds(8.0f);
 
-        Debug.LogWarning("SendNotification_NotificationIsReceived:::   Assert.AreEqual(1, receivedNotificationCount) receivedNotificationCount: "  + receivedNotificationCount.ToString());
+        Debug.LogWarning("SendNotification_NotificationIsReceived:::   Assert.AreEqual(1, receivedNotificationCount) receivedNotificationCount: " + receivedNotificationCount.ToString());
 
         Assert.AreEqual(1, receivedNotificationCount);
 
@@ -133,7 +133,7 @@ class AndroidNotificationTests
 
 
         AndroidNotificationCenter.NotificationReceivedCallback receivedNotificationHandler =
-            delegate(AndroidNotificationIntentData data)
+            delegate (AndroidNotificationIntentData data)
         {
             receivedNotificationCount += 1;
             Assert.AreEqual(originalId, data.Id);
@@ -144,7 +144,7 @@ class AndroidNotificationTests
 
         yield return new WaitForSeconds(8.0f);
 
-        Debug.LogWarning("SendNotification_NotificationIsReceived:::   Assert.AreEqual(1, receivedNotificationCount) receivedNotificationCount: "  + receivedNotificationCount.ToString());
+        Debug.LogWarning("SendNotification_NotificationIsReceived:::   Assert.AreEqual(1, receivedNotificationCount) receivedNotificationCount: " + receivedNotificationCount.ToString());
 
         Assert.AreEqual(1, receivedNotificationCount);
 
@@ -184,7 +184,7 @@ class AndroidNotificationTests
         AndroidNotificationCenter.CancelAllNotifications();
 
         AndroidNotificationCenter.NotificationReceivedCallback receivedNotificationHandler =
-            delegate(AndroidNotificationIntentData data)
+            delegate (AndroidNotificationIntentData data)
         {
             receivedNotificationCount += 1;
             Assert.AreEqual(originalId, data.Id);
@@ -194,7 +194,7 @@ class AndroidNotificationTests
 
         yield return new WaitForSeconds(6.0f);
 
-        Debug.LogWarning("SendNotification_NotificationIsReceived:::   Assert.AreEqual(1, receivedNotificationCount) receivedNotificationCount: "  + receivedNotificationCount.ToString());
+        Debug.LogWarning("SendNotification_NotificationIsReceived:::   Assert.AreEqual(1, receivedNotificationCount) receivedNotificationCount: " + receivedNotificationCount.ToString());
 
         Assert.AreEqual(0, receivedNotificationCount);
 
@@ -203,7 +203,7 @@ class AndroidNotificationTests
         receivedNotificationCount = 0;
     }
 
-//    [UnityTest]
+    //    [UnityTest]
     public IEnumerator ScheduleRepeatableNotification_NotificationsAreReceived()
     {
         AndroidNotificationCenter.CancelAllNotifications();
@@ -226,7 +226,7 @@ class AndroidNotificationTests
         int originalId = AndroidNotificationCenter.SendNotification(n, "default_test_channel_2");
 
         AndroidNotificationCenter.NotificationReceivedCallback receivedNotificationHandler =
-            delegate(AndroidNotificationIntentData data)
+            delegate (AndroidNotificationIntentData data)
         {
             receivedNotificationCount += 1;
             Assert.AreEqual(originalId, data.Id);
@@ -359,7 +359,7 @@ class AndroidNotificationTests
 
 
         AndroidNotificationCenter.NotificationReceivedCallback receivedNotificationHandler =
-            delegate(AndroidNotificationIntentData data)
+            delegate (AndroidNotificationIntentData data)
         {
             receivedNotificationCount += 1;
 
@@ -375,7 +375,7 @@ class AndroidNotificationTests
 
         yield return new WaitForSeconds(8.0f);
 
-        Debug.LogWarning("SendNotification_NotificationIsReceived:::   Assert.AreEqual(1, receivedNotificationCount) receivedNotificationCount: "  + receivedNotificationCount.ToString());
+        Debug.LogWarning("SendNotification_NotificationIsReceived:::   Assert.AreEqual(1, receivedNotificationCount) receivedNotificationCount: " + receivedNotificationCount.ToString());
 
         Assert.AreEqual(1, receivedNotificationCount);
 


### PR DESCRIPTION
We still maintain 1.4.x series, hence backporting non-breaking fixes from 2.0 into it.

This PR backports changes from these (clean cherry-picks):
https://github.com/Unity-Technologies/com.unity.mobile.notifications/pull/101
https://github.com/Unity-Technologies/com.unity.mobile.notifications/pull/95
https://github.com/Unity-Technologies/com.unity.mobile.notifications/pull/109