### PR TITLE
Android/jni refactor and optimization

### DIFF
--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCallback.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCallback.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 namespace Unity.Notifications.Android
@@ -6,6 +7,17 @@ namespace Unity.Notifications.Android
     {
         public NotificationCallback() : base("com.unity.androidnotifications.NotificationCallback")
         {
+        }
+
+        public override AndroidJavaObject Invoke(string methodName, AndroidJavaObject[] args)
+        {
+            if (methodName.Equals("onSentNotification", StringComparison.InvariantCulture) && args != null && args.Length == 1)
+            {
+                onSentNotification(args[0]);
+                return null;
+            }
+
+            return base.Invoke(methodName, args);
         }
 
         public void onSentNotification(AndroidJavaObject notification)

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -90,6 +90,7 @@ namespace Unity.Notifications.Android
             CollectMethods(clazz);
             JniApi.Notification.CollectJni();
             JniApi.NotificationBuilder.CollectJni();
+            JniApi.Bundle.CollectJni();
 #else
             KEY_FIRE_TIME = null;
             KEY_ID = null;
@@ -408,44 +409,68 @@ namespace Unity.Notifications.Android
 
         public static class Bundle
         {
+            static JniMethodID containsKey;
+            static JniMethodID getBoolean;
+            static JniMethodID getInt;
+            static JniMethodID getLong;
+            static JniMethodID getString;
+            static JniMethodID putInt;
+            static JniMethodID putLong;
+            static JniMethodID putString;
+
+            public static void CollectJni()
+            {
+                using (var clazz = new AndroidJavaClass("android/os/Bundle"))
+                {
+                    containsKey = JniApi.FindMethod(clazz, "containsKey", "(Ljava/lang/String;)Z", false);
+                    getBoolean = JniApi.FindMethod(clazz, "getBoolean", "(Ljava/lang/String;Z)Z", false);
+                    getInt = JniApi.FindMethod(clazz, "getInt", "(Ljava/lang/String;I)I", false);
+                    getLong = JniApi.FindMethod(clazz, "getLong", "(Ljava/lang/String;J)J", false);
+                    getString = JniApi.FindMethod(clazz, "getString", "(Ljava/lang/String;)Ljava/lang/String;", false);
+                    putInt = JniApi.FindMethod(clazz, "putInt", "(Ljava/lang/String;I)V", false);
+                    putLong = JniApi.FindMethod(clazz, "putLong", "(Ljava/lang/String;J)V", false);
+                    putString = JniApi.FindMethod(clazz, "putString", "(Ljava/lang/String;Ljava/lang/String;)V", false);
+                }
+            }
+
             public static bool ContainsKey(AndroidJavaObject bundle, AndroidJavaObject key)
             {
-                return bundle.Call<bool>("containsKey", key);
+                return bundle.Call<bool>(containsKey, key);
             }
 
             public static bool GetBoolean(AndroidJavaObject bundle, AndroidJavaObject key, bool defaultValue)
             {
-                return bundle.Call<bool>("getBoolean", key, defaultValue);
+                return bundle.Call<bool>(getBoolean, key, defaultValue);
             }
 
             public static int GetInt(AndroidJavaObject bundle, AndroidJavaObject key, int defaultValue)
             {
-                return bundle.Call<int>("getInt", key, defaultValue);
+                return bundle.Call<int>(getInt, key, defaultValue);
             }
 
             public static long GetLong(AndroidJavaObject bundle, AndroidJavaObject key, long defaultValue)
             {
-                return bundle.Call<long>("getLong", key, defaultValue);
+                return bundle.Call<long>(getLong, key, defaultValue);
             }
 
             public static string GetString(AndroidJavaObject bundle, AndroidJavaObject key)
             {
-                return bundle.Call<string>("getString", key);
+                return bundle.Call<string>(getString, key);
             }
 
             public static void PutInt(AndroidJavaObject bundle, AndroidJavaObject key, int value)
             {
-                bundle.Call("putInt", key, value);
+                bundle.Call(putInt, key, value);
             }
 
             public static void PutLong(AndroidJavaObject bundle, AndroidJavaObject key, long value)
             {
-                bundle.Call("putLong", key, value);
+                bundle.Call(putLong, key, value);
             }
 
             public static void PutString(AndroidJavaObject bundle, AndroidJavaObject key, string value)
             {
-                bundle.Call("putString", key, value);
+                bundle.Call(putString, key, value);
             }
         }
     }

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -3,6 +3,12 @@ using System.Linq;
 using System.Collections.Generic;
 using UnityEngine;
 
+#if UNITY_2022_2_OR_NEWER
+    using JniMethodID = System.IntPtr;
+#else
+    using JniMethodID = System.String;
+#endif
+
 namespace Unity.Notifications.Android
 {
     /// <summary>
@@ -44,22 +50,33 @@ namespace Unity.Notifications.Android
         public AndroidJavaObject KEY_NOTIFICATION;
         public AndroidJavaObject KEY_SMALL_ICON;
 
-        private const string getNotificationFromIntent = "getNotificationFromIntent";
-        private const string setNotificationIcon = "setNotificationIcon";
-        private const string setNotificationColor = "setNotificationColor";
-        private const string getNotificationColor = "getNotificationColor";
-        private const string setNotificationUsesChronometer = "setNotificationUsesChronometer";
-        private const string setNotificationGroupAlertBehavior = "setNotificationGroupAlertBehavior";
-        private const string getNotificationGroupAlertBehavior = "getNotificationGroupAlertBehavior";
-        private const string getNotificationChannelId = "getNotificationChannelId";
-        private const string scheduleNotification = "scheduleNotification";
-        private const string createNotificationBuilder = "createNotificationBuilder";
+        private JniMethodID getNotificationFromIntent;
+        private JniMethodID setNotificationIcon;
+        private JniMethodID setNotificationColor;
+        private JniMethodID getNotificationColor;
+        private JniMethodID setNotificationUsesChronometer;
+        private JniMethodID setNotificationGroupAlertBehavior;
+        private JniMethodID getNotificationGroupAlertBehavior;
+        private JniMethodID getNotificationChannelId;
+        private JniMethodID scheduleNotification;
+        private JniMethodID createNotificationBuilder;
 
 
         public NotificationManagerJni(AndroidJavaClass clazz, AndroidJavaObject obj)
         {
             klass = clazz;
             self = obj;
+
+            getNotificationFromIntent = default;
+            setNotificationIcon = default;
+            setNotificationColor = default;
+            getNotificationColor = default;
+            setNotificationUsesChronometer = default;
+            setNotificationGroupAlertBehavior = default;
+            getNotificationGroupAlertBehavior = default;
+            getNotificationChannelId = default;
+            scheduleNotification = default;
+            createNotificationBuilder = default;
 
 #if UNITY_ANDROID && !UNITY_EDITOR
             KEY_FIRE_TIME = clazz.GetStatic<AndroidJavaObject>("KEY_FIRE_TIME");
@@ -69,6 +86,8 @@ namespace Unity.Notifications.Android
             KEY_REPEAT_INTERVAL = clazz.GetStatic<AndroidJavaObject>("KEY_REPEAT_INTERVAL");
             KEY_NOTIFICATION = clazz.GetStatic<AndroidJavaObject>("KEY_NOTIFICATION");
             KEY_SMALL_ICON = clazz.GetStatic<AndroidJavaObject>("KEY_SMALL_ICON");
+
+            CollectMethods(clazz);
 #else
             KEY_FIRE_TIME = null;
             KEY_ID = null;
@@ -78,6 +97,20 @@ namespace Unity.Notifications.Android
             KEY_NOTIFICATION = null;
             KEY_SMALL_ICON = null;
 #endif
+        }
+
+        void CollectMethods(AndroidJavaClass clazz)
+        {
+            getNotificationFromIntent = JniApi.FindMethod(clazz, "getNotificationFromIntent", "(Landroid/content/Context;Landroid/content/Intent;)Landroid/app/Notification;", true);
+            setNotificationIcon = JniApi.FindMethod(clazz, "setNotificationIcon", "(Landroid/app/Notification$Builder;Ljava/lang/String;Ljava/lang/String;)V", true);
+            setNotificationColor = JniApi.FindMethod(clazz, "setNotificationColor", "(Landroid/app/Notification$Builder;I)V", true);
+            getNotificationColor = JniApi.FindMethod(clazz, "getNotificationColor", "(Landroid/app/Notification;)Ljava/lang/Integer;", true);
+            setNotificationUsesChronometer = JniApi.FindMethod(clazz, "setNotificationUsesChronometer", "(Landroid/app/Notification$Builder;Z)V", true);
+            setNotificationGroupAlertBehavior = JniApi.FindMethod(clazz, "setNotificationGroupAlertBehavior", "(Landroid/app/Notification$Builder;I)V", true);
+            getNotificationGroupAlertBehavior = JniApi.FindMethod(clazz, "getNotificationGroupAlertBehavior", "(Landroid/app/Notification;)I", true);
+            getNotificationChannelId = JniApi.FindMethod(clazz, "getNotificationChannelId", "(Landroid/app/Notification;)Ljava/lang/String;", true);
+            scheduleNotification = JniApi.FindMethod(clazz, "scheduleNotification", "(Landroid/app/Notification$Builder;)V", false);
+            createNotificationBuilder = JniApi.FindMethod(clazz, "createNotificationBuilder", "(Ljava/lang/String;)Landroid/app/Notification$Builder;", false);
         }
 
         public AndroidJavaObject GetNotificationFromIntent(AndroidJavaObject activity, AndroidJavaObject intent)

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -300,17 +300,107 @@ namespace Unity.Notifications.Android
         }
     }
 
