### PR TITLE
Android: refactor threading and notification scheduling

### DIFF
--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationBackgroundThread.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationBackgroundThread.java
@@ -28,8 +28,16 @@ public class UnityNotificationBackgroundThread extends Thread {
         @Override
         public boolean run(Context context, Set<String> notificationIds) {
             String id = String.valueOf(notificationId);
-            UnityNotificationManager.mUnityNotificationManager.performNotificationScheduling(notificationId, notificationBuilder);
-            return notificationIds.add(id);
+            try {
+                UnityNotificationManager.mUnityNotificationManager.performNotificationScheduling(notificationId, notificationBuilder);
+                return notificationIds.add(id);
+            } finally {
+                // if failed to schedule or replace, remove from settings and cache, so the status is correctly reported
+                if (!notificationIds.contains(id)) {
+                    UnityNotificationManager.deleteExpiredNotificationIntent(context, id);
+                    UnityNotificationManager.removeScheduledNotification(Integer.valueOf(notificationId));
+                }
+            }
         }
     }
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationBackgroundThread.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationBackgroundThread.java
@@ -60,14 +60,11 @@ public class UnityNotificationBackgroundThread extends Thread {
             try {
                 Runnable task = mTasks.take();
                 task.run();
-                android.util.Log.d("Unity", "Notification background task done");
             } catch (InterruptedException e) {
                 if (mTasks.isEmpty())
                     break;
             }
         }
