### PR TITLE
[iOS] backport fixes to 1.4

### DIFF
--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityAppController+Notifications.mm
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityAppController+Notifications.mm
@@ -50,7 +50,6 @@
          object: nil
          queue: [NSOperationQueue mainQueue]
          usingBlock:^(NSNotification *notification) {
-
              [UNUserNotificationCenter currentNotificationCenter].delegate = [UnityNotificationManager sharedInstance];
 
              BOOL authorizeOnLaunch = [[[NSBundle mainBundle] objectForInfoDictionaryKey: @"UnityNotificationRequestAuthorizationOnAppLaunch"] boolValue];

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityAppController+Notifications.mm
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityAppController+Notifications.mm
@@ -17,9 +17,6 @@
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         [UnityNotificationLifeCycleManager sharedInstance];
-
-        UNUserNotificationCenter* center = [UNUserNotificationCenter currentNotificationCenter];
-        center.delegate = [UnityNotificationManager sharedInstance];
     });
 }
 
@@ -49,10 +46,13 @@
              [UnityNotificationManager sharedInstance].lastReceivedNotification = NULL;
          }];
 
-        [nc addObserverForName: UIApplicationDidFinishLaunchingNotification
+        [nc addObserverForName: kUnityWillFinishLaunchingWithOptions
          object: nil
          queue: [NSOperationQueue mainQueue]
          usingBlock:^(NSNotification *notification) {
+
+             [UNUserNotificationCenter currentNotificationCenter].delegate = [UnityNotificationManager sharedInstance];
+
              BOOL authorizeOnLaunch = [[[NSBundle mainBundle] objectForInfoDictionaryKey: @"UnityNotificationRequestAuthorizationOnAppLaunch"] boolValue];
              BOOL supportsPushNotification = [[[NSBundle mainBundle] objectForInfoDictionaryKey: @"UnityAddRemoteNotificationCapability"] boolValue];
              BOOL registerRemoteOnLaunch = supportsPushNotification == YES ?

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
@@ -221,6 +221,12 @@ void _ReadNSDictionary(void* csDict, void* nsDict, void (*callback)(void* csDcit
             NSString* v = obj;
             callback(csDict, k.UTF8String, v.UTF8String);
         }
+        else if ([obj isKindOfClass: [NSNumber class]])
+        {
+            NSNumber* numberVal = (NSNumber*)obj;
+            NSString* str = numberVal.stringValue;
+            callback(csDict, k.UTF8String, str.UTF8String);
+        }
         else
         {
             NSError* error;

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
@@ -21,6 +21,8 @@ static NSString* ParseNotificationDataObject(id obj)
     else if ([obj isKindOfClass: [NSNumber class]])
     {
         NSNumber* numberVal = obj;
+        if (CFBooleanGetTypeID() == CFGetTypeID((__bridge CFTypeRef)(obj)))
+            return numberVal.boolValue ? @"true" : @"false";
         return numberVal.stringValue;
     }
     else if ([NSJSONSerialization isValidJSONObject: obj])


### PR DESCRIPTION
We still need to maintain 1.4.x notification package.
This PR backports non-breaking fixes from these PRs:
https://github.com/Unity-Technologies/com.unity.mobile.notifications/pull/130
https://github.com/Unity-Technologies/com.unity.mobile.notifications/pull/134
https://github.com/Unity-Technologies/com.unity.mobile.notifications/pull/135