### PR TITLE
Maintain time type when querying

### DIFF
--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.h
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.h
@@ -49,6 +49,7 @@ typedef struct iOSNotificationData
             int minute;
             int second;
             unsigned char repeats;
+            unsigned char originalUtc;
         } calendar;
 
         struct

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.h
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.h
@@ -49,7 +49,6 @@ typedef struct iOSNotificationData
             int minute;
             int second;
             unsigned char repeats;
-            unsigned char originalUtc;
         } calendar;
 
         struct

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
@@ -151,6 +151,8 @@ iOSNotificationData UNNotificationRequestToiOSNotificationData(UNNotificationReq
         notificationData.trigger.calendar.hour = (int)date.hour;
         notificationData.trigger.calendar.minute = (int)date.minute;
         notificationData.trigger.calendar.second = (int)date.second;
+        notificationData.trigger.calendar.repeats = (int)calendarTrigger.repeats;
+        notificationData.trigger.calendar.originalUtc = 1;
     }
     else if ([request.trigger isKindOfClass: [UNLocationNotificationTrigger class]])
     {

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
@@ -152,7 +152,6 @@ iOSNotificationData UNNotificationRequestToiOSNotificationData(UNNotificationReq
         notificationData.trigger.calendar.minute = (int)date.minute;
         notificationData.trigger.calendar.second = (int)date.second;
         notificationData.trigger.calendar.repeats = (int)calendarTrigger.repeats;
-        notificationData.trigger.calendar.originalUtc = 1;
     }
     else if ([request.trigger isKindOfClass: [UNLocationNotificationTrigger class]])
     {

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
@@ -49,7 +49,6 @@ namespace Unity.Notifications.iOS
         public Int32 minute;
         public Int32 second;
         public Byte repeats;
-        public Byte originalUtc;
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -275,13 +274,11 @@ namespace Unity.Notifications.iOS
                     case iOSNotificationTriggerType.Calendar:
                         {
                             var trigger = ((iOSNotificationCalendarTrigger)value);
-                            if (trigger.UtcTime)
-                                data.trigger.calendar.originalUtc = 1;
-                            else
-                            {
-                                data.trigger.calendar.originalUtc = 0;
+                            if (userInfo == null)
+                                userInfo = new Dictionary<string, string>();
+                            userInfo["OriginalUtc"] = trigger.UtcTime ? "1" : "0";
+                            if (!trigger.UtcTime)
                                 trigger = trigger.ToUtc();
-                            }
                             data.trigger.calendar.year = trigger.Year != null ? trigger.Year.Value : -1;
                             data.trigger.calendar.month = trigger.Month != null ? trigger.Month.Value : -1;
                             data.trigger.calendar.day = trigger.Day != null ? trigger.Day.Value : -1;
@@ -333,7 +330,7 @@ namespace Unity.Notifications.iOS
                                 UtcTime = true,
                                 Repeats = data.trigger.calendar.repeats != 0
                             };
-                            if (data.trigger.calendar.originalUtc == 0)
+                            if (userInfo != null && userInfo["OriginalUtc"] == "0")
                                 trigger = trigger.ToLocal();
                             return trigger;
                         }

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
@@ -49,6 +49,7 @@ namespace Unity.Notifications.iOS
         public Int32 minute;
         public Int32 second;
         public Byte repeats;
+        public Byte originalUtc;
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -273,7 +274,14 @@ namespace Unity.Notifications.iOS
                         }
                     case iOSNotificationTriggerType.Calendar:
                         {
-                            var trigger = ((iOSNotificationCalendarTrigger)value).ToUtc();
+                            var trigger = ((iOSNotificationCalendarTrigger)value);
+                            if (trigger.UtcTime)
+                                data.trigger.calendar.originalUtc = 1;
+                            else
+                            {
+                                data.trigger.calendar.originalUtc = 0;
+                                trigger = trigger.ToUtc();
+                            }
                             data.trigger.calendar.year = trigger.Year != null ? trigger.Year.Value : -1;
                             data.trigger.calendar.month = trigger.Month != null ? trigger.Month.Value : -1;
                             data.trigger.calendar.day = trigger.Day != null ? trigger.Day.Value : -1;
@@ -313,17 +321,22 @@ namespace Unity.Notifications.iOS
                             Repeats = data.trigger.timeInterval.repeats != 0,
                         };
                     case iOSNotificationTriggerType.Calendar:
