### PR TITLE
Fixes for pre-6 androids

### DIFF
--- a/TestProjects/com.unity.mobile-notifications-sample/Assets/Scripts/AndroidTest.cs
+++ b/TestProjects/com.unity.mobile-notifications-sample/Assets/Scripts/AndroidTest.cs
@@ -20,7 +20,7 @@ namespace Unity.Notifications.Tests.Sample
         private Dictionary<string, OrderedDictionary> m_groups;
         private Logger m_LOGGER;
         private int _notificationExplicitID;
-        private Button ButtonExplicitID;
+        private Button ButtonModifyExplicitID;
 
         public int notificationExplicitID
         {
@@ -28,14 +28,8 @@ namespace Unity.Notifications.Tests.Sample
             set
             {
                 _notificationExplicitID = value;
-                if (_notificationExplicitID == 0)
-                {
-                    ButtonExplicitID.interactable = false;
-                }
-                else
-                {
-                    ButtonExplicitID.interactable = true;
-                }
+                bool buttonsEnabled = _notificationExplicitID != 0;
+                ButtonModifyExplicitID.interactable = buttonsEnabled;
             }
         }
 
@@ -235,8 +229,8 @@ namespace Unity.Notifications.Tests.Sample
                 }
                 buttonGameObject.gameObject.SetActive(false);
             }
-            ButtonExplicitID = GameObject.Find("Modify/Modify pending Explicit notification").GetComponent<Button>();
-            ButtonExplicitID.interactable = false;
+            ButtonModifyExplicitID = GameObject.Find("Modify/Modify pending Explicit notification").GetComponent<Button>();
+            ButtonModifyExplicitID.interactable = false;
             m_gameObjectReferences.ButtonGroupTemplate.gameObject.SetActive(false);
         }
 

--- a/TestProjects/com.unity.mobile-notifications-sample/Assets/Scripts/AndroidTest.cs
+++ b/TestProjects/com.unity.mobile-notifications-sample/Assets/Scripts/AndroidTest.cs
@@ -21,6 +21,7 @@ namespace Unity.Notifications.Tests.Sample
         private Logger m_LOGGER;
         private int _notificationExplicitID;
         private Button ButtonModifyExplicitID;
+        private Button ButtonCancelExplicitID;
 
         public int notificationExplicitID
         {
@@ -30,6 +31,7 @@ namespace Unity.Notifications.Tests.Sample
                 _notificationExplicitID = value;
                 bool buttonsEnabled = _notificationExplicitID != 0;
                 ButtonModifyExplicitID.interactable = buttonsEnabled;
+                ButtonCancelExplicitID.interactable = buttonsEnabled;
             }
         }
 
@@ -116,6 +118,7 @@ namespace Unity.Notifications.Tests.Sample
             m_groups["Modify"] = new OrderedDictionary();
             //m_groups["Modify"]["Create notification preset"] = new Action(() => {  });
             m_groups["Modify"]["Modify pending Explicit notification"] = new Action(() => { ModifyExplicitNotification(); });
+            m_groups["Modify"]["Cancel pending Explicit notification"] = new Action(() => { CancelExplicitNotification(); });
 
             m_groups["Send"] = new OrderedDictionary();
             foreach (AndroidNotificationTemplate template in Resources.LoadAll("AndroidNotifications", typeof(AndroidNotificationTemplate)))
@@ -231,6 +234,8 @@ namespace Unity.Notifications.Tests.Sample
             }
             ButtonModifyExplicitID = GameObject.Find("Modify/Modify pending Explicit notification").GetComponent<Button>();
             ButtonModifyExplicitID.interactable = false;
+            ButtonCancelExplicitID = GameObject.Find("Modify/Cancel pending Explicit notification").GetComponent<Button>();
+            ButtonCancelExplicitID.interactable = false;
             m_gameObjectReferences.ButtonGroupTemplate.gameObject.SetActive(false);
         }
 
@@ -246,6 +251,14 @@ namespace Unity.Notifications.Tests.Sample
             m_LOGGER
                 .Blue($"[{DateTime.Now.ToString("HH:mm:ss.ffffff")}] Call {MethodBase.GetCurrentMethod().Name}")
                 .Properties(template, 1);
+        }
+
+        public void CancelExplicitNotification()
+        {
+            AndroidNotificationCenter.CancelScheduledNotification(notificationExplicitID);
+            notificationExplicitID = 0;
+            m_LOGGER
+                .Blue($"[{DateTime.Now.ToString("HH:mm:ss.ffffff")}] Call {MethodBase.GetCurrentMethod().Name}");
         }
 
         public void SendNotification(AndroidNotification notification, string channel = "default_channel", int notificationID = 0, bool log = true)