+    struct NotificationBuilderJni
+    {
+        JniMethodID getExtras;
+        JniMethodID setContentTitle;
+        JniMethodID setContentText;
+        JniMethodID setAutoCancel;
+        JniMethodID setNumber;
+        JniMethodID setStyle;
+        JniMethodID setWhen;
+        JniMethodID setGroup;
+        JniMethodID setGroupSummary;
+        JniMethodID setSortKey;
+        JniMethodID setShowWhen;
+
+        public void CollectJni()
+        {
+            using (var clazz = new AndroidJavaClass("android.app.Notification$Builder"))
+            {
+                getExtras = JniApi.FindMethod(clazz, "getExtras", "()Landroid/os/Bundle;", false);
+                setContentTitle = JniApi.FindMethod(clazz, "setContentTitle", "(Ljava/lang/CharSequence;)Landroid/app/Notification$Builder;", false);
+                setContentText = JniApi.FindMethod(clazz, "setContentText", "(Ljava/lang/CharSequence;)Landroid/app/Notification$Builder;", false);
+                setAutoCancel = JniApi.FindMethod(clazz, "setAutoCancel", "(Z)Landroid/app/Notification$Builder;", false);
+                setNumber = JniApi.FindMethod(clazz, "setNumber", "(I)Landroid/app/Notification$Builder;", false);
+                setStyle = JniApi.FindMethod(clazz, "setStyle", "(Landroid/app/Notification$Style;)Landroid/app/Notification$Builder;", false);
+                setWhen = JniApi.FindMethod(clazz, "setWhen", "(J)Landroid/app/Notification$Builder;", false);
+                setGroup = JniApi.FindMethod(clazz, "setGroup", "(Ljava/lang/String;)Landroid/app/Notification$Builder;", false);
+                setGroupSummary = JniApi.FindMethod(clazz, "setGroupSummary", "(Z)Landroid/app/Notification$Builder;", false);
+                setSortKey = JniApi.FindMethod(clazz, "setSortKey", "(Ljava/lang/String;)Landroid/app/Notification$Builder;", false);
+                setShowWhen = JniApi.FindMethod(clazz, "setShowWhen", "(Z)Landroid/app/Notification$Builder;", false);
+            }
+        }
+
+        public AndroidJavaObject GetExtras(AndroidJavaObject builder)
+        {
+            return builder.Call<AndroidJavaObject>(getExtras);
+        }
+
+        public void SetContentTitle(AndroidJavaObject builder, string title)
+        {
+            builder.Call<AndroidJavaObject>(setContentTitle, title).Dispose();
+        }
+
+        public void SetContentText(AndroidJavaObject builder, string text)
+        {
+            builder.Call<AndroidJavaObject>(setContentText, text).Dispose();
+        }
+
+        public void SetAutoCancel(AndroidJavaObject builder, bool shouldAutoCancel)
+        {
+            builder.Call<AndroidJavaObject>(setAutoCancel, shouldAutoCancel).Dispose();
+        }
+
+        public void SetNumber(AndroidJavaObject builder, int number)
+        {
+            builder.Call<AndroidJavaObject>(setNumber, number).Dispose();
+        }
+
+        public void SetStyle(AndroidJavaObject builder, AndroidJavaObject style)
+        {
+            builder.Call<AndroidJavaObject>(setStyle, style).Dispose();
+        }
+
+        public void SetWhen(AndroidJavaObject builder, long timestamp)
+        {
+            builder.Call<AndroidJavaObject>(setWhen, timestamp).Dispose();
+        }
+
+        public void SetGroup(AndroidJavaObject builder, string group)
+        {
+            builder.Call<AndroidJavaObject>(setGroup, group).Dispose();
+        }
+
+        public void SetGroupSummary(AndroidJavaObject builder, bool groupSummary)
+        {
+            builder.Call<AndroidJavaObject>(setGroupSummary, groupSummary).Dispose();
+        }
+
+        public void SetSortKey(AndroidJavaObject builder, string sortKey)
+        {
+            builder.Call<AndroidJavaObject>(setSortKey, sortKey).Dispose();
+        }
+
+        public void SetShowWhen(AndroidJavaObject builder, bool showTimestamp)
+        {
+            builder.Call<AndroidJavaObject>(setShowWhen, showTimestamp).Dispose();
+        }
+    }
+
     struct JniApi
     {
         public NotificationManagerJni NotificationManager;
         public NotificationJni Notification;
+        public NotificationBuilderJni NotificationBuilder;
 
         public JniApi(AndroidJavaClass notificationManagerClass, AndroidJavaObject notificationManager)
         {
             NotificationManager = new NotificationManagerJni(notificationManagerClass, notificationManager);
             Notification = default;
             Notification.CollectJni();
-            JniApi.NotificationBuilder.CollectJni();
+            NotificationBuilder = default;
+            NotificationBuilder.CollectJni();
             JniApi.Bundle.CollectJni();
         }
 
@@ -324,94 +414,6 @@ namespace Unity.Notifications.Android
 #else
             return name;
 #endif
-        }
-
-        public static class NotificationBuilder
-        {
-            static JniMethodID getExtras;
-            static JniMethodID setContentTitle;
-            static JniMethodID setContentText;
-            static JniMethodID setAutoCancel;
-            static JniMethodID setNumber;
-            static JniMethodID setStyle;
-            static JniMethodID setWhen;
-            static JniMethodID setGroup;
-            static JniMethodID setGroupSummary;
-            static JniMethodID setSortKey;
-            static JniMethodID setShowWhen;
-
-            public static void CollectJni()
-            {
-                using (var clazz = new AndroidJavaClass("android.app.Notification$Builder"))
-                {
-                    getExtras = JniApi.FindMethod(clazz, "getExtras", "()Landroid/os/Bundle;", false);
-                    setContentTitle = JniApi.FindMethod(clazz, "setContentTitle", "(Ljava/lang/CharSequence;)Landroid/app/Notification$Builder;", false);
-                    setContentText = JniApi.FindMethod(clazz, "setContentText", "(Ljava/lang/CharSequence;)Landroid/app/Notification$Builder;", false);
-                    setAutoCancel = JniApi.FindMethod(clazz, "setAutoCancel", "(Z)Landroid/app/Notification$Builder;", false);
-                    setNumber = JniApi.FindMethod(clazz, "setNumber", "(I)Landroid/app/Notification$Builder;", false);
-                    setStyle = JniApi.FindMethod(clazz, "setStyle", "(Landroid/app/Notification$Style;)Landroid/app/Notification$Builder;", false);
-                    setWhen = JniApi.FindMethod(clazz, "setWhen", "(J)Landroid/app/Notification$Builder;", false);
-                    setGroup = JniApi.FindMethod(clazz, "setGroup", "(Ljava/lang/String;)Landroid/app/Notification$Builder;", false);
-                    setGroupSummary = JniApi.FindMethod(clazz, "setGroupSummary", "(Z)Landroid/app/Notification$Builder;", false);
-                    setSortKey = JniApi.FindMethod(clazz, "setSortKey", "(Ljava/lang/String;)Landroid/app/Notification$Builder;", false);
-                    setShowWhen = JniApi.FindMethod(clazz, "setShowWhen", "(Z)Landroid/app/Notification$Builder;", false);
-                }
-            }
-
-            public static AndroidJavaObject GetExtras(AndroidJavaObject builder)
-            {
-                return builder.Call<AndroidJavaObject>(getExtras);
-            }
-
-            public static void SetContentTitle(AndroidJavaObject builder, string title)
-            {
-                builder.Call<AndroidJavaObject>(setContentTitle, title).Dispose();
-            }
-
-            public static void SetContentText(AndroidJavaObject builder, string text)
-            {
-                builder.Call<AndroidJavaObject>(setContentText, text).Dispose();
-            }
-
-            public static void SetAutoCancel(AndroidJavaObject builder, bool shouldAutoCancel)
-            {
-                builder.Call<AndroidJavaObject>(setAutoCancel, shouldAutoCancel).Dispose();
-            }
-
-            public static void SetNumber(AndroidJavaObject builder, int number)
-            {
-                builder.Call<AndroidJavaObject>(setNumber, number).Dispose();
-            }
-
-            public static void SetStyle(AndroidJavaObject builder, AndroidJavaObject style)
-            {
-                builder.Call<AndroidJavaObject>(setStyle, style).Dispose();
-            }
-
-            public static void SetWhen(AndroidJavaObject builder, long timestamp)
-            {
-                builder.Call<AndroidJavaObject>(setWhen, timestamp).Dispose();
-            }
-
-            public static void SetGroup(AndroidJavaObject builder, string group)
-            {
-                builder.Call<AndroidJavaObject>(setGroup, group).Dispose();
-            }
-
-            public static void SetGroupSummary(AndroidJavaObject builder, bool groupSummary)
-            {
-                builder.Call<AndroidJavaObject>(setGroupSummary, groupSummary).Dispose();
-            }
-
-            public static void SetSortKey(AndroidJavaObject builder, string sortKey)
-            {
-                builder.Call<AndroidJavaObject>(setSortKey, sortKey).Dispose();
-            }
-
-            public static void SetShowWhen(AndroidJavaObject builder, bool showTimestamp)
-            {
-                builder.Call<AndroidJavaObject>(setShowWhen, showTimestamp).Dispose();
-            }
         }
 
         public static class Bundle
@@ -836,35 +838,35 @@ namespace Unity.Notifications.Android
             s_Jni.NotificationManager.SetNotificationIcon(notificationBuilder, s_Jni.NotificationManager.KEY_SMALL_ICON, notification.SmallIcon);
             if (!string.IsNullOrEmpty(notification.LargeIcon))
                 s_Jni.NotificationManager.SetNotificationIcon(notificationBuilder, s_Jni.NotificationManager.KEY_LARGE_ICON, notification.LargeIcon);
-            JniApi.NotificationBuilder.SetContentTitle(notificationBuilder, notification.Title);
-            JniApi.NotificationBuilder.SetContentText(notificationBuilder, notification.Text);
-            JniApi.NotificationBuilder.SetAutoCancel(notificationBuilder, notification.ShouldAutoCancel);
+            s_Jni.NotificationBuilder.SetContentTitle(notificationBuilder, notification.Title);
+            s_Jni.NotificationBuilder.SetContentText(notificationBuilder, notification.Text);
+            s_Jni.NotificationBuilder.SetAutoCancel(notificationBuilder, notification.ShouldAutoCancel);
             if (notification.Number >= 0)
-                JniApi.NotificationBuilder.SetNumber(notificationBuilder, notification.Number);
+                s_Jni.NotificationBuilder.SetNumber(notificationBuilder, notification.Number);
             if (notification.Style == NotificationStyle.BigTextStyle)
             {
                 using (var style = new AndroidJavaObject("android.app.Notification$BigTextStyle"))
                 {
                     style.Call<AndroidJavaObject>("bigText", notification.Text).Dispose();
-                    JniApi.NotificationBuilder.SetStyle(notificationBuilder, style);
+                    s_Jni.NotificationBuilder.SetStyle(notificationBuilder, style);
                 }
             }
             long timestampValue = notification.ShowCustomTimestamp ? notification.CustomTimestamp.ToLong() : fireTime;
