### PR TITLE
Add missing authorisation statuses

### DIFF
--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationSettings.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationSettings.cs
@@ -14,11 +14,19 @@ namespace Unity.Notifications.iOS
         /// <summary>
         /// The application is not authorized to post notifications.
         /// </summary>
-        Denied,
+        Denied = 1,
         /// <summary>
         /// The application is authorized to post notifications.
         /// </summary>
-        Authorized
+        Authorized = 2,
+        /// <summary>
+        /// The application is authorized to post non-interruptive user notifications.
+        /// </summary>
+        Provisional = 3,
+        /// <summary>
+        /// The application is temporarily authorized to post notifications. Only available to app clips.
+        /// </summary>
+        Ephemeral = 4,
     }
 
     /// <summary>


### PR DESCRIPTION
https://github.com/Unity-Technologies/com.unity.mobile.notifications/issues/189

Unity enum misses a couple of values: https://developer.apple.com/documentation/usernotifications/unauthorizationstatus?language=objc