### PR TITLE
Fix recovering builder

### DIFF
--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationUtilities.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationUtilities.java
@@ -524,11 +524,17 @@ public class UnityNotificationUtilities {
     }
 
     protected static Notification.Builder recoverBuilder(Context context, Notification notification) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            Notification.Builder builder = Notification.Builder.recoverBuilder(context, notification);
-            // extras not recovered, transfer manually
-            builder.setExtras(notification.extras);
-            return builder;
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                Notification.Builder builder = Notification.Builder.recoverBuilder(context, notification);
+                // extras not recovered, transfer manually
+                builder.setExtras(notification.extras);
+                return builder;
+            }
+        } catch (Exception e) {
+            Log.e(TAG_UNITY, "Failed to recover builder for notification!", e);
+        } catch (OutOfMemoryError e) {
+            Log.e(TAG_UNITY, "Failed to recover builder for notification!", e);
         }
 
         return recoverBuilderCustom(context, notification);

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationUtilities.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationUtilities.java
@@ -530,12 +530,11 @@ public class UnityNotificationUtilities {
             builder.setExtras(notification.extras);
             return builder;
         }
-        else {
-            return recoverBuilderPreNougat(context, notification);
-        }
+
+        return recoverBuilderCustom(context, notification);
     }
 
-    private static Notification.Builder recoverBuilderPreNougat(Context context, Notification notification) {
+    private static Notification.Builder recoverBuilderCustom(Context context, Notification notification) {
         String channelID = notification.extras.getString(KEY_CHANNEL_ID);
         Notification.Builder builder = UnityNotificationManager.createNotificationBuilder(context, channelID);
         UnityNotificationManager.setNotificationIcon(builder, KEY_SMALL_ICON, notification.extras.getString(KEY_SMALL_ICON));

--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSimpleTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSimpleTests.cs
@@ -472,7 +472,7 @@ class AndroidNotificationSimpleTests
         var manager = managerClass.GetStatic<AndroidJavaObject>("mUnityNotificationManager");
         var context = manager.Get<AndroidJavaObject>("mContext");
         var utils = new AndroidJavaClass("com.unity.androidnotifications.UnityNotificationUtilities");
-        var recoveredBuilder = utils.CallStatic<AndroidJavaObject>("recoverBuilderPreNougat", context, notification);
+        var recoveredBuilder = utils.CallStatic<AndroidJavaObject>("recoverBuilderCustom", context, notification);
         Assert.IsNotNull(recoveredBuilder);
 
         var notificationAfterRecover = recoveredBuilder.Call<AndroidJavaObject>("build");


### PR DESCRIPTION
Androids default recoverBuilder() may fail in certain conditions. From info it may happen if application was reinstalled (updated) or if operating system was upgraded.
Because of that we need to handle an exception. At this point it makes sense to fallback to our own custom recover code (would lose users custom modifications to notification though), with better solution for it in the works.

https://github.com/Unity-Technologies/com.unity.mobile.notifications/issues/198
https://github.com/Unity-Technologies/com.unity.mobile.notifications/issues/196