-            JniApi.NotificationBuilder.SetWhen(notificationBuilder, timestampValue);
+            s_Jni.NotificationBuilder.SetWhen(notificationBuilder, timestampValue);
             if (!string.IsNullOrEmpty(notification.Group))
-                JniApi.NotificationBuilder.SetGroup(notificationBuilder, notification.Group);
+                s_Jni.NotificationBuilder.SetGroup(notificationBuilder, notification.Group);
             if (notification.GroupSummary)
-                JniApi.NotificationBuilder.SetGroupSummary(notificationBuilder, notification.GroupSummary);
+                s_Jni.NotificationBuilder.SetGroupSummary(notificationBuilder, notification.GroupSummary);
             if (!string.IsNullOrEmpty(notification.SortKey))
-                JniApi.NotificationBuilder.SetSortKey(notificationBuilder, notification.SortKey);
-            JniApi.NotificationBuilder.SetShowWhen(notificationBuilder, notification.ShowTimestamp);
+                s_Jni.NotificationBuilder.SetSortKey(notificationBuilder, notification.SortKey);
+            s_Jni.NotificationBuilder.SetShowWhen(notificationBuilder, notification.ShowTimestamp);
             int color = notification.Color.ToInt();
             if (color != 0)
                 s_Jni.NotificationManager.SetNotificationColor(notificationBuilder, color);
             s_Jni.NotificationManager.SetNotificationUsesChronometer(notificationBuilder, notification.UsesStopwatch);
             s_Jni.NotificationManager.SetNotificationGroupAlertBehavior(notificationBuilder, (int)notification.GroupAlertBehaviour);
 