-
-        android.util.Log.d("Unity", "Notification background thread exited");
     }
 
     private void performHousekeeping() {

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationBackgroundThread.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationBackgroundThread.java
@@ -16,6 +16,26 @@ public class UnityNotificationBackgroundThread extends Thread {
         mTasks.add(task);
     }
 
+    public void enqueueCancelNotification(int id) {
+        mTasks.add(() -> {
+            UnityNotificationManager.cancelPendingNotificationIntent(UnityNotificationManager.mUnityNotificationManager.mContext, id);
+        });
+    }
+
+    public void enqueueCancelAllNotifications() {
+        mTasks.add(() -> {
+            Context context = UnityNotificationManager.mUnityNotificationManager.mContext;
+            Set<String> ids = UnityNotificationManager.getScheduledNotificationIDs(context);
+
+            if (ids.size() > 0) {
+                for (String id : ids) {
+                    UnityNotificationManager.cancelPendingNotificationIntent(context, Integer.valueOf(id));
+                    UnityNotificationManager.deleteExpiredNotificationIntent(context, id);
+                }
+            }
+        });
+    }
+
     public void enqueueHousekeeping() {
         mTasks.add(() -> { performHousekeeping(); });
     }

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationBackgroundThread.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationBackgroundThread.java
@@ -1,18 +1,32 @@
 package com.unity.androidnotifications;
 
+import android.app.Notification;
 import android.content.Context;
 
 import java.util.concurrent.LinkedTransferQueue;
 import java.util.Set;
 
 public class UnityNotificationBackgroundThread extends Thread {
+    public static class ScheduleNotificationTask implements Runnable {
+        private Notification.Builder notificationBuilder;
+
+        public ScheduleNotificationTask(Notification.Builder builder) {
+            notificationBuilder = builder;
+        }
+
+        @Override
+        public void run() {
+            UnityNotificationManager.mUnityNotificationManager.performNotificationScheduling(notificationBuilder);
+        }
+    }
+
     private LinkedTransferQueue<Runnable> mTasks = new LinkedTransferQueue();
 
     public UnityNotificationBackgroundThread() {
         enqueueHousekeeping();
     }
 
-    public void enqueueTask(Runnable task) {
+    public void enqueueNotification(ScheduleNotificationTask task) {
         mTasks.add(task);
     }
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationBackgroundThread.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationBackgroundThread.java
@@ -1,6 +1,9 @@
 package com.unity.androidnotifications;
 
+import android.content.Context;
+
 import java.util.concurrent.LinkedTransferQueue;
+import java.util.Set;
 
 public class UnityNotificationBackgroundThread extends Thread {
     private LinkedTransferQueue<Runnable> mTasks = new LinkedTransferQueue();
@@ -11,6 +14,8 @@ public class UnityNotificationBackgroundThread extends Thread {
 
     @Override
     public void run() {
+        performHousekeeping();
+
         while (true) {
             try {
                 Runnable task = mTasks.take();
@@ -23,5 +28,11 @@ public class UnityNotificationBackgroundThread extends Thread {
         }
 
         android.util.Log.d("Unity", "Notification background thread exited");
+    }
+
+    private void performHousekeeping() {
+        Context context = UnityNotificationManager.mUnityNotificationManager.mContext;
+        Set<String> notificationIds = UnityNotificationManager.getScheduledNotificationIDs(context);
+        UnityNotificationManager.performNotificationHousekeeping(context, notificationIds);
     }
 }

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationBackgroundThread.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationBackgroundThread.java
@@ -28,9 +28,6 @@ public class UnityNotificationBackgroundThread extends Thread {
         @Override
         public boolean run(Context context, Set<String> notificationIds) {
             String id = String.valueOf(notificationId);
-            // are we replacing existing alarm or have capacity to schedule new one
-            if (!(notificationIds.contains(id) || UnityNotificationManager.canScheduleMoreAlarms(notificationIds)))
-                return false;
             UnityNotificationManager.mUnityNotificationManager.performNotificationScheduling(notificationId, notificationBuilder);
             return notificationIds.add(id);
         }

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationBackgroundThread.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationBackgroundThread.java
@@ -78,7 +78,7 @@ public class UnityNotificationBackgroundThread extends Thread {
 
     private LinkedTransferQueue<Task> mTasks = new LinkedTransferQueue();
     private int mSentNotificationsSinceHousekeeping = 0;
-    private int mOtherTasksSinceHousekeeping = 0;
+    private int mOtherTasksSinceHousekeeping;
 
     public UnityNotificationBackgroundThread() {
         // force housekeeping
@@ -128,8 +128,9 @@ public class UnityNotificationBackgroundThread extends Thread {
                 ++mSentNotificationsSinceHousekeeping;
             else
                 ++mOtherTasksSinceHousekeeping;
-            if (mSentNotificationsSinceHousekeeping >= 50)
+            if ((mSentNotificationsSinceHousekeeping + mOtherTasksSinceHousekeeping) >= 50) {
                 enqueueHousekeeping();
+            }
         } catch (Exception e) {
             Log.e(TAG_UNITY, "Exception executing notification task", e);
         }

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationBackgroundThread.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationBackgroundThread.java
@@ -47,15 +47,21 @@ public class UnityNotificationBackgroundThread extends Thread {
         public boolean run(Context context, Set<String> notificationIds) {
             UnityNotificationManager.cancelPendingNotificationIntent(context, notificationId);
             String id = String.valueOf(notificationId);
-            UnityNotificationManager.deleteExpiredNotificationIntent(context, id);
-            notificationIds.remove(id);
-            return true;
+            if (notificationIds.remove(id)) {
+                UnityNotificationManager.deleteExpiredNotificationIntent(context, id);
+                return true;
+            }
+
+            return false;
         }
     }
 
     private static class CancelAllNotificationsTask extends Task {
         @Override
         public boolean run(Context context, Set<String> notificationIds) {
+            if (notificationIds.isEmpty())
+                return false;
+
             for (String id : notificationIds) {
                 UnityNotificationManager.cancelPendingNotificationIntent(context, Integer.valueOf(id));
                 UnityNotificationManager.deleteExpiredNotificationIntent(context, id);

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationBackgroundThread.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationBackgroundThread.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import android.util.Log;
 
 import java.util.concurrent.LinkedTransferQueue;
+import java.util.HashSet;
 import java.util.Set;
 
 public class UnityNotificationBackgroundThread extends Thread {
@@ -21,6 +22,15 @@ public class UnityNotificationBackgroundThread extends Thread {
 
         @Override
         public void run() {
+            Context context = UnityNotificationManager.mUnityNotificationManager.mContext;
+            Set<String> ids = UnityNotificationManager.getScheduledNotificationIDs(context);
+            String id = String.valueOf(notificationId);
+            // are we replacing existing alarm or have capacity to schedule new one
+            if (!(ids.contains(id) || UnityNotificationManager.canScheduleMoreAlarms(ids)))
+                return;
+            ids = new HashSet<>(ids);
+            ids.add(id);
+            UnityNotificationManager.saveScheduledNotificationIDs(context, ids);
             UnityNotificationManager.mUnityNotificationManager.performNotificationScheduling(notificationId, notificationBuilder);
         }
     }

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationBackgroundThread.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationBackgroundThread.java
@@ -10,7 +10,7 @@ import java.util.concurrent.LinkedTransferQueue;
 import java.util.Set;
 
 public class UnityNotificationBackgroundThread extends Thread {
-    public static class ScheduleNotificationTask implements Runnable {
+    private static class ScheduleNotificationTask implements Runnable {
         private Notification.Builder notificationBuilder;
 
         public ScheduleNotificationTask(Notification.Builder builder) {
@@ -33,8 +33,8 @@ public class UnityNotificationBackgroundThread extends Thread {
         enqueueHousekeeping();
     }
 
-    public void enqueueNotification(ScheduleNotificationTask task) {
-        mTasks.add(task);
+    public void enqueueNotification(Notification.Builder notificationBuilder) {
+        mTasks.add(new UnityNotificationBackgroundThread.ScheduleNotificationTask(notificationBuilder));
     }
 
     public void enqueueCancelNotification(int id) {

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationBackgroundThread.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationBackgroundThread.java
@@ -8,14 +8,20 @@ import java.util.Set;
 public class UnityNotificationBackgroundThread extends Thread {
     private LinkedTransferQueue<Runnable> mTasks = new LinkedTransferQueue();
 
+    public UnityNotificationBackgroundThread() {
+        enqueueHousekeeping();
+    }
+
     public void enqueueTask(Runnable task) {
         mTasks.add(task);
     }
 
+    public void enqueueHousekeeping() {
+        mTasks.add(() -> { performHousekeeping(); });
+    }
+
     @Override
     public void run() {
-        performHousekeeping();
-
         while (true) {
             try {
                 Runnable task = mTasks.take();

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationBackgroundThread.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationBackgroundThread.java
@@ -1,0 +1,27 @@
+package com.unity.androidnotifications;
+
+import java.util.concurrent.LinkedTransferQueue;
+
+public class UnityNotificationBackgroundThread extends Thread {
+    private LinkedTransferQueue<Runnable> mTasks = new LinkedTransferQueue();
+
+    public void enqueueTask(Runnable task) {
+        mTasks.add(task);
+    }
+
+    @Override
+    public void run() {
+        while (true) {
+            try {
+                Runnable task = mTasks.take();
+                task.run();
+                android.util.Log.d("Unity", "Notification background task done");
+            } catch (InterruptedException e) {
+                if (mTasks.isEmpty())
+                    break;
+            }
+        }
+
+        android.util.Log.d("Unity", "Notification background thread exited");
+    }
+}

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationBackgroundThread.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationBackgroundThread.java
@@ -11,15 +11,17 @@ import java.util.Set;
 
 public class UnityNotificationBackgroundThread extends Thread {
     private static class ScheduleNotificationTask implements Runnable {
+        private int notificationId;
         private Notification.Builder notificationBuilder;
 
-        public ScheduleNotificationTask(Notification.Builder builder) {
+        public ScheduleNotificationTask(int id, Notification.Builder builder) {
+            notificationId = id;
             notificationBuilder = builder;
         }
 
         @Override
         public void run() {
-            UnityNotificationManager.mUnityNotificationManager.performNotificationScheduling(notificationBuilder);
+            UnityNotificationManager.mUnityNotificationManager.performNotificationScheduling(notificationId, notificationBuilder);
         }
     }
 
@@ -33,8 +35,8 @@ public class UnityNotificationBackgroundThread extends Thread {
         enqueueHousekeeping();
     }
 
-    public void enqueueNotification(Notification.Builder notificationBuilder) {
-        mTasks.add(new UnityNotificationBackgroundThread.ScheduleNotificationTask(notificationBuilder));
+    public void enqueueNotification(int id, Notification.Builder notificationBuilder) {
+        mTasks.add(new UnityNotificationBackgroundThread.ScheduleNotificationTask(id, notificationBuilder));
     }
 
     public void enqueueCancelNotification(int id) {

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationBackgroundThread.java.meta
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationBackgroundThread.java.meta
@@ -1,0 +1,32 @@
+fileFormatVersion: 2
+guid: 730fe99464139481283855dcdfc3b0e8
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Android: Android
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -39,7 +39,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
     protected static UnityNotificationManager mUnityNotificationManager;
     private static HashMap<Integer, Notification> mScheduledNotifications = new HashMap();
     private static HashSet<Integer> mVisibleNotifications = new HashSet<>();
-    private static int mSentSinceLastHousekeeping = 0;
 
     public Context mContext = null;
     protected Activity mActivity = null;
@@ -373,22 +372,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         ids = new HashSet<>(ids);
         ids.add(String.valueOf(notificationId));
         saveScheduledNotificationIDs(context, ids);
-        scheduleHousekeeping(context, ids);
         return intent;
-    }
-
-    private static synchronized void scheduleHousekeeping(Context context, Set<String> ids) {
-        ++mSentSinceLastHousekeeping;
-        if (mSentSinceLastHousekeeping > 50) {
-            mSentSinceLastHousekeeping = 0;
-            triggerHousekeeping();
-        }
-    }
-
-    private static synchronized void triggerHousekeeping() {
-        if (mUnityNotificationManager != null) {
-            mUnityNotificationManager.mBackgroundThread.enqueueHousekeeping();
-        }
     }
 
     protected static void performNotificationHousekeeping(Context context, Set<String> ids) {
@@ -402,7 +386,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
                 removeScheduledNotification(Integer.valueOf(id));
             }
             saveScheduledNotificationIDs(context, currentIds);
-            mSentSinceLastHousekeeping = 0;
         }
 
         // in case we have saved intents, clear them

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -261,34 +261,36 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
     // This is called from Unity managed code to call AlarmManager to set a broadcast intent for sending a notification.
     public void scheduleNotification(Notification.Builder notificationBuilder) {
-        Bundle extras = notificationBuilder.getExtras();
-        int id = extras.getInt(KEY_ID, -1);
-        long repeatInterval = extras.getLong(KEY_REPEAT_INTERVAL, -1);
-        long fireTime = extras.getLong(KEY_FIRE_TIME, -1);
-        Notification notification = null;
+        mBackgroundThread.enqueueTask(() -> {
+            Bundle extras = notificationBuilder.getExtras();
+            int id = extras.getInt(KEY_ID, -1);
+            long repeatInterval = extras.getLong(KEY_REPEAT_INTERVAL, -1);
+            long fireTime = extras.getLong(KEY_FIRE_TIME, -1);
+            Notification notification = null;
 
-        // if less than a second in the future, notify right away
-        boolean fireNow = fireTime - Calendar.getInstance().getTime().getTime() < 1000;
-        if (!fireNow || repeatInterval > 0) {
+            // if less than a second in the future, notify right away
+            boolean fireNow = fireTime - Calendar.getInstance().getTime().getTime() < 1000;
+            if (!fireNow || repeatInterval > 0) {
+                if (fireNow) {
+                    // schedule at next repetition
+                    fireTime += repeatInterval;
+                }
+
+                Intent intent = buildNotificationIntentUpdateList(mContext, id);
+
+                if (intent != null) {
+                    UnityNotificationManager.saveNotification(mContext, notificationBuilder.build());
+                    notification = scheduleAlarmWithNotification(notificationBuilder, intent, fireTime);
+                }
+            }
+
             if (fireNow) {
-                // schedule at next repetition
-                fireTime += repeatInterval;
+                if (notification == null) {
+                    notification = buildNotificationForSending(mContext, mOpenActivity, notificationBuilder);
+                }
+                notify(mContext, id, notification);
             }
-
-            Intent intent = buildNotificationIntentUpdateList(mContext, id);
-
-            if (intent != null) {
-                UnityNotificationManager.saveNotification(mContext, notificationBuilder.build());
-                notification = scheduleAlarmWithNotification(notificationBuilder, intent, fireTime);
-            }
-        }
-
-        if (fireNow) {
-            if (notification == null) {
-                notification = buildNotificationForSending(mContext, mOpenActivity, notificationBuilder);
-            }
-            notify(mContext, id, notification);
-        }
+        });
     }
 
     Notification scheduleAlarmWithNotification(Notification.Builder notificationBuilder, Intent intent, long fireTime) {

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -380,7 +380,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
                 currentIds.remove(id);
                 removeScheduledNotification(Integer.valueOf(id));
             }
-            saveScheduledNotificationIDs(context, currentIds);
         }
 
         // in case we have saved intents, clear them

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -643,10 +643,21 @@ public class UnityNotificationManager extends BroadcastReceiver {
     // Call the system notification service to notify the notification.
     protected static void notify(Context context, int id, Notification notification) {
         boolean showInForeground = notification.extras.getBoolean(KEY_SHOW_IN_FOREGROUND, true);
+        boolean didShowNotification = false;
         if (!isInForeground() || showInForeground) {
+            didShowNotification = true;
             getNotificationManager(context).notify(id, notification);
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) synchronized (UnityNotificationManager.class) {
                 mVisibleNotifications.add(Integer.valueOf(id));
+            }
+        }
+
+        if (!didShowNotification) {
+            // if notification is not shown and not repeating, cleanup so it's status does not show as scheduled
+            long repeatInterval = notification.extras.getLong(KEY_REPEAT_INTERVAL, -1);
+            if (repeatInterval <= 0) {
+                removeScheduledNotification(id);
+                deleteExpiredNotificationIntent(context, String.valueOf(id));
             }
         }
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -260,7 +260,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
     public void scheduleNotification(Notification.Builder notificationBuilder) {
         int id = notificationBuilder.getExtras().getInt(KEY_ID, -1);
         putScheduledNotification(id);
-        mBackgroundThread.enqueueNotification(new UnityNotificationBackgroundThread.ScheduleNotificationTask(notificationBuilder));
+        mBackgroundThread.enqueueNotification(notificationBuilder);
     }
 
     protected void performNotificationScheduling(Notification.Builder notificationBuilder) {

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -260,12 +260,11 @@ public class UnityNotificationManager extends BroadcastReceiver {
     public void scheduleNotification(Notification.Builder notificationBuilder) {
         int id = notificationBuilder.getExtras().getInt(KEY_ID, -1);
         putScheduledNotification(id);
-        mBackgroundThread.enqueueNotification(notificationBuilder);
+        mBackgroundThread.enqueueNotification(id, notificationBuilder);
     }
 
-    protected void performNotificationScheduling(Notification.Builder notificationBuilder) {
+    protected void performNotificationScheduling(int id, Notification.Builder notificationBuilder) {
         Bundle extras = notificationBuilder.getExtras();
-        int id = extras.getInt(KEY_ID, -1);
         long repeatInterval = extras.getLong(KEY_REPEAT_INTERVAL, -1);
         long fireTime = extras.getLong(KEY_FIRE_TIME, -1);
         Notification notification = null;

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -645,9 +645,9 @@ public class UnityNotificationManager extends BroadcastReceiver {
         boolean showInForeground = notification.extras.getBoolean(KEY_SHOW_IN_FOREGROUND, true);
         if (!isInForeground() || showInForeground) {
             getNotificationManager(context).notify(id, notification);
-        }
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) synchronized (UnityNotificationManager.class) {
-            mVisibleNotifications.add(Integer.valueOf(id));
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) synchronized (UnityNotificationManager.class) {
+                mVisibleNotifications.add(Integer.valueOf(id));
+            }
         }
 
         try {

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -76,7 +76,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
         mContext = context;
         mActivity = activity;
         mBackgroundThread = new UnityNotificationBackgroundThread();
-        mBackgroundThread.start();
 
         try {
             ApplicationInfo ai = activity.getPackageManager().getApplicationInfo(activity.getPackageName(), PackageManager.GET_META_DATA);
@@ -102,7 +101,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
             Log.e(TAG_UNITY, "Failed to load meta-data, NullPointer: " + e.getMessage());
         }
 
-        triggerHousekeeping(context, null);
+        mBackgroundThread.start();
     }
 
     public static UnityNotificationManager getNotificationManagerImpl(Context context) {
@@ -397,7 +396,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         }
     }
 
-    private static void performNotificationHousekeeping(Context context, Set<String> ids) {
+    protected static void performNotificationHousekeeping(Context context, Set<String> ids) {
         Log.d(TAG_UNITY, "Checking for invalid notification IDs still hanging around");
 
         Set<String> invalid = findInvalidNotificationIds(context, ids);
@@ -598,7 +597,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         }
     }
 
-    private static synchronized Set<String> getScheduledNotificationIDs(Context context) {
+    protected static synchronized Set<String> getScheduledNotificationIDs(Context context) {
         SharedPreferences prefs = context.getSharedPreferences(NOTIFICATION_IDS_SHARED_PREFS, Context.MODE_PRIVATE);
         Set<String> ids = prefs.getStringSet(NOTIFICATION_IDS_SHARED_PREFS_KEY, new HashSet<String>());
         return ids;

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -378,21 +378,13 @@ public class UnityNotificationManager extends BroadcastReceiver {
         ++mSentSinceLastHousekeeping;
         if (mSentSinceLastHousekeeping > 50) {
             mSentSinceLastHousekeeping = 0;
-            triggerHousekeeping(context, ids);
+            triggerHousekeeping();
         }
     }
 
-    private static synchronized void triggerHousekeeping(Context context, Set<String> ids) {
-        if (ids == null) {
-            ids = getScheduledNotificationIDs(context);
-        }
-
-        // needed for lamda
-        final Set<String> notificationIds = ids;
+    private static synchronized void triggerHousekeeping() {
         if (mUnityNotificationManager != null) {
-            mUnityNotificationManager.mBackgroundThread.enqueueTask(() -> {
-                performNotificationHousekeeping(context, notificationIds);
-            });
+            mUnityNotificationManager.mBackgroundThread.enqueueHousekeeping();
         }
     }
 
@@ -592,7 +584,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
                     cancelPendingNotificationIntent(context, Integer.valueOf(id));
                     deleteExpiredNotificationIntent(context, id);
                 }
-                triggerHousekeeping(context, null);
+                triggerHousekeeping();
             });
         }
     }
@@ -613,7 +605,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
     public void cancelPendingNotification(int id) {
         synchronized (UnityNotificationManager.class) {
             UnityNotificationManager.cancelPendingNotificationIntent(mContext, id);
-            triggerHousekeeping(mContext, null);
+            triggerHousekeeping();
         }
     }
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -402,8 +402,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
         Set<String> invalid = findInvalidNotificationIds(context, ids);
         synchronized (UnityNotificationManager.class) {
-            // list might have changed while we searched
-            Set<String> currentIds = new HashSet<>(getScheduledNotificationIDs(context));
+            Set<String> currentIds = new HashSet<>(ids);
             for (String id : invalid) {
                 currentIds.remove(id);
                 removeScheduledNotification(Integer.valueOf(id));

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -864,7 +864,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         return mScheduledNotifications.get(id);
     }
 
-    private static synchronized Notification removeScheduledNotification(Integer id) {
+    protected static synchronized Notification removeScheduledNotification(Integer id) {
         return mScheduledNotifications.remove(id);
     }
 }

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -277,7 +277,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
                 fireTime += repeatInterval;
             }
 
-            Intent intent = buildNotificationIntentUpdateList(mContext, id);
+            Intent intent = buildNotificationIntent(mContext);
 
             if (intent != null) {
                 UnityNotificationManager.saveNotification(mContext, notificationBuilder.build());
@@ -353,19 +353,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
         openAppIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
 
         return openAppIntent;
-    }
-
-    // Build a notification Intent to store the PendingIntent.
-    private static synchronized Intent buildNotificationIntentUpdateList(Context context, int notificationId) {
-        Set<String> ids = getScheduledNotificationIDs(context);
-        if (!canScheduleMoreAlarms(ids))
-            return null;
-
-        Intent intent = buildNotificationIntent(context);
-        ids = new HashSet<>(ids);
-        ids.add(String.valueOf(notificationId));
-        saveScheduledNotificationIDs(context, ids);
-        return intent;
     }
 
     protected static boolean canScheduleMoreAlarms(Set<String> ids) {
@@ -574,7 +561,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         return ids;
     }
 
-    private static synchronized void saveScheduledNotificationIDs(Context context, Set<String> ids) {
+    protected static synchronized void saveScheduledNotificationIDs(Context context, Set<String> ids) {
         SharedPreferences.Editor editor = context.getSharedPreferences(NOTIFICATION_IDS_SHARED_PREFS, Context.MODE_PRIVATE).edit().clear();
         editor.putStringSet(NOTIFICATION_IDS_SHARED_PREFS_KEY, ids);
         editor.apply();

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -48,7 +48,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
     protected Class mOpenActivity = null;
     protected UnityNotificationBackgroundThread mBackgroundThread;
 
-    protected static final int SAMSUNG_NOTIFICATION_LIMIT = 500;
     protected static final String TAG_UNITY = "UnityNotifications";
 
     protected static final String KEY_FIRE_TIME = "fireTime";
@@ -357,21 +356,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
         openAppIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
 
         return openAppIntent;
-    }
-
-    protected static boolean canScheduleMoreAlarms(Set<String> ids) {
-        if (ids.size() < (SAMSUNG_NOTIFICATION_LIMIT - 1))
-            return true;
-        if ("samsung".equals(android.os.Build.MANUFACTURER)) {
-            // There seems to be a limit of 500 concurrently scheduled alarms on Samsung devices.
-            // Attempting to schedule more than that might cause the app to crash.
-            Log.w(TAG_UNITY, String.format("Attempting to schedule more than %1$d notifications. There is a limit of %1$d concurrently scheduled Alarms on Samsung devices" +
-                            " either wait for the currently scheduled ones to be triggered or cancel them if you wish to schedule additional notifications.",
-                    SAMSUNG_NOTIFICATION_LIMIT));
-            return false;
-        }
-
-        return true;
     }
 
     protected static void performNotificationHousekeeping(Context context, Set<String> ids) {

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -571,22 +571,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
     // Cancel all the pending notifications.
     public void cancelAllPendingNotificationIntents() {
-        Set<String> ids;
-        synchronized (UnityNotificationManager.class) {
-            ids = this.getScheduledNotificationIDs(mContext);
-            saveScheduledNotificationIDs(mContext, new HashSet<>());
-        }
-
-        if (ids.size() > 0) {
-            Context context = mContext;
-            mBackgroundThread.enqueueTask(() -> {
-                for (String id : ids) {
-                    cancelPendingNotificationIntent(context, Integer.valueOf(id));
-                    deleteExpiredNotificationIntent(context, id);
-                }
-                triggerHousekeeping();
-            });
-        }
+        mBackgroundThread.enqueueCancelAllNotifications();
     }
 
     protected static synchronized Set<String> getScheduledNotificationIDs(Context context) {
@@ -603,10 +588,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
     // Cancel a pending notification by id.
     public void cancelPendingNotification(int id) {
-        synchronized (UnityNotificationManager.class) {
-            UnityNotificationManager.cancelPendingNotificationIntent(mContext, id);
-            triggerHousekeeping();
-        }
+        mBackgroundThread.enqueueCancelNotification(id);
     }
 
     // Cancel a pending notification by id.

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -40,7 +40,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
     private static HashMap<Integer, Notification> mScheduledNotifications = new HashMap();
     private static HashSet<Integer> mVisibleNotifications = new HashSet<>();
     private static int mSentSinceLastHousekeeping = 0;
-    private static boolean mPerformingHousekeeping = false;
 
     public Context mContext = null;
     protected Activity mActivity = null;
@@ -393,25 +392,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         final Set<String> notificationIds = ids;
         if (mUnityNotificationManager != null) {
             mUnityNotificationManager.mBackgroundThread.enqueueTask(() -> {
-                try {
-                    // when scheduling lots of notifications at once we can have more than one housekeeping thread running
-                    // synchronize them and chain to happen one after the other
-                    synchronized (UnityNotificationManager.class) {
-                        while (mPerformingHousekeeping) {
-                            UnityNotificationManager.class.wait();
-                        }
-                        mPerformingHousekeeping = true;
-                    }
-
-                    performNotificationHousekeeping(context, notificationIds);
-                } catch (InterruptedException e) {
-                    Log.e(TAG_UNITY, "Notification housekeeping interrupted");
-                } finally {
-                    synchronized (UnityNotificationManager.class) {
-                        mPerformingHousekeeping = false;
-                        UnityNotificationManager.class.notify();
-                    }
-                }
+                performNotificationHousekeeping(context, notificationIds);
             });
         }
     }

--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
@@ -320,6 +320,8 @@ class AndroidNotificationSendingTests
         // temporary null the manager, cause that's what we have in reality
         var manager = managerClass.GetStatic<AndroidJavaObject>("mUnityNotificationManager");
         managerClass.SetStatic<AndroidJavaObject>("mUnityNotificationManager", null);
+        // also clear cached notifications, since they don't exist after reboot
+        managerClass.GetStatic<AndroidJavaObject>("mScheduledNotifications").Call("clear");
 
         // simulate reboot by directly cancelling scheduled alarms preserving saves
         managerClass.CallStatic("cancelPendingNotificationIntent", context, id);

--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
@@ -317,6 +317,10 @@ class AndroidNotificationSendingTests
         int id = AndroidNotificationCenter.SendNotification(n, kDefaultTestChannel);
         yield return new WaitForSeconds(0.2f);
 
+        // temporary null the manager, cause that's what we have in reality
+        var manager = managerClass.GetStatic<AndroidJavaObject>("mUnityNotificationManager");
+        managerClass.SetStatic<AndroidJavaObject>("mUnityNotificationManager", null);
+
         // simulate reboot by directly cancelling scheduled alarms preserving saves
         managerClass.CallStatic("cancelPendingNotificationIntent", context, id);
         yield return new WaitForSeconds(0.2f);
@@ -327,6 +331,8 @@ class AndroidNotificationSendingTests
 
         Debug.LogWarning("SendNotification_CanReschedule completed");
 
+        // restore manager (to not ruin other tests)
+        managerClass.SetStatic("mUnityNotificationManager", manager);
         Assert.AreEqual(1, currentHandler.receivedNotificationCount);
     }
 }


### PR DESCRIPTION
Major refactoring of how notification scheduling and cleanup is performed:
- A dedicated thread is created to offload work from main thread and not create ad-hoc threads for housekeeping
- Notification scheduling now submits a task to queue and is done on other thread, because it's not so cheap process
- We had clashes between threads if scheduling or canceling happened at the same time as we performed housekeeping (cleanup of old stuff) on other thread; now all these tasks are performed on a separate dedicated thread, so minimize thread clashes
- rather than loading saving a set of notification ids each time when scheduling or canceling, a set of ids is maintained in a worker thread and is saved on changes; this should speedup batch scheduling, since we now avoid excessive saves of ids

Couple of unrelated changes:
- Noticed that if ShowInForegroud is false on pre-M (<6.0) devices would report notification status as scheduled after it's delivery, fixed
- Removed the Samsung specific thing with 500 alarms; now simply handle an exception, so everything works the same, except that now it expands to other devices and if Samsung removed or increased this limitation, we adapt out of the box

Note to QA:
- Android only
- Changes only affect scheduling or canceling, no need to check different types of notification content
- Aside from mentioned pre-M change this PR is not specific to Android version
- Since the changes are multi-threading related, advise is to try some high-end and some crappy slow device
- Tested by me:
  - attempt to schedule over 500 notifications on Samsung still works the same - schedules 500, the rest fail, only now you see exceptions is logcat with OS message (used Galaxy S7 7.0)
  - automated tests pass in Yamato and locally no Nokia 7 Plus
  - Scheduling 150 notifications is ~3 times faster on Nokia 7 Plus; the performance measured before landing the PR with perf optimisations (JNI stuff), so compared to public package version should be even more
- Testing drills required:
  - schedule notification for the future and see if it arrives whatever you do in between (app in background or closed, open again etc.); just note, that on some devices we already had issues with killing, so in case of problems compare against pre-PR version
  - schedule batches, cancel some
  - try reschedule after device reboot
  - basically, try to break it (get notification not scheduled or not canceled)
  - I only have a project for perf testing, but it's a simple for loop with Stopwatch :)