### PR TITLE
Run tests on 2019.4

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -3,6 +3,13 @@ test_editors:
   - version: 2022.1
   - version: 2021.3
   - version: 2020.3
+  - version: 2019.4
+
+android_test_editors:
+  - version: trunk
+  - version: 2022.1
+  - version: 2021.3
+  - version: 2020.3
 
 ios_test_editors:
   - version: trunk
@@ -77,7 +84,7 @@ test_{{ platform.name }}_{{ editor.version }}:
 {% endfor %}
 {% endfor %}
 
-{% for editor in test_editors %}
+{% for editor in android_test_editors %}
 test_Android_{{ editor.version }}:
   name: Test {{ editor.version }} on Android
   agent:
@@ -169,7 +176,11 @@ test_trigger:
     {% for platform in test_platforms %}
     - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
     {% endfor %}
+    {% endfor %}
+    {% for editor in android_test_editors %}
+    {% for platform in test_platforms %}
     - .yamato/upm-ci.yml#test_Android_{{ editor.version }}
+    {% endfor %}
     {% endfor %}
 
 publish:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -178,9 +178,7 @@ test_trigger:
     {% endfor %}
     {% endfor %}
     {% for editor in android_test_editors %}
-    {% for platform in test_platforms %}
     - .yamato/upm-ci.yml#test_Android_{{ editor.version }}
-    {% endfor %}
     {% endfor %}
 
 publish:


### PR DESCRIPTION
Package tooling requires to run at least some tests on all supported versions.
Notifications package almost doesn't depend on Unity versions, so adding only Editor (2019.4 will be out of support very soon anyway).