### PR TITLE
Prepare 1.4.3

### DIFF
--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this package will be documented in this file.
 
+## [1.4.3] - 2022-04-15
+
+### Fixes:
+- [Android] [issue 101](https://github.com/Unity-Technologies/com.unity.mobile.notifications/pull/101) Fix GC allocation every frame.
+- [1360115](https://issuetracker.unity3d.com/issues/mobile-notifications-project-settings-window-loses-focus-when-clicking-on-any-category-while-mobile-notifications-pane-is-open) Fixed focus loss when trying to switching from notifications settings.
+- [Android] [case 1376849] Fixed receivers needs to be marked as exported in manifest file, disable exact alarms on Android 12 because they require special permissions.
+- [iOS] [1375744](https://issuetracker.unity3d.com/issues/ios-app-freezes-slash-crashes-when-both-mobile-notifications-and-firebase-are-used) Fixed application startup hang when application uses Unity notifications or Firebase.
+- [iOS] [case 1382960] Handle numeric data in UserInfo.
+- [iOS] Correctly handle boolean values in UserInfo, previously boolean values were detected as numbers and get parsed as 1 or 0, now they will be correctly handled as 'true' and 'false'.
+
 ## [1.4.2] - 2021-07-22
 
 ### Fixes:

--- a/com.unity.mobile.notifications/package.json
+++ b/com.unity.mobile.notifications/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.mobile.notifications",
   "displayName": "Mobile Notifications",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "unity": "2019.4",
   "description": "Mobile Notifications package adds support for scheduling local repeatable or one-time notifications on iOS and Android.\n\nRequires iOS 10 and Android 4.4 or above.",
   "keywords": [


### PR DESCRIPTION
This PR only bumps package version and adds release notes. Look at at as a new package release - a general pass is required.
This packs a backport of a bunch or previously tested PRs.
Basic functionality is tested on CI on Android, but not iOS (not possible in this release series). No other testing was done (almost all backports were clean).
For more specific things to check, look at the changes to release notes.