--- a/TestProjects/com.unity.mobile-notifications-sample/Assets/Scripts/AndroidTest.cs
+++ b/TestProjects/com.unity.mobile-notifications-sample/Assets/Scripts/AndroidTest.cs
@@ -22,6 +22,7 @@ namespace Unity.Notifications.Tests.Sample
         private int _notificationExplicitID;
         private Button ButtonModifyExplicitID;
         private Button ButtonCancelExplicitID;
+        private Button ButtonCheckStatusExplicitID;
 
         public int notificationExplicitID
         {
@@ -32,6 +33,7 @@ namespace Unity.Notifications.Tests.Sample
                 bool buttonsEnabled = _notificationExplicitID != 0;
                 ButtonModifyExplicitID.interactable = buttonsEnabled;
                 ButtonCancelExplicitID.interactable = buttonsEnabled;
+                ButtonCheckStatusExplicitID.interactable = buttonsEnabled;
             }
         }
 
@@ -60,6 +62,7 @@ namespace Unity.Notifications.Tests.Sample
                 .Properties(notificationIntentData.Notification, 1);
             if (notificationIntentData.Id == notificationExplicitID)
             {
+                AndroidNotificationCenter.CheckScheduledNotificationStatus(notificationExplicitID);
                 notificationExplicitID = 0;
             }
         }
@@ -119,6 +122,8 @@ namespace Unity.Notifications.Tests.Sample
             //m_groups["Modify"]["Create notification preset"] = new Action(() => {  });
             m_groups["Modify"]["Modify pending Explicit notification"] = new Action(() => { ModifyExplicitNotification(); });
             m_groups["Modify"]["Cancel pending Explicit notification"] = new Action(() => { CancelExplicitNotification(); });
+            m_groups["Modify"]["Check status of Explicit notification"] = new Action(() => { CheckStatusOfExplicitNotification (); });
+            
 
             m_groups["Send"] = new OrderedDictionary();
             foreach (AndroidNotificationTemplate template in Resources.LoadAll("AndroidNotifications", typeof(AndroidNotificationTemplate)))
@@ -130,6 +135,7 @@ namespace Unity.Notifications.Tests.Sample
                         {
                             Title = template.Title,
                             Text = template.Text,
+                            
                             SmallIcon = template.SmallIcon,
                             LargeIcon = template.LargeIcon,
                             Style = template.NotificationStyle,
@@ -236,6 +242,9 @@ namespace Unity.Notifications.Tests.Sample
             ButtonModifyExplicitID.interactable = false;
             ButtonCancelExplicitID = GameObject.Find("Modify/Cancel pending Explicit notification").GetComponent<Button>();
             ButtonCancelExplicitID.interactable = false;
+            ButtonCheckStatusExplicitID = GameObject.Find("Modify/Check status of Explicit notification").GetComponent<Button>();
+            ButtonCheckStatusExplicitID.interactable = false;
+            
             m_gameObjectReferences.ButtonGroupTemplate.gameObject.SetActive(false);
         }
 
@@ -259,6 +268,13 @@ namespace Unity.Notifications.Tests.Sample
             notificationExplicitID = 0;
             m_LOGGER
                 .Blue($"[{DateTime.Now.ToString("HH:mm:ss.ffffff")}] Call {MethodBase.GetCurrentMethod().Name}");
+        }
+
+        public void CheckStatusOfExplicitNotification()
+        {
+            m_LOGGER
+                .Blue($"[{DateTime.Now.ToString("HH:mm:ss.ffffff")}] Explicit notification (ID:{notificationExplicitID}) status: {AndroidNotificationCenter.CheckScheduledNotificationStatus(notificationExplicitID)}");
+            
         }
 
         public void SendNotification(AndroidNotification notification, string channel = "default_channel", int notificationID = 0, bool log = true)

--- a/TestProjects/com.unity.mobile-notifications-sample/Assets/Scripts/AndroidTest.cs
+++ b/TestProjects/com.unity.mobile-notifications-sample/Assets/Scripts/AndroidTest.cs
@@ -123,7 +123,7 @@ namespace Unity.Notifications.Tests.Sample
             m_groups["Modify"]["Modify pending Explicit notification"] = new Action(() => { ModifyExplicitNotification(); });
             m_groups["Modify"]["Cancel pending Explicit notification"] = new Action(() => { CancelExplicitNotification(); });
             m_groups["Modify"]["Check status of Explicit notification"] = new Action(() => { CheckStatusOfExplicitNotification (); });