-            using (var extras = JniApi.NotificationBuilder.GetExtras(notificationBuilder))
+            using (var extras = s_Jni.NotificationBuilder.GetExtras(notificationBuilder))
             {
                 JniApi.Bundle.PutInt(extras, s_Jni.NotificationManager.KEY_ID, id);
                 JniApi.Bundle.PutLong(extras, s_Jni.NotificationManager.KEY_REPEAT_INTERVAL, notification.RepeatInterval.ToLong());

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -201,6 +201,18 @@ namespace Unity.Notifications.Android
     {
         public NotificationManagerJni NotificationManager;
 
+        public static JniMethodID FindMethod(AndroidJavaClass clazz, string name, string signature, bool isStatic)
+        {
+#if UNITY_2022_2_OR_NEWER
+            var method = AndroidJNIHelper.GetMethodID(clazz.GetRawClass(), name, signature, isStatic);
+            if (method == IntPtr.Zero)
+                throw new Exception($"Method {name} with signature {signature} not found");
+            return method;
+#else
+            return name;
+#endif
+        }
+
         public static class Notification
         {
             public static AndroidJavaObject EXTRA_TITLE;

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -192,6 +192,11 @@ namespace Unity.Notifications.Android
 
         public static class NotificationBuilder
         {
+            public static AndroidJavaObject GetExtras(AndroidJavaObject builder)
+            {
+                return builder.Call<AndroidJavaObject>("getExtras");
+            }
+
             public static void SetContentTitle(AndroidJavaObject builder, string title)
             {
                 builder.Call<AndroidJavaObject>("setContentTitle", title).Dispose();
@@ -688,7 +693,7 @@ namespace Unity.Notifications.Android
             s_Jni.NotificationManager.SetNotificationUsesChronometer(notificationBuilder, notification.UsesStopwatch);
             s_Jni.NotificationManager.SetNotificationGroupAlertBehavior(notificationBuilder, (int)notification.GroupAlertBehaviour);
 
-            using (var extras = notificationBuilder.Call<AndroidJavaObject>("getExtras"))
+            using (var extras = JniApi.NotificationBuilder.GetExtras(notificationBuilder))
             {
                 JniApi.Bundle.PutInt(extras, s_Jni.NotificationManager.KEY_ID, id);
                 JniApi.Bundle.PutLong(extras, s_Jni.NotificationManager.KEY_REPEAT_INTERVAL, notification.RepeatInterval.ToLong());

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -44,6 +44,17 @@ namespace Unity.Notifications.Android
         public AndroidJavaObject KEY_NOTIFICATION;
         public AndroidJavaObject KEY_SMALL_ICON;
 
+        private const string getNotificationFromIntent = "getNotificationFromIntent";
+        private const string setNotificationIcon = "setNotificationIcon";
+        private const string setNotificationColor = "setNotificationColor";
+        private const string getNotificationColor = "getNotificationColor";
+        private const string setNotificationUsesChronometer = "setNotificationUsesChronometer";
+        private const string setNotificationGroupAlertBehavior = "setNotificationGroupAlertBehavior";
+        private const string getNotificationGroupAlertBehavior = "getNotificationGroupAlertBehavior";
+        private const string getNotificationChannelId = "getNotificationChannelId";
+        private const string scheduleNotification = "scheduleNotification";
+        private const string createNotificationBuilder = "createNotificationBuilder";
+
 
         public NotificationManagerJni(AndroidJavaClass clazz, AndroidJavaObject obj)
         {
@@ -71,22 +82,22 @@ namespace Unity.Notifications.Android
 
         public AndroidJavaObject GetNotificationFromIntent(AndroidJavaObject activity, AndroidJavaObject intent)
         {
-            return klass.CallStatic<AndroidJavaObject>("getNotificationFromIntent", activity, intent);
+            return klass.CallStatic<AndroidJavaObject>(getNotificationFromIntent, activity, intent);
         }
 
         public void SetNotificationIcon(AndroidJavaObject builder, AndroidJavaObject keyName, string icon)
         {
-            klass.CallStatic("setNotificationIcon", builder, keyName, icon);
+            klass.CallStatic(setNotificationIcon, builder, keyName, icon);
         }
 
         public void SetNotificationColor(AndroidJavaObject builder, int color)
         {
-            klass.CallStatic("setNotificationColor", builder, color);
+            klass.CallStatic(setNotificationColor, builder, color);
         }
 
         public Color? GetNotificationColor(AndroidJavaObject notification)
         {
-            using (var color = klass.CallStatic<AndroidJavaObject>("getNotificationColor", notification))
+            using (var color = klass.CallStatic<AndroidJavaObject>(getNotificationColor, notification))
             {
                 if (color == null)
                     return null;
@@ -96,22 +107,22 @@ namespace Unity.Notifications.Android
 
         public void SetNotificationUsesChronometer(AndroidJavaObject builder, bool usesStopwatch)
         {
-            klass.CallStatic("setNotificationUsesChronometer", builder, usesStopwatch);
+            klass.CallStatic(setNotificationUsesChronometer, builder, usesStopwatch);
         }
 
         public void SetNotificationGroupAlertBehavior(AndroidJavaObject builder, int groupAlertBehaviour)
         {
-            klass.CallStatic("setNotificationGroupAlertBehavior", builder, groupAlertBehaviour);
+            klass.CallStatic(setNotificationGroupAlertBehavior, builder, groupAlertBehaviour);
         }
 
         public int GetNotificationGroupAlertBehavior(AndroidJavaObject notification)
         {
-            return klass.CallStatic<int>("getNotificationGroupAlertBehavior", notification);
+            return klass.CallStatic<int>(getNotificationGroupAlertBehavior, notification);
         }
 
         public string GetNotificationChannelId(AndroidJavaObject notification)
         {
-            return klass.CallStatic<string>("getNotificationChannelId", notification);
+            return klass.CallStatic<string>(getNotificationChannelId, notification);
         }
 
         public void RegisterNotificationChannel(AndroidNotificationChannel channel)
@@ -142,7 +153,7 @@ namespace Unity.Notifications.Android
 
         public void ScheduleNotification(AndroidJavaObject notificationBuilder)
         {
-            self.Call("scheduleNotification", notificationBuilder);
+            self.Call(scheduleNotification, notificationBuilder);
         }
 
         public bool CheckIfPendingNotificationIsRegistered(int id)
@@ -182,7 +193,7 @@ namespace Unity.Notifications.Android
 
         public AndroidJavaObject CreateNotificationBuilder(String channelId)
         {
-            return self.Call<AndroidJavaObject>("createNotificationBuilder", channelId);
+            return self.Call<AndroidJavaObject>(createNotificationBuilder, channelId);
         }
     }
 

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -245,12 +245,18 @@ namespace Unity.Notifications.Android
         JniMethodID getGroup;
         JniMethodID getSortKey;
 
+        JniFieldID extras;
+        JniFieldID flags;
+        JniFieldID number;
+        JniFieldID when;
+
         public void CollectJni()
         {
             using (var notificationClass = new AndroidJavaClass("android.app.Notification"))
             {
                 CollectConstants(notificationClass);
                 CollectMethods(notificationClass);
+                CollectFields(notificationClass);
             }
         }
 
@@ -271,19 +277,27 @@ namespace Unity.Notifications.Android
             getSortKey = JniApi.FindMethod(clazz, "getSortKey", "()Ljava/lang/String;", false);
         }
 
+        void CollectFields(AndroidJavaClass clazz)
+        {
+            extras = JniApi.FindField(clazz, "extras", "Landroid/os/Bundle;", false);
+            flags = JniApi.FindField(clazz, "flags", "I", false);
+            number = JniApi.FindField(clazz, "number", "I", false);
+            when = JniApi.FindField(clazz, "when", "J", false);
+        }
+
         public AndroidJavaObject Extras(AndroidJavaObject notification)
         {
-            return notification.Get<AndroidJavaObject>("extras");
+            return notification.Get<AndroidJavaObject>(extras);
         }
 
         public int Flags(AndroidJavaObject notification)
         {
-            return notification.Get<int>("flags");
+            return notification.Get<int>(flags);
         }
 
         public int Number(AndroidJavaObject notification)
         {
-            return notification.Get<int>("number");
+            return notification.Get<int>(number);
         }
 
         public string GetGroup(AndroidJavaObject notification)
@@ -298,7 +312,7 @@ namespace Unity.Notifications.Android
 
         internal long When(AndroidJavaObject notification)
         {
-            return notification.Get<long>("when");
+            return notification.Get<long>(when);
         }
     }
 

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -88,6 +88,7 @@ namespace Unity.Notifications.Android
             KEY_SMALL_ICON = clazz.GetStatic<AndroidJavaObject>("KEY_SMALL_ICON");
 
             CollectMethods(clazz);
+            JniApi.Notification.CollectJni();
 #else
             KEY_FIRE_TIME = null;
             KEY_ID = null;
@@ -256,18 +257,23 @@ namespace Unity.Notifications.Android
             public static int FLAG_AUTO_CANCEL;
             public static int FLAG_GROUP_SUMMARY;
 
-            public static void CollectConstants()
+            public static void CollectJni()
             {
                 using (var notificationClass = new AndroidJavaClass("android.app.Notification"))
                 {
-                    EXTRA_TITLE = notificationClass.GetStatic<AndroidJavaObject>("EXTRA_TITLE");
-                    EXTRA_TEXT = notificationClass.GetStatic<AndroidJavaObject>("EXTRA_TEXT");
-                    EXTRA_SHOW_CHRONOMETER = notificationClass.GetStatic<AndroidJavaObject>("EXTRA_SHOW_CHRONOMETER");
-                    EXTRA_BIG_TEXT = notificationClass.GetStatic<AndroidJavaObject>("EXTRA_BIG_TEXT");
-                    EXTRA_SHOW_WHEN = notificationClass.GetStatic<AndroidJavaObject>("EXTRA_SHOW_WHEN");
-                    FLAG_AUTO_CANCEL = notificationClass.GetStatic<int>("FLAG_AUTO_CANCEL");
-                    FLAG_GROUP_SUMMARY = notificationClass.GetStatic<int>("FLAG_GROUP_SUMMARY");
+                    CollectConstants(notificationClass);
                 }
+            }
+
+            static void CollectConstants(AndroidJavaClass clazz)
+            {
+                EXTRA_TITLE = clazz.GetStatic<AndroidJavaObject>("EXTRA_TITLE");
+                EXTRA_TEXT = clazz.GetStatic<AndroidJavaObject>("EXTRA_TEXT");
+                EXTRA_SHOW_CHRONOMETER = clazz.GetStatic<AndroidJavaObject>("EXTRA_SHOW_CHRONOMETER");
+                EXTRA_BIG_TEXT = clazz.GetStatic<AndroidJavaObject>("EXTRA_BIG_TEXT");
+                EXTRA_SHOW_WHEN = clazz.GetStatic<AndroidJavaObject>("EXTRA_SHOW_WHEN");
+                FLAG_AUTO_CANCEL = clazz.GetStatic<int>("FLAG_AUTO_CANCEL");
+                FLAG_GROUP_SUMMARY = clazz.GetStatic<int>("FLAG_GROUP_SUMMARY");
             }
 
             public static AndroidJavaObject Extras(AndroidJavaObject notification)
@@ -449,7 +455,6 @@ namespace Unity.Notifications.Android
             var notificationManager = notificationManagerClass.CallStatic<AndroidJavaObject>("getNotificationManagerImpl", context, s_CurrentActivity);
             notificationManager.Call("setNotificationCallback", new NotificationCallback());
             s_Jni.NotificationManager = new NotificationManagerJni(notificationManagerClass, notificationManager);
-            JniApi.Notification.CollectConstants();
 
             s_Initialized = true;
 #endif

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -5,8 +5,10 @@ using UnityEngine;
 
 #if UNITY_2022_2_OR_NEWER
     using JniMethodID = System.IntPtr;
+    using JniFieldID = System.IntPtr;
 #else
     using JniMethodID = System.String;
+    using JniFieldID = System.String;
 #endif
 
 namespace Unity.Notifications.Android
@@ -471,6 +473,18 @@ namespace Unity.Notifications.Android
             NotificationBuilder.CollectJni();
             Bundle = default;
             Bundle.CollectJni();
+        }
+
+        public static JniFieldID FindField(AndroidJavaClass clazz, string name, string signature, bool isStatic)
+        {
+#if UNITY_2022_2_OR_NEWER
+            var field = AndroidJNIHelper.GetFieldID(clazz.GetRawClass(), name, signature, isStatic);
+            if (field == IntPtr.Zero)
+                throw new Exception($"Field {name} with signature {signature} not found");
+            return field;
+#else
+            return name;
+#endif
         }
 
         public static JniMethodID FindMethod(AndroidJavaClass clazz, string name, string signature, bool isStatic)

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -4,11 +4,11 @@ using System.Collections.Generic;
 using UnityEngine;
 
 #if UNITY_2022_2_OR_NEWER
-    using JniMethodID = System.IntPtr;
-    using JniFieldID = System.IntPtr;
+using JniMethodID = System.IntPtr;
+using JniFieldID = System.IntPtr;
 #else
-    using JniMethodID = System.String;
-    using JniFieldID = System.String;
+using JniMethodID = System.String;
+using JniFieldID = System.String;
 #endif
 
 namespace Unity.Notifications.Android

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -257,11 +257,15 @@ namespace Unity.Notifications.Android
             public static int FLAG_AUTO_CANCEL;
             public static int FLAG_GROUP_SUMMARY;
 
+            static JniMethodID getGroup;
+            static JniMethodID getSortKey;
+
             public static void CollectJni()
             {
                 using (var notificationClass = new AndroidJavaClass("android.app.Notification"))
                 {
                     CollectConstants(notificationClass);
+                    CollectMethods(notificationClass);
                 }
             }
 
@@ -274,6 +278,12 @@ namespace Unity.Notifications.Android
                 EXTRA_SHOW_WHEN = clazz.GetStatic<AndroidJavaObject>("EXTRA_SHOW_WHEN");
                 FLAG_AUTO_CANCEL = clazz.GetStatic<int>("FLAG_AUTO_CANCEL");
                 FLAG_GROUP_SUMMARY = clazz.GetStatic<int>("FLAG_GROUP_SUMMARY");
+            }
+
+            static void CollectMethods(AndroidJavaClass clazz)
+            {
+                getGroup = JniApi.FindMethod(clazz, "getGroup", "()Ljava/lang/String;", false);
+                getSortKey = JniApi.FindMethod(clazz, "getSortKey", "()Ljava/lang/String;", false);
             }
 
             public static AndroidJavaObject Extras(AndroidJavaObject notification)
@@ -293,12 +303,12 @@ namespace Unity.Notifications.Android
 
             public static string GetGroup(AndroidJavaObject notification)
             {
-                return notification.Call<string>("getGroup");
+                return notification.Call<string>(getGroup);
             }
 
             public static string GetSortKey(AndroidJavaObject notification)
             {
-                return notification.Call<string>("getSortKey");
+                return notification.Call<string>(getSortKey);
             }
 
             internal static long When(AndroidJavaObject notification)

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -388,11 +388,79 @@ namespace Unity.Notifications.Android
         }
     }
 
+    struct BundleJni
+    {
+        JniMethodID containsKey;
+        JniMethodID getBoolean;
+        JniMethodID getInt;
+        JniMethodID getLong;
+        JniMethodID getString;
+        JniMethodID putInt;
+        JniMethodID putLong;
+        JniMethodID putString;
+
+        public void CollectJni()
+        {
+            using (var clazz = new AndroidJavaClass("android/os/Bundle"))
+            {
+                containsKey = JniApi.FindMethod(clazz, "containsKey", "(Ljava/lang/String;)Z", false);
+                getBoolean = JniApi.FindMethod(clazz, "getBoolean", "(Ljava/lang/String;Z)Z", false);
+                getInt = JniApi.FindMethod(clazz, "getInt", "(Ljava/lang/String;I)I", false);
+                getLong = JniApi.FindMethod(clazz, "getLong", "(Ljava/lang/String;J)J", false);
+                getString = JniApi.FindMethod(clazz, "getString", "(Ljava/lang/String;)Ljava/lang/String;", false);
+                putInt = JniApi.FindMethod(clazz, "putInt", "(Ljava/lang/String;I)V", false);
+                putLong = JniApi.FindMethod(clazz, "putLong", "(Ljava/lang/String;J)V", false);
+                putString = JniApi.FindMethod(clazz, "putString", "(Ljava/lang/String;Ljava/lang/String;)V", false);
+            }
+        }
+
+        public bool ContainsKey(AndroidJavaObject bundle, AndroidJavaObject key)
+        {
+            return bundle.Call<bool>(containsKey, key);
+        }
+
+        public bool GetBoolean(AndroidJavaObject bundle, AndroidJavaObject key, bool defaultValue)
+        {
+            return bundle.Call<bool>(getBoolean, key, defaultValue);
+        }
+
+        public int GetInt(AndroidJavaObject bundle, AndroidJavaObject key, int defaultValue)
+        {
+            return bundle.Call<int>(getInt, key, defaultValue);
+        }
+
+        public long GetLong(AndroidJavaObject bundle, AndroidJavaObject key, long defaultValue)
+        {
+            return bundle.Call<long>(getLong, key, defaultValue);
+        }
+
+        public string GetString(AndroidJavaObject bundle, AndroidJavaObject key)
+        {
+            return bundle.Call<string>(getString, key);
+        }
+
+        public void PutInt(AndroidJavaObject bundle, AndroidJavaObject key, int value)
+        {
+            bundle.Call(putInt, key, value);
+        }
+
+        public void PutLong(AndroidJavaObject bundle, AndroidJavaObject key, long value)
+        {
+            bundle.Call(putLong, key, value);
+        }
+
+        public void PutString(AndroidJavaObject bundle, AndroidJavaObject key, string value)
+        {
+            bundle.Call(putString, key, value);
+        }
+    }
+
     struct JniApi
     {
         public NotificationManagerJni NotificationManager;
         public NotificationJni Notification;
         public NotificationBuilderJni NotificationBuilder;
+        public BundleJni Bundle;
 
         public JniApi(AndroidJavaClass notificationManagerClass, AndroidJavaObject notificationManager)
         {
@@ -401,7 +469,8 @@ namespace Unity.Notifications.Android
             Notification.CollectJni();
             NotificationBuilder = default;
             NotificationBuilder.CollectJni();
-            JniApi.Bundle.CollectJni();
+            Bundle = default;
+            Bundle.CollectJni();
         }
 
         public static JniMethodID FindMethod(AndroidJavaClass clazz, string name, string signature, bool isStatic)
@@ -414,73 +483,6 @@ namespace Unity.Notifications.Android
 #else
             return name;
 #endif
-        }
-
-        public static class Bundle
-        {
-            static JniMethodID containsKey;
-            static JniMethodID getBoolean;
-            static JniMethodID getInt;
-            static JniMethodID getLong;
-            static JniMethodID getString;
-            static JniMethodID putInt;
-            static JniMethodID putLong;
-            static JniMethodID putString;
-
-            public static void CollectJni()
-            {
-                using (var clazz = new AndroidJavaClass("android/os/Bundle"))
-                {
-                    containsKey = JniApi.FindMethod(clazz, "containsKey", "(Ljava/lang/String;)Z", false);
-                    getBoolean = JniApi.FindMethod(clazz, "getBoolean", "(Ljava/lang/String;Z)Z", false);
-                    getInt = JniApi.FindMethod(clazz, "getInt", "(Ljava/lang/String;I)I", false);
-                    getLong = JniApi.FindMethod(clazz, "getLong", "(Ljava/lang/String;J)J", false);
-                    getString = JniApi.FindMethod(clazz, "getString", "(Ljava/lang/String;)Ljava/lang/String;", false);
-                    putInt = JniApi.FindMethod(clazz, "putInt", "(Ljava/lang/String;I)V", false);
-                    putLong = JniApi.FindMethod(clazz, "putLong", "(Ljava/lang/String;J)V", false);
-                    putString = JniApi.FindMethod(clazz, "putString", "(Ljava/lang/String;Ljava/lang/String;)V", false);
-                }
-            }
-
-            public static bool ContainsKey(AndroidJavaObject bundle, AndroidJavaObject key)
-            {
-                return bundle.Call<bool>(containsKey, key);
-            }
-
-            public static bool GetBoolean(AndroidJavaObject bundle, AndroidJavaObject key, bool defaultValue)
-            {
-                return bundle.Call<bool>(getBoolean, key, defaultValue);
-            }
-
-            public static int GetInt(AndroidJavaObject bundle, AndroidJavaObject key, int defaultValue)
-            {
-                return bundle.Call<int>(getInt, key, defaultValue);
-            }
-
-            public static long GetLong(AndroidJavaObject bundle, AndroidJavaObject key, long defaultValue)
-            {
-                return bundle.Call<long>(getLong, key, defaultValue);
-            }
-
-            public static string GetString(AndroidJavaObject bundle, AndroidJavaObject key)
-            {
-                return bundle.Call<string>(getString, key);
-            }
-
-            public static void PutInt(AndroidJavaObject bundle, AndroidJavaObject key, int value)
-            {
-                bundle.Call(putInt, key, value);
-            }
-
-            public static void PutLong(AndroidJavaObject bundle, AndroidJavaObject key, long value)
-            {
-                bundle.Call(putLong, key, value);
-            }
-
-            public static void PutString(AndroidJavaObject bundle, AndroidJavaObject key, string value)
-            {
-                bundle.Call(putString, key, value);
-            }
         }
     }
 
@@ -868,11 +870,11 @@ namespace Unity.Notifications.Android
 
             using (var extras = s_Jni.NotificationBuilder.GetExtras(notificationBuilder))
             {
-                JniApi.Bundle.PutInt(extras, s_Jni.NotificationManager.KEY_ID, id);
-                JniApi.Bundle.PutLong(extras, s_Jni.NotificationManager.KEY_REPEAT_INTERVAL, notification.RepeatInterval.ToLong());
-                JniApi.Bundle.PutLong(extras, s_Jni.NotificationManager.KEY_FIRE_TIME, fireTime);
+                s_Jni.Bundle.PutInt(extras, s_Jni.NotificationManager.KEY_ID, id);
+                s_Jni.Bundle.PutLong(extras, s_Jni.NotificationManager.KEY_REPEAT_INTERVAL, notification.RepeatInterval.ToLong());
+                s_Jni.Bundle.PutLong(extras, s_Jni.NotificationManager.KEY_FIRE_TIME, fireTime);
                 if (!string.IsNullOrEmpty(notification.IntentData))
-                    JniApi.Bundle.PutString(extras, s_Jni.NotificationManager.KEY_INTENT_DATA, notification.IntentData);
+                    s_Jni.Bundle.PutString(extras, s_Jni.NotificationManager.KEY_INTENT_DATA, notification.IntentData);
             }
 
             return notificationBuilder;
@@ -882,7 +884,7 @@ namespace Unity.Notifications.Android
         {
             using (var extras = s_Jni.Notification.Extras(notificationObj))
             {
-                var id = JniApi.Bundle.GetInt(extras, s_Jni.NotificationManager.KEY_ID, -1);
+                var id = s_Jni.Bundle.GetInt(extras, s_Jni.NotificationManager.KEY_ID, -1);
                 if (id == -1)
                     return null;
 
@@ -890,28 +892,28 @@ namespace Unity.Notifications.Android
                 int flags = s_Jni.Notification.Flags(notificationObj);
 
                 var notification = new AndroidNotification();
-                notification.Title = JniApi.Bundle.GetString(extras, s_Jni.Notification.EXTRA_TITLE);
-                notification.Text = JniApi.Bundle.GetString(extras, s_Jni.Notification.EXTRA_TEXT);
-                notification.SmallIcon = JniApi.Bundle.GetString(extras, s_Jni.NotificationManager.KEY_SMALL_ICON);
-                notification.LargeIcon = JniApi.Bundle.GetString(extras, s_Jni.NotificationManager.KEY_LARGE_ICON);
+                notification.Title = s_Jni.Bundle.GetString(extras, s_Jni.Notification.EXTRA_TITLE);
+                notification.Text = s_Jni.Bundle.GetString(extras, s_Jni.Notification.EXTRA_TEXT);
+                notification.SmallIcon = s_Jni.Bundle.GetString(extras, s_Jni.NotificationManager.KEY_SMALL_ICON);
+                notification.LargeIcon = s_Jni.Bundle.GetString(extras, s_Jni.NotificationManager.KEY_LARGE_ICON);
                 notification.ShouldAutoCancel = 0 != (flags & s_Jni.Notification.FLAG_AUTO_CANCEL);
-                notification.UsesStopwatch = JniApi.Bundle.GetBoolean(extras, s_Jni.Notification.EXTRA_SHOW_CHRONOMETER, false);
-                notification.FireTime = JniApi.Bundle.GetLong(extras, s_Jni.NotificationManager.KEY_FIRE_TIME, -1L).ToDatetime();
-                notification.RepeatInterval = JniApi.Bundle.GetLong(extras, s_Jni.NotificationManager.KEY_REPEAT_INTERVAL, -1L).ToTimeSpan();
+                notification.UsesStopwatch = s_Jni.Bundle.GetBoolean(extras, s_Jni.Notification.EXTRA_SHOW_CHRONOMETER, false);
+                notification.FireTime = s_Jni.Bundle.GetLong(extras, s_Jni.NotificationManager.KEY_FIRE_TIME, -1L).ToDatetime();
+                notification.RepeatInterval = s_Jni.Bundle.GetLong(extras, s_Jni.NotificationManager.KEY_REPEAT_INTERVAL, -1L).ToTimeSpan();
 
-                if (JniApi.Bundle.ContainsKey(extras, s_Jni.Notification.EXTRA_BIG_TEXT))
+                if (s_Jni.Bundle.ContainsKey(extras, s_Jni.Notification.EXTRA_BIG_TEXT))
                     notification.Style = NotificationStyle.BigTextStyle;
                 else
                     notification.Style = NotificationStyle.None;
 
                 notification.Color = s_Jni.NotificationManager.GetNotificationColor(notificationObj);
                 notification.Number = s_Jni.Notification.Number(notificationObj);
-                notification.IntentData = JniApi.Bundle.GetString(extras, s_Jni.NotificationManager.KEY_INTENT_DATA);
+                notification.IntentData = s_Jni.Bundle.GetString(extras, s_Jni.NotificationManager.KEY_INTENT_DATA);
                 notification.Group = s_Jni.Notification.GetGroup(notificationObj);
                 notification.GroupSummary = 0 != (flags & s_Jni.Notification.FLAG_GROUP_SUMMARY);
                 notification.SortKey = s_Jni.Notification.GetSortKey(notificationObj);
                 notification.GroupAlertBehaviour = s_Jni.NotificationManager.GetNotificationGroupAlertBehavior(notificationObj).ToGroupAlertBehaviours();
-                var showTimestamp = JniApi.Bundle.GetBoolean(extras, s_Jni.Notification.EXTRA_SHOW_WHEN, false);
+                var showTimestamp = s_Jni.Bundle.GetBoolean(extras, s_Jni.Notification.EXTRA_SHOW_WHEN, false);
                 notification.ShowTimestamp = showTimestamp;
                 if (showTimestamp)
                     notification.CustomTimestamp = s_Jni.Notification.When(notificationObj).ToDatetime();

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -89,6 +89,7 @@ namespace Unity.Notifications.Android
 
             CollectMethods(clazz);
             JniApi.Notification.CollectJni();
+            JniApi.NotificationBuilder.CollectJni();
 #else
             KEY_FIRE_TIME = null;
             KEY_ID = null;
@@ -319,59 +320,89 @@ namespace Unity.Notifications.Android
 
         public static class NotificationBuilder
         {
+            static JniMethodID getExtras;
+            static JniMethodID setContentTitle;
+            static JniMethodID setContentText;
+            static JniMethodID setAutoCancel;
+            static JniMethodID setNumber;
+            static JniMethodID setStyle;
+            static JniMethodID setWhen;
+            static JniMethodID setGroup;
+            static JniMethodID setGroupSummary;
+            static JniMethodID setSortKey;
+            static JniMethodID setShowWhen;
+
+            public static void CollectJni()
+            {
+                using (var clazz = new AndroidJavaClass("android.app.Notification$Builder"))
+                {
+                    getExtras = JniApi.FindMethod(clazz, "getExtras", "()Landroid/os/Bundle;", false);
+                    setContentTitle = JniApi.FindMethod(clazz, "setContentTitle", "(Ljava/lang/CharSequence;)Landroid/app/Notification$Builder;", false);
+                    setContentText = JniApi.FindMethod(clazz, "setContentText", "(Ljava/lang/CharSequence;)Landroid/app/Notification$Builder;", false);
+                    setAutoCancel = JniApi.FindMethod(clazz, "setAutoCancel", "(Z)Landroid/app/Notification$Builder;", false);
+                    setNumber = JniApi.FindMethod(clazz, "setNumber", "(I)Landroid/app/Notification$Builder;", false);
+                    setStyle = JniApi.FindMethod(clazz, "setStyle", "(Landroid/app/Notification$Style;)Landroid/app/Notification$Builder;", false);
+                    setWhen = JniApi.FindMethod(clazz, "setWhen", "(J)Landroid/app/Notification$Builder;", false);
+                    setGroup = JniApi.FindMethod(clazz, "setGroup", "(Ljava/lang/String;)Landroid/app/Notification$Builder;", false);
+                    setGroupSummary = JniApi.FindMethod(clazz, "setGroupSummary", "(Z)Landroid/app/Notification$Builder;", false);
+                    setSortKey = JniApi.FindMethod(clazz, "setSortKey", "(Ljava/lang/String;)Landroid/app/Notification$Builder;", false);
+                    setShowWhen = JniApi.FindMethod(clazz, "setShowWhen", "(Z)Landroid/app/Notification$Builder;", false);
+                }
+            }
+
             public static AndroidJavaObject GetExtras(AndroidJavaObject builder)
             {
-                return builder.Call<AndroidJavaObject>("getExtras");
+                return builder.Call<AndroidJavaObject>(getExtras);
             }
 
             public static void SetContentTitle(AndroidJavaObject builder, string title)
             {
-                builder.Call<AndroidJavaObject>("setContentTitle", title).Dispose();
+                builder.Call<AndroidJavaObject>(setContentTitle, title).Dispose();
             }
 
             public static void SetContentText(AndroidJavaObject builder, string text)
             {
-                builder.Call<AndroidJavaObject>("setContentText", text).Dispose();
+                builder.Call<AndroidJavaObject>(setContentText, text).Dispose();
             }
 
             public static void SetAutoCancel(AndroidJavaObject builder, bool shouldAutoCancel)
             {
-                builder.Call<AndroidJavaObject>("setAutoCancel", shouldAutoCancel).Dispose();
+                builder.Call<AndroidJavaObject>(setAutoCancel, shouldAutoCancel).Dispose();
             }
 
             public static void SetNumber(AndroidJavaObject builder, int number)
             {
-                builder.Call<AndroidJavaObject>("setNumber", number).Dispose();
+                builder.Call<AndroidJavaObject>(setNumber, number).Dispose();
             }
 
             public static void SetStyle(AndroidJavaObject builder, AndroidJavaObject style)
             {
-                builder.Call<AndroidJavaObject>("setStyle", style).Dispose();
+                builder.Call<AndroidJavaObject>(setStyle, style).Dispose();
             }
 
             public static void SetWhen(AndroidJavaObject builder, long timestamp)
             {
-                builder.Call<AndroidJavaObject>("setWhen", timestamp).Dispose();
+                builder.Call<AndroidJavaObject>(setWhen, timestamp).Dispose();
             }
 
             public static void SetGroup(AndroidJavaObject builder, string group)
             {
-                builder.Call<AndroidJavaObject>("setGroup", group).Dispose();
+                builder.Call<AndroidJavaObject>(setGroup, group).Dispose();
             }
 
             public static void SetGroupSummary(AndroidJavaObject builder, bool groupSummary)
             {
-                builder.Call<AndroidJavaObject>("setGroupSummary", groupSummary).Dispose();
+                builder.Call<AndroidJavaObject>(setGroupSummary, groupSummary).Dispose();
             }
 
             public static void SetSortKey(AndroidJavaObject builder, string sortKey)
             {
-                builder.Call<AndroidJavaObject>("setSortKey", sortKey).Dispose();
+                builder.Call<AndroidJavaObject>(setSortKey, sortKey).Dispose();
             }
 
             public static void SetShowWhen(AndroidJavaObject builder, bool showTimestamp)
             {
-                builder.Call<AndroidJavaObject>("setShowWhen", showTimestamp).Dispose();
+                builder.Call<AndroidJavaObject>(setShowWhen, showTimestamp).Dispose();
             }
         }
 

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -219,6 +219,31 @@ namespace Unity.Notifications.Android
 
         public static class Bundle
         {
+            public static bool ContainsKey(AndroidJavaObject bundle, AndroidJavaObject key)
+            {
+                return bundle.Call<bool>("containsKey", key);
+            }
+
+            public static bool GetBoolean(AndroidJavaObject bundle, AndroidJavaObject key, bool defaultValue)
+            {
+                return bundle.Call<bool>("getBoolean", key, defaultValue);
+            }
+
+            public static int GetInt(AndroidJavaObject bundle, AndroidJavaObject key, int defaultValue)
+            {
+                return bundle.Call<int>("getInt", key, defaultValue);
+            }
+
+            public static long GetLong(AndroidJavaObject bundle, AndroidJavaObject key, long defaultValue)
+            {
+                return bundle.Call<long>("getLong", key, defaultValue);
+            }
+
+            public static string GetString(AndroidJavaObject bundle, AndroidJavaObject key)
+            {
+                return bundle.Call<string>("getString", key);
+            }
+
             public static void PutInt(AndroidJavaObject bundle, AndroidJavaObject key, int value)
             {
                 bundle.Call("putInt", key, value);
@@ -669,7 +694,7 @@ namespace Unity.Notifications.Android
         {
             using (var extras = notificationObj.Get<AndroidJavaObject>("extras"))
             {
-                var id = extras.Call<int>("getInt", KEY_ID, -1);
+                var id = JniApi.Bundle.GetInt(extras, KEY_ID, -1);
                 if (id == -1)
                     return null;
 
@@ -677,28 +702,28 @@ namespace Unity.Notifications.Android
                 int flags = notificationObj.Get<int>("flags");
 
                 var notification = new AndroidNotification();
-                notification.Title = extras.Call<string>("getString", Notification_EXTRA_TITLE);
-                notification.Text = extras.Call<string>("getString", Notification_EXTRA_TEXT);
-                notification.SmallIcon = extras.Call<string>("getString", KEY_SMALL_ICON);
-                notification.LargeIcon = extras.Call<string>("getString", KEY_LARGE_ICON);
+                notification.Title = JniApi.Bundle.GetString(extras, Notification_EXTRA_TITLE);
+                notification.Text = JniApi.Bundle.GetString(extras, Notification_EXTRA_TEXT);
+                notification.SmallIcon = JniApi.Bundle.GetString(extras, KEY_SMALL_ICON);
+                notification.LargeIcon = JniApi.Bundle.GetString(extras, KEY_LARGE_ICON);
                 notification.ShouldAutoCancel = 0 != (flags & Notification_FLAG_AUTO_CANCEL);
-                notification.UsesStopwatch = extras.Call<bool>("getBoolean", Notification_EXTRA_SHOW_CHRONOMETER, false);
-                notification.FireTime = extras.Call<long>("getLong", KEY_FIRE_TIME, -1L).ToDatetime();
-                notification.RepeatInterval = extras.Call<long>("getLong", KEY_REPEAT_INTERVAL, -1L).ToTimeSpan();
+                notification.UsesStopwatch = JniApi.Bundle.GetBoolean(extras, Notification_EXTRA_SHOW_CHRONOMETER, false);
+                notification.FireTime = JniApi.Bundle.GetLong(extras, KEY_FIRE_TIME, -1L).ToDatetime();
+                notification.RepeatInterval = JniApi.Bundle.GetLong(extras, KEY_REPEAT_INTERVAL, -1L).ToTimeSpan();
 
-                if (extras.Call<bool>("containsKey", Notification_EXTRA_BIG_TEXT))
+                if (JniApi.Bundle.ContainsKey(extras, Notification_EXTRA_BIG_TEXT))
                     notification.Style = NotificationStyle.BigTextStyle;
                 else
                     notification.Style = NotificationStyle.None;
 
                 notification.Color = s_Jni.NotificationManager.GetNotificationColor(notificationObj);
                 notification.Number = notificationObj.Get<int>("number");
-                notification.IntentData = extras.Call<string>("getString", KEY_INTENT_DATA);
+                notification.IntentData = JniApi.Bundle.GetString(extras, KEY_INTENT_DATA);
                 notification.Group = notificationObj.Call<string>("getGroup");
                 notification.GroupSummary = 0 != (flags & Notification_FLAG_GROUP_SUMMARY);
                 notification.SortKey = notificationObj.Call<string>("getSortKey");
                 notification.GroupAlertBehaviour = s_Jni.NotificationManager.GetNotificationGroupAlertBehavior(notificationObj).ToGroupAlertBehaviours();
-                var showTimestamp = extras.Call<bool>("getBoolean", Notification_EXTRA_SHOW_WHEN, false);
+                var showTimestamp = JniApi.Bundle.GetBoolean(extras, Notification_EXTRA_SHOW_WHEN, false);
                 notification.ShowTimestamp = showTimestamp;
                 if (showTimestamp)
                     notification.CustomTimestamp = notificationObj.Get<long>("when").ToDatetime();

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -36,11 +36,37 @@ namespace Unity.Notifications.Android
         private AndroidJavaClass klass;
         private AndroidJavaObject self;
 
+        public AndroidJavaObject KEY_FIRE_TIME;
+        public AndroidJavaObject KEY_ID;
+        public AndroidJavaObject KEY_INTENT_DATA;
+        public AndroidJavaObject KEY_LARGE_ICON;
+        public AndroidJavaObject KEY_REPEAT_INTERVAL;
+        public AndroidJavaObject KEY_NOTIFICATION;
+        public AndroidJavaObject KEY_SMALL_ICON;
+
 
         public NotificationManagerJni(AndroidJavaClass clazz, AndroidJavaObject obj)
         {
             klass = clazz;
             self = obj;
+
+#if UNITY_ANDROID && !UNITY_EDITOR
+            KEY_FIRE_TIME = clazz.GetStatic<AndroidJavaObject>("KEY_FIRE_TIME");
+            KEY_ID = clazz.GetStatic<AndroidJavaObject>("KEY_ID");
+            KEY_INTENT_DATA = clazz.GetStatic<AndroidJavaObject>("KEY_INTENT_DATA");
+            KEY_LARGE_ICON = clazz.GetStatic<AndroidJavaObject>("KEY_LARGE_ICON");
+            KEY_REPEAT_INTERVAL = clazz.GetStatic<AndroidJavaObject>("KEY_REPEAT_INTERVAL");
+            KEY_NOTIFICATION = clazz.GetStatic<AndroidJavaObject>("KEY_NOTIFICATION");
+            KEY_SMALL_ICON = clazz.GetStatic<AndroidJavaObject>("KEY_SMALL_ICON");
+#else
+            KEY_FIRE_TIME = null;
+            KEY_ID = null;
+            KEY_INTENT_DATA = null;
+            KEY_LARGE_ICON = null;
+            KEY_REPEAT_INTERVAL = null;
+            KEY_NOTIFICATION = null;
+            KEY_SMALL_ICON = null;
+#endif
         }
 
         public AndroidJavaObject GetNotificationFromIntent(AndroidJavaObject activity, AndroidJavaObject intent)
@@ -288,14 +314,6 @@ namespace Unity.Notifications.Android
         private static int Notification_FLAG_AUTO_CANCEL;
         private static int Notification_FLAG_GROUP_SUMMARY;
 
-        private static AndroidJavaObject KEY_FIRE_TIME;
-        private static AndroidJavaObject KEY_ID;
-        private static AndroidJavaObject KEY_INTENT_DATA;
-        private static AndroidJavaObject KEY_LARGE_ICON;
-        private static AndroidJavaObject KEY_REPEAT_INTERVAL;
-        private static AndroidJavaObject KEY_NOTIFICATION;
-        private static AndroidJavaObject KEY_SMALL_ICON;
-
         /// <summary>
         /// Initialize the AndroidNotificationCenter class.
         /// Can be safely called multiple times
@@ -334,14 +352,6 @@ namespace Unity.Notifications.Android
                 Notification_FLAG_AUTO_CANCEL = notificationClass.GetStatic<int>("FLAG_AUTO_CANCEL");
                 Notification_FLAG_GROUP_SUMMARY = notificationClass.GetStatic<int>("FLAG_GROUP_SUMMARY");
             }
-
-            KEY_FIRE_TIME = notificationManagerClass.GetStatic<AndroidJavaObject>("KEY_FIRE_TIME");
-            KEY_ID = notificationManagerClass.GetStatic<AndroidJavaObject>("KEY_ID");
-            KEY_INTENT_DATA = notificationManagerClass.GetStatic<AndroidJavaObject>("KEY_INTENT_DATA");
-            KEY_LARGE_ICON = notificationManagerClass.GetStatic<AndroidJavaObject>("KEY_LARGE_ICON");
-            KEY_REPEAT_INTERVAL = notificationManagerClass.GetStatic<AndroidJavaObject>("KEY_REPEAT_INTERVAL");
-            KEY_NOTIFICATION = notificationManagerClass.GetStatic<AndroidJavaObject>("KEY_NOTIFICATION");
-            KEY_SMALL_ICON = notificationManagerClass.GetStatic<AndroidJavaObject>("KEY_SMALL_ICON");
 
             s_Initialized = true;
 #endif
@@ -647,9 +657,9 @@ namespace Unity.Notifications.Android
             }
 
             var notificationBuilder = s_Jni.NotificationManager.CreateNotificationBuilder(channelId);
-            s_Jni.NotificationManager.SetNotificationIcon(notificationBuilder, KEY_SMALL_ICON, notification.SmallIcon);
+            s_Jni.NotificationManager.SetNotificationIcon(notificationBuilder, s_Jni.NotificationManager.KEY_SMALL_ICON, notification.SmallIcon);
             if (!string.IsNullOrEmpty(notification.LargeIcon))
-                s_Jni.NotificationManager.SetNotificationIcon(notificationBuilder, KEY_LARGE_ICON, notification.LargeIcon);
+                s_Jni.NotificationManager.SetNotificationIcon(notificationBuilder, s_Jni.NotificationManager.KEY_LARGE_ICON, notification.LargeIcon);
             JniApi.NotificationBuilder.SetContentTitle(notificationBuilder, notification.Title);
             JniApi.NotificationBuilder.SetContentText(notificationBuilder, notification.Text);
             JniApi.NotificationBuilder.SetAutoCancel(notificationBuilder, notification.ShouldAutoCancel);
@@ -680,11 +690,11 @@ namespace Unity.Notifications.Android
 
             using (var extras = notificationBuilder.Call<AndroidJavaObject>("getExtras"))
             {
-                JniApi.Bundle.PutInt(extras, KEY_ID, id);
-                JniApi.Bundle.PutLong(extras, KEY_REPEAT_INTERVAL, notification.RepeatInterval.ToLong());
-                JniApi.Bundle.PutLong(extras, KEY_FIRE_TIME, fireTime);
+                JniApi.Bundle.PutInt(extras, s_Jni.NotificationManager.KEY_ID, id);
+                JniApi.Bundle.PutLong(extras, s_Jni.NotificationManager.KEY_REPEAT_INTERVAL, notification.RepeatInterval.ToLong());
+                JniApi.Bundle.PutLong(extras, s_Jni.NotificationManager.KEY_FIRE_TIME, fireTime);
                 if (!string.IsNullOrEmpty(notification.IntentData))
-                    JniApi.Bundle.PutString(extras, KEY_INTENT_DATA, notification.IntentData);
+                    JniApi.Bundle.PutString(extras, s_Jni.NotificationManager.KEY_INTENT_DATA, notification.IntentData);
             }
 
             return notificationBuilder;
@@ -694,7 +704,7 @@ namespace Unity.Notifications.Android
         {
             using (var extras = notificationObj.Get<AndroidJavaObject>("extras"))
             {
-                var id = JniApi.Bundle.GetInt(extras, KEY_ID, -1);
+                var id = JniApi.Bundle.GetInt(extras, s_Jni.NotificationManager.KEY_ID, -1);
                 if (id == -1)
                     return null;
 
@@ -704,12 +714,12 @@ namespace Unity.Notifications.Android
                 var notification = new AndroidNotification();
                 notification.Title = JniApi.Bundle.GetString(extras, Notification_EXTRA_TITLE);
                 notification.Text = JniApi.Bundle.GetString(extras, Notification_EXTRA_TEXT);
-                notification.SmallIcon = JniApi.Bundle.GetString(extras, KEY_SMALL_ICON);
-                notification.LargeIcon = JniApi.Bundle.GetString(extras, KEY_LARGE_ICON);
+                notification.SmallIcon = JniApi.Bundle.GetString(extras, s_Jni.NotificationManager.KEY_SMALL_ICON);
+                notification.LargeIcon = JniApi.Bundle.GetString(extras, s_Jni.NotificationManager.KEY_LARGE_ICON);
                 notification.ShouldAutoCancel = 0 != (flags & Notification_FLAG_AUTO_CANCEL);
                 notification.UsesStopwatch = JniApi.Bundle.GetBoolean(extras, Notification_EXTRA_SHOW_CHRONOMETER, false);
-                notification.FireTime = JniApi.Bundle.GetLong(extras, KEY_FIRE_TIME, -1L).ToDatetime();
-                notification.RepeatInterval = JniApi.Bundle.GetLong(extras, KEY_REPEAT_INTERVAL, -1L).ToTimeSpan();
+                notification.FireTime = JniApi.Bundle.GetLong(extras, s_Jni.NotificationManager.KEY_FIRE_TIME, -1L).ToDatetime();
+                notification.RepeatInterval = JniApi.Bundle.GetLong(extras, s_Jni.NotificationManager.KEY_REPEAT_INTERVAL, -1L).ToTimeSpan();
 
                 if (JniApi.Bundle.ContainsKey(extras, Notification_EXTRA_BIG_TEXT))
                     notification.Style = NotificationStyle.BigTextStyle;
@@ -718,7 +728,7 @@ namespace Unity.Notifications.Android
 
                 notification.Color = s_Jni.NotificationManager.GetNotificationColor(notificationObj);
                 notification.Number = notificationObj.Get<int>("number");
-                notification.IntentData = JniApi.Bundle.GetString(extras, KEY_INTENT_DATA);
+                notification.IntentData = JniApi.Bundle.GetString(extras, s_Jni.NotificationManager.KEY_INTENT_DATA);
                 notification.Group = notificationObj.Call<string>("getGroup");
                 notification.GroupSummary = 0 != (flags & Notification_FLAG_GROUP_SUMMARY);
                 notification.SortKey = notificationObj.Call<string>("getSortKey");

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -163,6 +163,74 @@ namespace Unity.Notifications.Android
     struct JniApi
     {
         public NotificationManagerJni NotificationManager;
+
+        public static class NotificationBuilder
+        {
+            public static void SetContentTitle(AndroidJavaObject builder, string title)
+            {
+                builder.Call<AndroidJavaObject>("setContentTitle", title).Dispose();
+            }
+
+            public static void SetContentText(AndroidJavaObject builder, string text)
+            {
+                builder.Call<AndroidJavaObject>("setContentText", text).Dispose();
+            }
+
+            public static void SetAutoCancel(AndroidJavaObject builder, bool shouldAutoCancel)
+            {
+                builder.Call<AndroidJavaObject>("setAutoCancel", shouldAutoCancel).Dispose();
+            }
+
+            public static void SetNumber(AndroidJavaObject builder, int number)
+            {
+                builder.Call<AndroidJavaObject>("setNumber", number).Dispose();
+            }
+
+            public static void SetStyle(AndroidJavaObject builder, AndroidJavaObject style)
+            {
+                builder.Call<AndroidJavaObject>("setStyle", style).Dispose();
+            }
+
+            public static void SetWhen(AndroidJavaObject builder, long timestamp)
+            {
+                builder.Call<AndroidJavaObject>("setWhen", timestamp).Dispose();
+            }
+
+            public static void SetGroup(AndroidJavaObject builder, string group)
+            {
+                builder.Call<AndroidJavaObject>("setGroup", group).Dispose();
+            }
+
+            public static void SetGroupSummary(AndroidJavaObject builder, bool groupSummary)
+            {
+                builder.Call<AndroidJavaObject>("setGroupSummary", groupSummary).Dispose();
+            }
+
+            public static void SetSortKey(AndroidJavaObject builder, string sortKey)
+            {
+                builder.Call<AndroidJavaObject>("setSortKey", sortKey).Dispose();
+            }
+
+            public static void SetShowWhen(AndroidJavaObject builder, bool showTimestamp)
+            {
+                builder.Call<AndroidJavaObject>("setShowWhen", showTimestamp).Dispose();
+            }
+
+            public static void ExtrasPutInt(AndroidJavaObject extras, AndroidJavaObject key, int value)
+            {
+                extras.Call("putInt", key, value);
+            }
+
+            public static void ExtrasPutLong(AndroidJavaObject extras, AndroidJavaObject key, long value)
+            {
+                extras.Call("putLong", key, value);
+            }
+
+            public static void ExtrasPutString(AndroidJavaObject extras, AndroidJavaObject key, string value)
+            {
+                extras.Call("putString", key, value);
+            }
+        }
     }
 
     /// <summary>
@@ -554,28 +622,28 @@ namespace Unity.Notifications.Android
             s_Jni.NotificationManager.SetNotificationIcon(notificationBuilder, KEY_SMALL_ICON, notification.SmallIcon);
             if (!string.IsNullOrEmpty(notification.LargeIcon))
                 s_Jni.NotificationManager.SetNotificationIcon(notificationBuilder, KEY_LARGE_ICON, notification.LargeIcon);
-            notificationBuilder.Call<AndroidJavaObject>("setContentTitle", notification.Title).Dispose();
-            notificationBuilder.Call<AndroidJavaObject>("setContentText", notification.Text).Dispose();
-            notificationBuilder.Call<AndroidJavaObject>("setAutoCancel", notification.ShouldAutoCancel).Dispose();
+            JniApi.NotificationBuilder.SetContentTitle(notificationBuilder, notification.Title);
+            JniApi.NotificationBuilder.SetContentText(notificationBuilder, notification.Text);
+            JniApi.NotificationBuilder.SetAutoCancel(notificationBuilder, notification.ShouldAutoCancel);
             if (notification.Number >= 0)
-                notificationBuilder.Call<AndroidJavaObject>("setNumber", notification.Number).Dispose();
+                JniApi.NotificationBuilder.SetNumber(notificationBuilder, notification.Number);
             if (notification.Style == NotificationStyle.BigTextStyle)
             {
                 using (var style = new AndroidJavaObject("android.app.Notification$BigTextStyle"))
                 {
                     style.Call<AndroidJavaObject>("bigText", notification.Text).Dispose();
-                    notificationBuilder.Call<AndroidJavaObject>("setStyle", style).Dispose();
+                    JniApi.NotificationBuilder.SetStyle(notificationBuilder, style);
                 }
             }
             long timestampValue = notification.ShowCustomTimestamp ? notification.CustomTimestamp.ToLong() : fireTime;
-            notificationBuilder.Call<AndroidJavaObject>("setWhen", timestampValue).Dispose();
+            JniApi.NotificationBuilder.SetWhen(notificationBuilder, timestampValue);
             if (!string.IsNullOrEmpty(notification.Group))
-                notificationBuilder.Call<AndroidJavaObject>("setGroup", notification.Group).Dispose();
+                JniApi.NotificationBuilder.SetGroup(notificationBuilder, notification.Group);
             if (notification.GroupSummary)
-                notificationBuilder.Call<AndroidJavaObject>("setGroupSummary", notification.GroupSummary).Dispose();
+                JniApi.NotificationBuilder.SetGroupSummary(notificationBuilder, notification.GroupSummary);
             if (!string.IsNullOrEmpty(notification.SortKey))
-                notificationBuilder.Call<AndroidJavaObject>("setSortKey", notification.SortKey).Dispose();
-            notificationBuilder.Call<AndroidJavaObject>("setShowWhen", notification.ShowTimestamp).Dispose();
+                JniApi.NotificationBuilder.SetSortKey(notificationBuilder, notification.SortKey);
+            JniApi.NotificationBuilder.SetShowWhen(notificationBuilder, notification.ShowTimestamp);
             int color = notification.Color.ToInt();
             if (color != 0)
                 s_Jni.NotificationManager.SetNotificationColor(notificationBuilder, color);
@@ -584,11 +652,11 @@ namespace Unity.Notifications.Android
 
             using (var extras = notificationBuilder.Call<AndroidJavaObject>("getExtras"))
             {
-                extras.Call("putInt", KEY_ID, id);
-                extras.Call("putLong", KEY_REPEAT_INTERVAL, notification.RepeatInterval.ToLong());
-                extras.Call("putLong", KEY_FIRE_TIME, fireTime);
+                JniApi.NotificationBuilder.ExtrasPutInt(extras, KEY_ID, id);
+                JniApi.NotificationBuilder.ExtrasPutLong(extras, KEY_REPEAT_INTERVAL, notification.RepeatInterval.ToLong());
+                JniApi.NotificationBuilder.ExtrasPutLong(extras, KEY_FIRE_TIME, fireTime);
                 if (!string.IsNullOrEmpty(notification.IntentData))
-                    extras.Call("putString", KEY_INTENT_DATA, notification.IntentData);
+                    JniApi.NotificationBuilder.ExtrasPutString(extras, KEY_INTENT_DATA, notification.IntentData);
             }
 
             return notificationBuilder;

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -136,7 +136,13 @@ namespace Unity.Notifications.Android
             {
                 if (color == null)
                     return null;
+#if UNITY_2022_2_OR_NEWER
+                int val;
+                AndroidJNIHelper.Unbox(color.GetRawObject(), out val);
+                return val.ToColor();
+#else
                 return color.Call<int>("intValue").ToColor();
+#endif
             }
         }
 

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -215,20 +215,23 @@ namespace Unity.Notifications.Android
             {
                 builder.Call<AndroidJavaObject>("setShowWhen", showTimestamp).Dispose();
             }
+        }
 
-            public static void ExtrasPutInt(AndroidJavaObject extras, AndroidJavaObject key, int value)
+        public static class Bundle
+        {
+            public static void PutInt(AndroidJavaObject bundle, AndroidJavaObject key, int value)
             {
-                extras.Call("putInt", key, value);
+                bundle.Call("putInt", key, value);
             }
 
-            public static void ExtrasPutLong(AndroidJavaObject extras, AndroidJavaObject key, long value)
+            public static void PutLong(AndroidJavaObject bundle, AndroidJavaObject key, long value)
             {
-                extras.Call("putLong", key, value);
+                bundle.Call("putLong", key, value);
             }
 
-            public static void ExtrasPutString(AndroidJavaObject extras, AndroidJavaObject key, string value)
+            public static void PutString(AndroidJavaObject bundle, AndroidJavaObject key, string value)
             {
-                extras.Call("putString", key, value);
+                bundle.Call("putString", key, value);
             }
         }
     }
@@ -652,11 +655,11 @@ namespace Unity.Notifications.Android
 
             using (var extras = notificationBuilder.Call<AndroidJavaObject>("getExtras"))
             {
-                JniApi.NotificationBuilder.ExtrasPutInt(extras, KEY_ID, id);
-                JniApi.NotificationBuilder.ExtrasPutLong(extras, KEY_REPEAT_INTERVAL, notification.RepeatInterval.ToLong());
-                JniApi.NotificationBuilder.ExtrasPutLong(extras, KEY_FIRE_TIME, fireTime);
+                JniApi.Bundle.PutInt(extras, KEY_ID, id);
+                JniApi.Bundle.PutLong(extras, KEY_REPEAT_INTERVAL, notification.RepeatInterval.ToLong());
+                JniApi.Bundle.PutLong(extras, KEY_FIRE_TIME, fireTime);
                 if (!string.IsNullOrEmpty(notification.IntentData))
-                    JniApi.NotificationBuilder.ExtrasPutString(extras, KEY_INTENT_DATA, notification.IntentData);
+                    JniApi.Bundle.PutString(extras, KEY_INTENT_DATA, notification.IntentData);
             }
 
             return notificationBuilder;

--- a/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
@@ -182,7 +182,8 @@ class iOSNotificationTests
 
         iOSNotificationCenter.ScheduleNotification(notification);
         Debug.Log($"SendNotificationUsingCalendarTrigger_NotificationIsReceived, Now: {dateTime}, Notification should arrive on: {dt}");
-        yield return WaitForNotification(10.0f);
+        yield return WaitForNotification(20.0f);
+        Debug.Log($"SendNotificationUsingCalendarTrigger_NotificationIsReceived, wait finished at: {DateTime.Now}");
         Assert.AreEqual(1, receivedNotificationCount);
         Assert.IsNotNull(lastReceivedNotification);
         Assert.AreEqual(text, lastReceivedNotification.Title);


### PR DESCRIPTION
The thing in this PR is performance. JNI calls are expensive and scheduling a notification is way too costly at the moment.
This PR addresses the C#<->Java interop part of the problem. Setting up Notification.Builder takes milliseconds of time (low single digit figure, but that's still huge time). The main problem is that when using AndroidJavaObject we actually invoke Java code where reflection is used to find the method to invoke (there is some cashing there). In latest Unity we have improvement in the area where we can call method via jmethodID, a significant shortcut.
Tested on 3 different devices and in all cases I see a fairly consistent ~3x improvement for creating and setting up Notification.Builder on 22.2 (didn't measure older versions, but on average should also be better due to not calling Java for no reason, like to set the value that is already the default).

Testing done:
- Automated test test sending/receiving and all parameter setting/getting
- Performance tested using specially made project on Nokia 7 Plus (10.0), Asus ROG (8.1) and Samsung Galaxy S7 (7.0)
- On first two also ran automated tests locally using 2022.2

Request for QA:
- the key split is Unity 2022.2 vs older versions (different implementation)
- make sure notification parameters work, use fancy notifications (colors, icons); in package project should have enough buttons for that
- no need to test many Unity versions, one version older then 2022.2 on one or two devices should suffice for "older"
- Unity 2022.2 needs more testing, but there's a split:
  - test the same fancy notifications in this version on one or two devices
  - we do collect most of required stuff during initialization and blow up if something is not found; send one notification on device and if it works, you can assume it's OK; try this on more devices and different android versions