### PR TITLE
Prepare 2.0.1

### DIFF
--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this package will be documented in this file.
 
+## [2.0.1] - 2022-04-15
+
+### Fixes:
+- [Android] Change exported attribute to false in the manifest for package receivers.
+- [Android] [issue 144](https://github.com/Unity-Technologies/com.unity.mobile.notifications/issues/144) Fix Transaction.TooLargeException exception on some devices for notifications with large icons or more content.
+- [Android] [issue 160](https://github.com/Unity-Technologies/com.unity.mobile.notifications/issues/160) Fix UnityNotificationRestartOnBootReceiver not setting FLAG_IMMUTABLE.
+
+### Changes & Improvements:
+- [Android] Build will now fail if minimum SDK in Unity is lower than supported by package.
+
 ## [2.0.0] - 2022-02-02
 
 ### Fixes:

--- a/com.unity.mobile.notifications/package.json
+++ b/com.unity.mobile.notifications/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.mobile.notifications",
   "displayName": "Mobile Notifications",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "unity": "2019.4",
   "description": "Mobile Notifications package adds support for scheduling local repeatable or one-time notifications on iOS and Android.\n\nRequires iOS 10 and Android 4.4 or above.",
   "keywords": [


### PR DESCRIPTION
New package release.
Basic functionality is tested on CI for both Android and iOS.
All changes have been tested on earlier PRs, only a general pass is required for release.