-            
+
 
             m_groups["Send"] = new OrderedDictionary();
             foreach (AndroidNotificationTemplate template in Resources.LoadAll("AndroidNotifications", typeof(AndroidNotificationTemplate)))
@@ -135,7 +135,7 @@ namespace Unity.Notifications.Tests.Sample
                         {
                             Title = template.Title,
                             Text = template.Text,
-                            
+
                             SmallIcon = template.SmallIcon,
                             LargeIcon = template.LargeIcon,
                             Style = template.NotificationStyle,
@@ -244,7 +244,7 @@ namespace Unity.Notifications.Tests.Sample
             ButtonCancelExplicitID.interactable = false;
             ButtonCheckStatusExplicitID = GameObject.Find("Modify/Check status of Explicit notification").GetComponent<Button>();
             ButtonCheckStatusExplicitID.interactable = false;
-            
+
             m_gameObjectReferences.ButtonGroupTemplate.gameObject.SetActive(false);
         }
 
@@ -274,7 +274,7 @@ namespace Unity.Notifications.Tests.Sample
         {
             m_LOGGER
                 .Blue($"[{DateTime.Now.ToString("HH:mm:ss.ffffff")}] Explicit notification (ID:{notificationExplicitID}) status: {AndroidNotificationCenter.CheckScheduledNotificationStatus(notificationExplicitID)}");
-            
+
         }
 
         public void SendNotification(AndroidNotification notification, string channel = "default_channel", int notificationID = 0, bool log = true)

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -603,6 +603,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
                     cancelPendingNotificationIntent(context, Integer.valueOf(id));
                     deleteExpiredNotificationIntent(context, id);
                 }
+                triggerHousekeeping(context, null);
             }).start();
         }
     }

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -427,11 +427,13 @@ public class UnityNotificationManager extends BroadcastReceiver {
             }
         }
 
-        StatusBarNotification[] active = getNotificationManager(context).getActiveNotifications();
-        for (StatusBarNotification notification : active) {
-            // any notifications in status bar are still valid
-            String id = String.valueOf(notification.getId());
-            invalid.remove(id);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            StatusBarNotification[] active = getNotificationManager(context).getActiveNotifications();
+            for (StatusBarNotification notification : active) {
+                // any notifications in status bar are still valid
+                String id = String.valueOf(notification.getId());
+                invalid.remove(id);
+            }
         }
 
         // if app is launched with notification, user still has access to it


### PR DESCRIPTION
Three fixes for Android:
- [case 1423875](https://fogbugz.unity3d.com/f/cases/1423875/) - unguarded call of API added in Android 6 (M)
- notification status reporting for pre-6 (previously unimplemented at all)
- removal of cached notifications, introduced in previous release

In Android 6 an API was introduced to query for notifications, displayed in status bar. This PR implements our own tracking for older versions by putting an ID into set and setting an intent to be invoked on deletion. Not adding this for 6 and later (makes code more complex, but saves resources and will be simpler to remove once we drop support for Android 6 some day, also, querying Androids status bar gives more reliable data than our own tracking).
Implementation of our own tracking of sent notifications allowed to also implement notification status check, that previously only worked on 6 and later.
In previous release the caching of scheduled notifications was introduced, but notifications are kept in it forever (unless you kill the app). This PR adds removal for them in the housekeeping (also required thread synchronization to be added, since scheduling and housekeeping happens on different threads).

QA request:
- In-package test project has new button in "Modify" section to cancel the notification. Works with explicit ID notification, cancels only that single notification. Internally this also triggers housekeeping, where the Android 6 API was called.
- Need testing:
  - Actual device with Android lower than 6 (I don't have one at hand); I tested the code by commenting out Android version checks, but that's not the same.
  - AndroidNotificationCenter.CheckScheduledNotificationStatus() should work for pre-6 (documentation for it still needs update about it); Q: maybe I should add a button for that in test project?
  - Scheduling and cancelling drills should trigger all relevant code paths, so we know both 6+ and older androids work
  - If you have a notification in status bar, pressing it should launch the app and AndroidNotificationCenter.GetLastNotificationIntent should give it to you, regardless of whether you have app in foreground, background or killed before notification arrived or after it arrived.
  - Only basic sending & canceling is affected, no need to test all those fancy variants of notifications
  - Tested on Samsung Galaxy S7 (7.0); in reality this isn't device specific and Android version only matters whether it's <6 or 6+.