-                        return new iOSNotificationCalendarTrigger()
                         {
-                            Year = (data.trigger.calendar.year > 0) ? (int?)data.trigger.calendar.year : null,
-                            Month = (data.trigger.calendar.month > 0) ? (int?)data.trigger.calendar.month : null,
-                            Day = (data.trigger.calendar.day > 0) ? (int?)data.trigger.calendar.day : null,
-                            Hour = (data.trigger.calendar.hour >= 0) ? (int?)data.trigger.calendar.hour : null,
-                            Minute = (data.trigger.calendar.minute >= 0) ? (int?)data.trigger.calendar.minute : null,
-                            Second = (data.trigger.calendar.second >= 0) ? (int?)data.trigger.calendar.second : null,
-                            UtcTime = true,
-                            Repeats = data.trigger.calendar.repeats != 0
-                        };
+                            var trigger = new iOSNotificationCalendarTrigger()
+                            {
+                                Year = (data.trigger.calendar.year > 0) ? (int?)data.trigger.calendar.year : null,
+                                Month = (data.trigger.calendar.month > 0) ? (int?)data.trigger.calendar.month : null,
+                                Day = (data.trigger.calendar.day > 0) ? (int?)data.trigger.calendar.day : null,
+                                Hour = (data.trigger.calendar.hour >= 0) ? (int?)data.trigger.calendar.hour : null,
+                                Minute = (data.trigger.calendar.minute >= 0) ? (int?)data.trigger.calendar.minute : null,
+                                Second = (data.trigger.calendar.second >= 0) ? (int?)data.trigger.calendar.second : null,
+                                UtcTime = true,
+                                Repeats = data.trigger.calendar.repeats != 0
+                            };
+                            if (data.trigger.calendar.originalUtc == 0)
+                                trigger = trigger.ToLocal();
+                            return trigger;
+                        }
                     case iOSNotificationTriggerType.Location:
                         return new iOSNotificationLocationTrigger()
                         {

--- a/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
@@ -348,4 +348,42 @@ class iOSNotificationTests
         Assert.AreEqual(4, trigger.Minute);
         Assert.AreEqual(5, trigger.Second);
     }
+
+    [Test]
+    public void iOSNotification_CalendarTrigger_ReturnsSameKindDateTime()
+    {
+        var trigger1 = new iOSNotificationCalendarTrigger()
+        {
+            Hour = 8,
+            Minute = 30,
+            UtcTime = false,
+        };
+
+        var trigger2 = new iOSNotificationCalendarTrigger()
+        {
+            Hour = 8,
+            Minute = 30,
+            UtcTime = false,
+        };
+
+        var notification = new iOSNotification()
+        {
+            Title = "text",
+            Body = "text",
+            Trigger = trigger1,
+        };
+
+        var retTrigger = (iOSNotificationCalendarTrigger)notification.Trigger;
+
+        Assert.AreEqual(trigger1.Hour, retTrigger.Hour);
+        Assert.AreEqual(trigger1.Minute, retTrigger.Minute);
+        Assert.AreEqual(trigger1.UtcTime, retTrigger.UtcTime);
+
+        notification.Trigger = trigger2;
+        retTrigger = (iOSNotificationCalendarTrigger)notification.Trigger;
+
+        Assert.AreEqual(trigger2.Hour, retTrigger.Hour);
+        Assert.AreEqual(trigger2.Minute, retTrigger.Minute);
+        Assert.AreEqual(trigger2.UtcTime, retTrigger.UtcTime);
+    }
 }

--- a/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
@@ -187,6 +187,8 @@ class iOSNotificationTests
         Assert.AreEqual(1, receivedNotificationCount);
         Assert.IsNotNull(lastReceivedNotification);
         Assert.AreEqual(text, lastReceivedNotification.Title);
+        var retTrigger = (iOSNotificationCalendarTrigger)lastReceivedNotification.Trigger;
+        Assert.AreEqual(useUtc, retTrigger.UtcTime);
     }
 
     [UnityTest]

--- a/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
@@ -314,7 +314,7 @@ class iOSNotificationTests
     }
 
     [Test]
-    public void OSNotificationCalendarTrigger_AssignNonEmptyComponents_Works()
+    public void iOSNotificationCalendarTrigger_AssignNonEmptyComponents_Works()
     {
         var dt = new DateTime(2025, 1, 2, 3, 4, 5);
 


### PR DESCRIPTION
When using Calendar trigger we use UTC time internally.
However, because C# DateTime ignores kind when doing comparisons, you may run into issues if setting trigger using local time and later query it.
This PR makes time kind to be preserved (still use UTC internally).