### PR TITLE
Refactor notification manager

### DIFF
--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -570,11 +570,9 @@ namespace Unity.Notifications.Android
 #elif UNITY_ANDROID
             var unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer");
             s_CurrentActivity = unityPlayer.GetStatic<AndroidJavaObject>("currentActivity");
-            var context = s_CurrentActivity.Call<AndroidJavaObject>("getApplicationContext");
 
             var notificationManagerClass = new AndroidJavaClass("com.unity.androidnotifications.UnityNotificationManager");
-            var notificationManager = notificationManagerClass.CallStatic<AndroidJavaObject>("getNotificationManagerImpl", context, s_CurrentActivity);
-            notificationManager.Call("setNotificationCallback", new NotificationCallback());
+            var notificationManager = notificationManagerClass.CallStatic<AndroidJavaObject>("getNotificationManagerImpl", s_CurrentActivity, new NotificationCallback());
             s_Jni = new JniApi(notificationManagerClass, notificationManager);
 
             s_Initialized = true;

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -568,8 +568,8 @@ namespace Unity.Notifications.Android
 #if UNITY_EDITOR || !UNITY_ANDROID
             s_CurrentActivity = null;
 #elif UNITY_ANDROID
-            var unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer");
-            s_CurrentActivity = unityPlayer.GetStatic<AndroidJavaObject>("currentActivity");
+            using (var unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer"))
+                s_CurrentActivity = unityPlayer.GetStatic<AndroidJavaObject>("currentActivity");
 
             var notificationManagerClass = new AndroidJavaClass("com.unity.androidnotifications.UnityNotificationManager");
             var notificationManager = notificationManagerClass.CallStatic<AndroidJavaObject>("getNotificationManagerImpl", s_CurrentActivity, new NotificationCallback());

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -106,7 +106,7 @@ namespace Unity.Notifications.Android
 
         void CollectMethods(AndroidJavaClass clazz)
         {
-            getNotificationFromIntent = JniApi.FindMethod(clazz, "getNotificationFromIntent", "(Landroid/content/Context;Landroid/content/Intent;)Landroid/app/Notification;", true);
+            getNotificationFromIntent = JniApi.FindMethod(clazz, "getNotificationFromIntent", "(Landroid/content/Intent;)Landroid/app/Notification;", false);
             setNotificationIcon = JniApi.FindMethod(clazz, "setNotificationIcon", "(Landroid/app/Notification$Builder;Ljava/lang/String;Ljava/lang/String;)V", true);
             setNotificationColor = JniApi.FindMethod(clazz, "setNotificationColor", "(Landroid/app/Notification$Builder;I)V", true);
             getNotificationColor = JniApi.FindMethod(clazz, "getNotificationColor", "(Landroid/app/Notification;)Ljava/lang/Integer;", true);
@@ -118,9 +118,9 @@ namespace Unity.Notifications.Android
             createNotificationBuilder = JniApi.FindMethod(clazz, "createNotificationBuilder", "(Ljava/lang/String;)Landroid/app/Notification$Builder;", false);
         }
 
-        public AndroidJavaObject GetNotificationFromIntent(AndroidJavaObject activity, AndroidJavaObject intent)
+        public AndroidJavaObject GetNotificationFromIntent(AndroidJavaObject intent)
         {
-            return klass.CallStatic<AndroidJavaObject>(getNotificationFromIntent, activity, intent);
+            return self.Call<AndroidJavaObject>(getNotificationFromIntent, intent);
         }
 
         public void SetNotificationIcon(AndroidJavaObject builder, AndroidJavaObject keyName, string icon)
@@ -839,7 +839,7 @@ namespace Unity.Notifications.Android
                 return null;
 
             var intent = s_CurrentActivity.Call<AndroidJavaObject>("getIntent");
-            var notification = s_Jni.NotificationManager.GetNotificationFromIntent(s_CurrentActivity, intent);
+            var notification = s_Jni.NotificationManager.GetNotificationFromIntent(intent);
             if (notification == null)
                 return null;
             return GetNotificationData(notification);

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationBackgroundThread.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationBackgroundThread.java
@@ -4,7 +4,6 @@ import static com.unity.androidnotifications.UnityNotificationManager.KEY_ID;
 import static com.unity.androidnotifications.UnityNotificationManager.TAG_UNITY;
 
 import android.app.Notification;
-import android.content.Context;
 import android.util.Log;
 
 import java.util.concurrent.ConcurrentHashMap;
@@ -17,7 +16,7 @@ import java.util.Set;
 public class UnityNotificationBackgroundThread extends Thread {
     private static abstract class Task {
         // returns true if notificationIds was modified (needs to be saved)
-        public abstract boolean run(Context context, ConcurrentHashMap<Integer, Notification.Builder> notifications);
+        public abstract boolean run(UnityNotificationManager manager, ConcurrentHashMap<Integer, Notification.Builder> notifications);
     }
 
     private static class ScheduleNotificationTask extends Task {
@@ -32,7 +31,7 @@ public class UnityNotificationBackgroundThread extends Thread {
         }
 
         @Override
-        public boolean run(Context context, ConcurrentHashMap<Integer, Notification.Builder> notifications) {
+        public boolean run(UnityNotificationManager manager, ConcurrentHashMap<Integer, Notification.Builder> notifications) {
             String id = String.valueOf(notificationId);
             Integer ID = Integer.valueOf(notificationId);
             boolean didSchedule = false;
@@ -43,8 +42,8 @@ public class UnityNotificationBackgroundThread extends Thread {
                 // if failed to schedule or replace, remove
                 if (!didSchedule) {
                     notifications.remove(notificationId);
-                    UnityNotificationManager.cancelPendingNotificationIntent(context, notificationId);
-                    UnityNotificationManager.deleteExpiredNotificationIntent(context, id);
+                    manager.cancelPendingNotificationIntent(notificationId);
+                    manager.deleteExpiredNotificationIntent(id);
                 }
             }
 
@@ -60,10 +59,10 @@ public class UnityNotificationBackgroundThread extends Thread {
         }
 
         @Override
-        public boolean run(Context context, ConcurrentHashMap<Integer, Notification.Builder> notifications) {
-            UnityNotificationManager.cancelPendingNotificationIntent(context, notificationId);
+        public boolean run(UnityNotificationManager manager, ConcurrentHashMap<Integer, Notification.Builder> notifications) {
+            manager.cancelPendingNotificationIntent(notificationId);
             if (notifications.remove(notificationId) != null) {
-                UnityNotificationManager.deleteExpiredNotificationIntent(context, String.valueOf(notificationId));
+                manager.deleteExpiredNotificationIntent(String.valueOf(notificationId));
                 return true;
             }
 
@@ -73,15 +72,15 @@ public class UnityNotificationBackgroundThread extends Thread {
 
     private static class CancelAllNotificationsTask extends Task {
         @Override
-        public boolean run(Context context, ConcurrentHashMap<Integer, Notification.Builder> notifications) {
+        public boolean run(UnityNotificationManager manager, ConcurrentHashMap<Integer, Notification.Builder> notifications) {
             if (notifications.isEmpty())
                 return false;
 
             Enumeration<Integer> ids = notifications.keys();
             while (ids.hasMoreElements()) {
                 Integer notificationId = ids.nextElement();
-                UnityNotificationManager.cancelPendingNotificationIntent(context, notificationId);
-                UnityNotificationManager.deleteExpiredNotificationIntent(context, String.valueOf(notificationId));
+                manager.cancelPendingNotificationIntent(notificationId);
+                manager.deleteExpiredNotificationIntent(String.valueOf(notificationId));
             }
 
             notifications.clear();
@@ -97,13 +96,13 @@ public class UnityNotificationBackgroundThread extends Thread {
         }
 
         @Override
-        public boolean run(Context context, ConcurrentHashMap<Integer, Notification.Builder> notifications) {
+        public boolean run(UnityNotificationManager manager, ConcurrentHashMap<Integer, Notification.Builder> notifications) {
             HashSet<String> notificationIds = new HashSet<>();
             Enumeration<Integer> ids = notifications.keys();
             while (ids.hasMoreElements()) {
                 notificationIds.add(String.valueOf(ids.nextElement()));
             }
-            thread.performHousekeeping(context, notificationIds);
+            thread.performHousekeeping(notificationIds);
             return false;
         }
     }
@@ -111,11 +110,11 @@ public class UnityNotificationBackgroundThread extends Thread {
     private static final int TASKS_FOR_HOUSEKEEPING = 50;
     private LinkedTransferQueue<Task> mTasks = new LinkedTransferQueue();
     private ConcurrentHashMap<Integer, Notification.Builder> mScheduledNotifications;
-    private static Context mContext;
+    private UnityNotificationManager mManager;
     private int mTasksSinceHousekeeping = TASKS_FOR_HOUSEKEEPING;  // we want hoursekeeping at the start
 
-    public UnityNotificationBackgroundThread(Context context, ConcurrentHashMap<Integer, Notification.Builder> scheduledNotifications) {
-        mContext = context;
+    public UnityNotificationBackgroundThread(UnityNotificationManager manager, ConcurrentHashMap<Integer, Notification.Builder> scheduledNotifications) {
+        mManager = manager;
         mScheduledNotifications = scheduledNotifications;
         // rescheduling after reboot may have loaded, otherwise load here
         if (mScheduledNotifications.size() == 0)
@@ -144,7 +143,7 @@ public class UnityNotificationBackgroundThread extends Thread {
         while (true) {
             try {
                 Task task = mTasks.take();
-                haveChanges |= executeTask(mContext, task, mScheduledNotifications);
+                haveChanges |= executeTask(mManager, task, mScheduledNotifications);
                 if (!(task instanceof HousekeepingTask))
                     ++mTasksSinceHousekeeping;
                 if (mTasks.size() == 0 && haveChanges) {
@@ -158,26 +157,26 @@ public class UnityNotificationBackgroundThread extends Thread {
         }
     }
 
-    private boolean executeTask(Context context, Task task, ConcurrentHashMap<Integer, Notification.Builder> notifications) {
+    private boolean executeTask(UnityNotificationManager manager, Task task, ConcurrentHashMap<Integer, Notification.Builder> notifications) {
         try {
-            return task.run(context, notifications);
+            return task.run(manager, notifications);
         } catch (Exception e) {
             Log.e(TAG_UNITY, "Exception executing notification task", e);
             return false;
         }
     }
 
-    private void performHousekeeping(Context context, Set<String> notificationIds) {
+    private void performHousekeeping(Set<String> notificationIds) {
         // don't do housekeeping if last task we did was housekeeping (other=1)
         boolean performHousekeeping = mTasksSinceHousekeeping >= TASKS_FOR_HOUSEKEEPING;
         mTasksSinceHousekeeping = 0;
         if (performHousekeeping)
-            UnityNotificationManager.performNotificationHousekeeping(context, notificationIds);
-        UnityNotificationManager.saveScheduledNotificationIDs(context, notificationIds);
+            mManager.performNotificationHousekeeping(notificationIds);
+        mManager.saveScheduledNotificationIDs(notificationIds);
     }
 
     private void loadNotifications() {
-        List<Notification.Builder> notifications = UnityNotificationManager.loadSavedNotifications(mContext);
+        List<Notification.Builder> notifications = mManager.loadSavedNotifications();
         for (Notification.Builder builder : notifications) {
             int id = builder.getExtras().getInt(KEY_ID, -1);
             mScheduledNotifications.put(id, builder);

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -52,24 +52,24 @@ public class UnityNotificationManager extends BroadcastReceiver {
     protected UnityNotificationBackgroundThread mBackgroundThread;
     protected Random mRandom;
 
-    protected static final String TAG_UNITY = "UnityNotifications";
+    static final String TAG_UNITY = "UnityNotifications";
 
-    protected static final String KEY_FIRE_TIME = "fireTime";
-    protected static final String KEY_ID = "id";
-    protected static final String KEY_INTENT_DATA = "data";
-    protected static final String KEY_LARGE_ICON = "largeIcon";
-    protected static final String KEY_REPEAT_INTERVAL = "repeatInterval";
-    protected static final String KEY_NOTIFICATION = "unityNotification";
-    protected static final String KEY_NOTIFICATION_ID = "com.unity.NotificationID";
-    protected static final String KEY_SMALL_ICON = "smallIcon";
-    protected static final String KEY_CHANNEL_ID = "channelID";
-    protected static final String KEY_SHOW_IN_FOREGROUND = "com.unity.showInForeground";
-    protected static final String KEY_NOTIFICATION_DISMISSED = "com.unity.NotificationDismissed";
+    static final String KEY_FIRE_TIME = "fireTime";
+    static final String KEY_ID = "id";
+    static final String KEY_INTENT_DATA = "data";
+    static final String KEY_LARGE_ICON = "largeIcon";
+    static final String KEY_REPEAT_INTERVAL = "repeatInterval";
+    static final String KEY_NOTIFICATION = "unityNotification";
+    static final String KEY_NOTIFICATION_ID = "com.unity.NotificationID";
+    static final String KEY_SMALL_ICON = "smallIcon";
+    static final String KEY_CHANNEL_ID = "channelID";
+    static final String KEY_SHOW_IN_FOREGROUND = "com.unity.showInForeground";
+    static final String KEY_NOTIFICATION_DISMISSED = "com.unity.NotificationDismissed";
 
-    protected static final String NOTIFICATION_CHANNELS_SHARED_PREFS = "UNITY_NOTIFICATIONS";
-    protected static final String NOTIFICATION_CHANNELS_SHARED_PREFS_KEY = "ChannelIDs";
-    protected static final String NOTIFICATION_IDS_SHARED_PREFS = "UNITY_STORED_NOTIFICATION_IDS";
-    protected static final String NOTIFICATION_IDS_SHARED_PREFS_KEY = "UNITY_NOTIFICATION_IDS";
+    static final String NOTIFICATION_CHANNELS_SHARED_PREFS = "UNITY_NOTIFICATIONS";
+    static final String NOTIFICATION_CHANNELS_SHARED_PREFS_KEY = "ChannelIDs";
+    static final String NOTIFICATION_IDS_SHARED_PREFS = "UNITY_STORED_NOTIFICATION_IDS";
+    static final String NOTIFICATION_IDS_SHARED_PREFS_KEY = "UNITY_NOTIFICATION_IDS";
 
     // Constructor with zero parameter is necessary for system to call onReceive() callback.
     public UnityNotificationManager() {

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -19,7 +19,6 @@ import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
-import android.os.BadParcelableException;
 import android.provider.Settings;
 import android.service.notification.StatusBarNotification;
 import android.util.Log;

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -337,7 +337,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
             Intent intent = buildNotificationIntent();
 
             if (intent != null) {
-                UnityNotificationManager.saveNotification(mContext, notificationBuilder.build());
+                saveNotification(notificationBuilder.build());
                 scheduleAlarmWithNotification(notificationBuilder, intent, fireTime);
             }
         }
@@ -487,9 +487,9 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
     // Save the notification intent to SharedPreferences if reschedule_on_restart is true,
     // which will be consumed by UnityNotificationRestartOnBootReceiver for device reboot.
-    protected static synchronized void saveNotification(Context context, Notification notification) {
+    synchronized void saveNotification(Notification notification) {
         String notification_id = Integer.toString(notification.extras.getInt(KEY_ID, -1));
-        SharedPreferences prefs = context.getSharedPreferences(getSharedPrefsNameByNotificationId(notification_id), Context.MODE_PRIVATE);
+        SharedPreferences prefs = mContext.getSharedPreferences(getSharedPrefsNameByNotificationId(notification_id), Context.MODE_PRIVATE);
         UnityNotificationUtilities.serializeNotification(prefs, notification);
     }
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -840,11 +840,11 @@ public class UnityNotificationManager extends BroadcastReceiver {
         return (appProcessInfo.importance == IMPORTANCE_FOREGROUND || appProcessInfo.importance == IMPORTANCE_VISIBLE);
     }
 
-    public static Notification getNotificationFromIntent(Context context, Intent intent) {
+    public Notification getNotificationFromIntent(Intent intent) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             if (intent.hasExtra(KEY_NOTIFICATION_ID)) {
                 int id = intent.getExtras().getInt(KEY_NOTIFICATION_ID);
-                StatusBarNotification[] shownNotifications = getNotificationManager(context).getActiveNotifications();
+                StatusBarNotification[] shownNotifications = getNotificationManager().getActiveNotifications();
                 for (StatusBarNotification n : shownNotifications) {
                     if (n.getId() == id) {
                         return n.getNotification();
@@ -853,7 +853,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
             }
         }
 
-        Object notification = getNotificationOrBuilderForIntent(context, intent);
+        Object notification = getNotificationOrBuilderForIntent(mContext, intent);
         if (notification == null)
             return null;
         if (notification instanceof Notification)

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -71,8 +71,8 @@ public class UnityNotificationManager extends BroadcastReceiver {
     static final String NOTIFICATION_IDS_SHARED_PREFS_KEY = "UNITY_NOTIFICATION_IDS";
 
     private void initialize(Activity activity, NotificationCallback notificationCallback) {
-        if (mContext == null)
-            mContext = activity.getApplicationContext();
+        // always assign these, as callback here is always new, activity and context might be
+        mContext = activity.getApplicationContext();
         mActivity = activity;
         mNotificationCallback = notificationCallback;
         if (mScheduledNotifications == null)
@@ -114,11 +114,12 @@ public class UnityNotificationManager extends BroadcastReceiver {
     static synchronized UnityNotificationManager getNotificationManagerImpl(Context context) {
         if (mUnityNotificationManager == null) {
             mUnityNotificationManager = new UnityNotificationManager();
-            mUnityNotificationManager.mContext = context.getApplicationContext();
             mUnityNotificationManager.mVisibleNotifications = new HashSet<>();
             mUnityNotificationManager.mScheduledNotifications = new ConcurrentHashMap();
         }
 
+        // always assign context, as it might change
+        mUnityNotificationManager.mContext = context.getApplicationContext();
         return mUnityNotificationManager;
     }
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -45,11 +45,11 @@ public class UnityNotificationManager extends BroadcastReceiver {
     private static ConcurrentHashMap<Integer, Notification.Builder> mScheduledNotifications = new ConcurrentHashMap();
     private static HashSet<Integer> mVisibleNotifications = new HashSet<>();
 
-    public Context mContext = null;
-    protected Activity mActivity = null;
-    protected Class mOpenActivity = null;
-    protected UnityNotificationBackgroundThread mBackgroundThread;
-    protected Random mRandom;
+    private Context mContext = null;
+    private Activity mActivity = null;
+    private Class mOpenActivity = null;
+    private UnityNotificationBackgroundThread mBackgroundThread;
+    private Random mRandom;
 
     static final String TAG_UNITY = "UnityNotifications";
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -428,7 +428,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
                 invalid.remove(id);
             }
         }
-        else synchronized (UnityNotificationManager.class) {
+        else synchronized (this) {
             for (Integer visibleId : mVisibleNotifications) {
                 String id = String.valueOf(visibleId);
                 invalid.remove(id);
@@ -548,7 +548,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
                 if (id == n.getId())
                     return 2;
             }
-        } else synchronized (UnityNotificationManager.class) {
+        } else synchronized (this) {
             for (Integer notificationId : mVisibleNotifications) {
                 if (notificationId.intValue() == id)
                     return 2;
@@ -631,7 +631,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             if (KEY_NOTIFICATION_DISMISSED.equals(intent.getAction())) {
                 int removedId = intent.getIntExtra(KEY_NOTIFICATION_DISMISSED, -1);
-                if (removedId > 0) synchronized (UnityNotificationManager.class) {
+                if (removedId > 0) synchronized (this) {
                     mVisibleNotifications.remove(removedId);
                 }
                 return;
@@ -676,7 +676,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         boolean showInForeground = notification.extras.getBoolean(KEY_SHOW_IN_FOREGROUND, true);
         if (!isInForeground() || showInForeground) {
             getNotificationManager().notify(id, notification);
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) synchronized (UnityNotificationManager.class) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) synchronized (this) {
                 mVisibleNotifications.add(Integer.valueOf(id));
             }
         }

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -468,8 +468,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         UnityNotificationUtilities.serializeNotification(prefs, notification);
     }
 
-    static String getSharedPrefsNameByNotificationId(String id)
-    {
+    static String getSharedPrefsNameByNotificationId(String id) {
         return String.format("u_notification_data_%s", id);
     }
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -745,17 +745,13 @@ public class UnityNotificationManager extends BroadcastReceiver {
         }
     }
 
-    public Notification.Builder createNotificationBuilder(String channelID) {
-        return createNotificationBuilder(mContext, channelID);
-    }
-
     @SuppressWarnings("deprecation")
-    static Notification.Builder createNotificationBuilder(Context context, String channelID) {
+    public Notification.Builder createNotificationBuilder(String channelID) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-            Notification.Builder notificationBuilder = new Notification.Builder(context);
+            Notification.Builder notificationBuilder = new Notification.Builder(mContext);
 
             // For device below Android O, we use the values from NotificationChannelWrapper to set visibility, priority etc.
-            NotificationChannelWrapper fakeNotificationChannel = getNotificationChannel(context, channelID);
+            NotificationChannelWrapper fakeNotificationChannel = getNotificationChannel(channelID);
 
             if (fakeNotificationChannel.vibrationPattern != null && fakeNotificationChannel.vibrationPattern.length > 0) {
                 notificationBuilder.setDefaults(Notification.DEFAULT_LIGHTS | Notification.DEFAULT_SOUND);
@@ -791,7 +787,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
             return notificationBuilder;
         } else {
-            return new Notification.Builder(context, channelID);
+            return new Notification.Builder(mContext, channelID);
         }
     }
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -338,7 +338,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
                 fireTime += repeatInterval;
             }
 
-            Intent intent = buildNotificationIntent(mContext);
+            Intent intent = buildNotificationIntent();
 
             if (intent != null) {
                 UnityNotificationManager.saveNotification(mContext, notificationBuilder.build());
@@ -370,19 +370,19 @@ public class UnityNotificationManager extends BroadcastReceiver {
         UnityNotificationManager.scheduleNotificationIntentAlarm(context, repeatInterval, fireTime, broadcast);
     }
 
-    static void scheduleAlarmWithNotification(Notification.Builder notificationBuilder, Context context) {
+    void scheduleAlarmWithNotification(Notification.Builder notificationBuilder) {
         long fireTime = notificationBuilder.getExtras().getLong(KEY_FIRE_TIME, 0L);
-        Intent intent = buildNotificationIntent(context);
+        Intent intent = buildNotificationIntent();
 
         Class openActivity;
-        if (mUnityNotificationManager == null || mUnityNotificationManager.mOpenActivity == null) {
-            openActivity = UnityNotificationUtilities.getOpenAppActivity(context, true);
+        if (mOpenActivity == null) {
+            openActivity = UnityNotificationUtilities.getOpenAppActivity(mContext, true);
         }
         else {
             openActivity = mUnityNotificationManager.mOpenActivity;
         }
 
-        scheduleAlarmWithNotification(context, openActivity, notificationBuilder, intent, fireTime);
+        scheduleAlarmWithNotification(mContext, openActivity, notificationBuilder, intent, fireTime);
     }
 
     private Notification buildNotificationForSending(Class openActivity, Notification.Builder builder) {
@@ -431,7 +431,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
     }
 
     private Set<String> findInvalidNotificationIds(Set<String> ids) {
-        Intent intent = buildNotificationIntent(mContext);
+        Intent intent = buildNotificationIntent();
         HashSet<String> invalid = new HashSet<String>();
         for (String id : ids) {
             // Get the given broadcast PendingIntent by id as request code.
@@ -469,8 +469,8 @@ public class UnityNotificationManager extends BroadcastReceiver {
         return invalid;
     }
 
-    protected static Intent buildNotificationIntent(Context context) {
-        Intent intent = new Intent(context, UnityNotificationManager.class);
+    private Intent buildNotificationIntent() {
+        Intent intent = new Intent(mContext, UnityNotificationManager.class);
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
         return intent;
     }

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -365,7 +365,8 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
     private Notification buildNotificationForSending(Class openActivity, Notification.Builder builder) {
         int id = builder.getExtras().getInt(KEY_ID, -1);
-        Intent openAppIntent = buildOpenAppIntent(openActivity);
+        Intent openAppIntent = new Intent(mContext, openActivity);
+        openAppIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
         openAppIntent.putExtra(KEY_NOTIFICATION_ID, id);
         PendingIntent pendingIntent = getActivityPendingIntent(id, openAppIntent, 0);
         builder.setContentIntent(pendingIntent);
@@ -381,14 +382,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
         finalizeNotificationForDisplay(builder);
         return builder.build();
-    }
-
-    // Build an Intent to open the given activity with the data from input Intent.
-    private Intent buildOpenAppIntent(Class className) {
-        Intent openAppIntent = new Intent(mContext, className);
-        openAppIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
-
-        return openAppIntent;
     }
 
     void performNotificationHousekeeping(Set<String> ids) {

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -416,7 +416,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
     void performNotificationHousekeeping(Set<String> ids) {
         Log.d(TAG_UNITY, "Checking for invalid notification IDs still hanging around");
 
-        Set<String> invalid = findInvalidNotificationIds(mContext, ids);
+        Set<String> invalid = findInvalidNotificationIds(ids);
         synchronized (UnityNotificationManager.class) {
             Set<String> currentIds = new HashSet<>(ids);
             for (String id : invalid) {
@@ -430,20 +430,20 @@ public class UnityNotificationManager extends BroadcastReceiver {
             deleteExpiredNotificationIntent(id);
     }
 
-    private static Set<String> findInvalidNotificationIds(Context context, Set<String> ids) {
-        Intent intent = buildNotificationIntent(context);
+    private Set<String> findInvalidNotificationIds(Set<String> ids) {
+        Intent intent = buildNotificationIntent(mContext);
         HashSet<String> invalid = new HashSet<String>();
         for (String id : ids) {
             // Get the given broadcast PendingIntent by id as request code.
             // FLAG_NO_CREATE is set to return null if the described PendingIntent doesn't exist.
-            PendingIntent broadcast = getBroadcastPendingIntent(context, Integer.valueOf(id), intent, PendingIntent.FLAG_NO_CREATE);
+            PendingIntent broadcast = getBroadcastPendingIntent(mContext, Integer.valueOf(id), intent, PendingIntent.FLAG_NO_CREATE);
             if (broadcast == null) {
                 invalid.add(id);
             }
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            StatusBarNotification[] active = getNotificationManager(context).getActiveNotifications();
+            StatusBarNotification[] active = getNotificationManager().getActiveNotifications();
             for (StatusBarNotification notification : active) {
                 // any notifications in status bar are still valid
                 String id = String.valueOf(notification.getId());

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -362,7 +362,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         mScheduledNotifications.putIfAbsent(Integer.valueOf(id), notificationBuilder);
         intent.putExtra(KEY_NOTIFICATION_ID, id);
 
-        PendingIntent broadcast = getBroadcastPendingIntent(mContext, id, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent broadcast = getBroadcastPendingIntent(id, intent, PendingIntent.FLAG_UPDATE_CURRENT);
         UnityNotificationManager.scheduleNotificationIntentAlarm(mContext, repeatInterval, fireTime, broadcast);
     }
 
@@ -385,7 +385,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         int id = builder.getExtras().getInt(KEY_ID, -1);
         Intent openAppIntent = buildOpenAppIntent(openActivity);
         openAppIntent.putExtra(KEY_NOTIFICATION_ID, id);
-        PendingIntent pendingIntent = getActivityPendingIntent(mContext, id, openAppIntent, 0);
+        PendingIntent pendingIntent = getActivityPendingIntent(id, openAppIntent, 0);
         builder.setContentIntent(pendingIntent);
 
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
@@ -393,7 +393,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
             Intent deleteIntent = new Intent(mContext, UnityNotificationManager.class);
             deleteIntent.setAction(KEY_NOTIFICATION_DISMISSED); // need action to distinguish intent from content one
             deleteIntent.putExtra(KEY_NOTIFICATION_DISMISSED, id);
-            PendingIntent deletePending = getBroadcastPendingIntent(mContext, id, deleteIntent, 0);
+            PendingIntent deletePending = getBroadcastPendingIntent(id, deleteIntent, 0);
             builder.setDeleteIntent(deletePending);
         }
 
@@ -432,7 +432,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         for (String id : ids) {
             // Get the given broadcast PendingIntent by id as request code.
             // FLAG_NO_CREATE is set to return null if the described PendingIntent doesn't exist.
-            PendingIntent broadcast = getBroadcastPendingIntent(mContext, Integer.valueOf(id), intent, PendingIntent.FLAG_NO_CREATE);
+            PendingIntent broadcast = getBroadcastPendingIntent(Integer.valueOf(id), intent, PendingIntent.FLAG_NO_CREATE);
             if (broadcast == null) {
                 invalid.add(id);
             }
@@ -471,18 +471,18 @@ public class UnityNotificationManager extends BroadcastReceiver {
         return intent;
     }
 
-    public static PendingIntent getActivityPendingIntent(Context context, int id, Intent intent, int flags) {
+    private PendingIntent getActivityPendingIntent(int id, Intent intent, int flags) {
         if (Build.VERSION.SDK_INT >= 23)
-            return PendingIntent.getActivity(context, id, intent, flags | PendingIntent.FLAG_IMMUTABLE);
+            return PendingIntent.getActivity(mContext, id, intent, flags | PendingIntent.FLAG_IMMUTABLE);
         else
-            return PendingIntent.getActivity(context, id, intent, flags);
+            return PendingIntent.getActivity(mContext, id, intent, flags);
     }
 
-    public static PendingIntent getBroadcastPendingIntent(Context context, int id, Intent intent, int flags) {
+    private PendingIntent getBroadcastPendingIntent(int id, Intent intent, int flags) {
         if (Build.VERSION.SDK_INT >= 23)
-            return PendingIntent.getBroadcast(context, id, intent, flags | PendingIntent.FLAG_IMMUTABLE);
+            return PendingIntent.getBroadcast(mContext, id, intent, flags | PendingIntent.FLAG_IMMUTABLE);
         else
-            return PendingIntent.getBroadcast(context, id, intent, flags);
+            return PendingIntent.getBroadcast(mContext, id, intent, flags);
     }
 
     // Save the notification intent to SharedPreferences if reschedule_on_restart is true,
@@ -585,7 +585,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
     // Check if the pending notification with the given id has been registered.
     public boolean checkIfPendingNotificationIsRegistered(int id) {
         Intent intent = new Intent(mActivity, UnityNotificationManager.class);
-        return (getBroadcastPendingIntent(mContext, id, intent, PendingIntent.FLAG_NO_CREATE) != null);
+        return (getBroadcastPendingIntent(id, intent, PendingIntent.FLAG_NO_CREATE) != null);
     }
 
     // Cancel all the pending notifications.
@@ -613,7 +613,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
     // Cancel a pending notification by id.
     void cancelPendingNotificationIntent(int id) {
         Intent intent = new Intent(mContext, UnityNotificationManager.class);
-        PendingIntent broadcast = getBroadcastPendingIntent(mContext, id, intent, PendingIntent.FLAG_NO_CREATE);
+        PendingIntent broadcast = getBroadcastPendingIntent(id, intent, PendingIntent.FLAG_NO_CREATE);
 
         if (broadcast != null) {
             AlarmManager alarmManager = (AlarmManager) mContext.getSystemService(Context.ALARM_SERVICE);

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -500,7 +500,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
     // Load all the notification intents from SharedPreferences.
     synchronized List<Notification.Builder> loadSavedNotifications() {
-        Set<String> ids = getScheduledNotificationIDs(mContext);
+        Set<String> ids = getScheduledNotificationIDs();
 
         List<Notification.Builder> intent_data_list = new ArrayList();
         Set<String> idsMarkedForRemoval = new HashSet<String>();
@@ -593,8 +593,8 @@ public class UnityNotificationManager extends BroadcastReceiver {
         mBackgroundThread.enqueueCancelAllNotifications();
     }
 
-    protected static synchronized Set<String> getScheduledNotificationIDs(Context context) {
-        SharedPreferences prefs = context.getSharedPreferences(NOTIFICATION_IDS_SHARED_PREFS, Context.MODE_PRIVATE);
+    private synchronized Set<String> getScheduledNotificationIDs() {
+        SharedPreferences prefs = mContext.getSharedPreferences(NOTIFICATION_IDS_SHARED_PREFS, Context.MODE_PRIVATE);
         Set<String> ids = prefs.getStringSet(NOTIFICATION_IDS_SHARED_PREFS_KEY, new HashSet<String>());
         return ids;
     }

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -363,7 +363,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         intent.putExtra(KEY_NOTIFICATION_ID, id);
 
         PendingIntent broadcast = getBroadcastPendingIntent(id, intent, PendingIntent.FLAG_UPDATE_CURRENT);
-        UnityNotificationManager.scheduleNotificationIntentAlarm(mContext, repeatInterval, fireTime, broadcast);
+        scheduleNotificationIntentAlarm(repeatInterval, fireTime, broadcast);
     }
 
     void scheduleAlarmWithNotification(Notification.Builder notificationBuilder) {
@@ -546,8 +546,8 @@ public class UnityNotificationManager extends BroadcastReceiver {
     }
 
     // Call AlarmManager to set the broadcast intent with fire time and interval.
-    protected static void scheduleNotificationIntentAlarm(Context context, long repeatInterval, long fireTime, PendingIntent broadcast) {
-        AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+    private void scheduleNotificationIntentAlarm(long repeatInterval, long fireTime, PendingIntent broadcast) {
+        AlarmManager alarmManager = (AlarmManager) mContext.getSystemService(Context.ALARM_SERVICE);
 
         if (repeatInterval <= 0) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && canScheduleExactAlarms(alarmManager)) {

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -127,12 +127,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
     }
 
     public NotificationManager getNotificationManager() {
-        return getNotificationManager(mContext);
-    }
-
-    // Get system notification service.
-    public static NotificationManager getNotificationManager(Context context) {
-        return (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        return (NotificationManager) mContext.getSystemService(Context.NOTIFICATION_SERVICE);
     }
 
     public void registerNotificationChannel(
@@ -192,7 +187,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
     public NotificationChannelWrapper getNotificationChannel(String id) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            NotificationChannel ch = getNotificationManager(mContext).getNotificationChannel(id);
+            NotificationChannel ch = getNotificationManagerImpl(mContext).getNotificationManager().getNotificationChannel(id);
             if (ch == null)
                 return null;
             return notificationChannelToWrapper(ch);

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -107,12 +107,17 @@ public class UnityNotificationManager extends BroadcastReceiver {
         mBackgroundThread.start();
     }
 
-    public static UnityNotificationManager getNotificationManagerImpl(Context context) {
-        return getNotificationManagerImpl(context, (Activity) context);
+    public static synchronized UnityNotificationManager getNotificationManagerImpl(Context context) {
+        if (mUnityNotificationManager == null) {
+            mUnityNotificationManager = new UnityNotificationManager();
+        }
+
+        mUnityNotificationManager.mContext = context.getApplicationContext();
+        return mUnityNotificationManager;
     }
 
     // Called from managed code.
-    public static UnityNotificationManager getNotificationManagerImpl(Context context, Activity activity) {
+    public static synchronized UnityNotificationManager getNotificationManagerImpl(Context context, Activity activity) {
         if (mUnityNotificationManager == null) {
             mUnityNotificationManager = new UnityNotificationManager();
         }

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -42,7 +42,6 @@ import com.unity3d.player.UnityPlayer;
 public class UnityNotificationManager extends BroadcastReceiver {
     protected static NotificationCallback mNotificationCallback;
     protected static UnityNotificationManager mUnityNotificationManager;
-    private static ConcurrentHashMap<Integer, Notification.Builder> mScheduledNotifications = new ConcurrentHashMap();
 
     private Context mContext = null;
     private Activity mActivity = null;
@@ -50,6 +49,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
     private UnityNotificationBackgroundThread mBackgroundThread;
     private Random mRandom;
     private HashSet<Integer> mVisibleNotifications;
+    private ConcurrentHashMap<Integer, Notification.Builder> mScheduledNotifications;
 
     static final String TAG_UNITY = "UnityNotifications";
 
@@ -74,6 +74,8 @@ public class UnityNotificationManager extends BroadcastReceiver {
         if (mContext == null)
             mContext = activity.getApplicationContext();
         mActivity = activity;
+        if (mScheduledNotifications == null)
+            mScheduledNotifications = new ConcurrentHashMap();
         if (mBackgroundThread == null)
             mBackgroundThread = new UnityNotificationBackgroundThread(this, mScheduledNotifications);
         if (mRandom == null)
@@ -114,6 +116,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
             mUnityNotificationManager = new UnityNotificationManager();
             mUnityNotificationManager.mContext = context.getApplicationContext();
             mUnityNotificationManager.mVisibleNotifications = new HashSet<>();
+            mUnityNotificationManager.mScheduledNotifications = new ConcurrentHashMap();
         }
 
         return mUnityNotificationManager;

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -395,12 +395,10 @@ public class UnityNotificationManager extends BroadcastReceiver {
         Log.d(TAG_UNITY, "Checking for invalid notification IDs still hanging around");
 
         Set<String> invalid = findInvalidNotificationIds(ids);
-        synchronized (UnityNotificationManager.class) {
-            Set<String> currentIds = new HashSet<>(ids);
-            for (String id : invalid) {
-                currentIds.remove(id);
-                mScheduledNotifications.remove(id);
-            }
+        Set<String> currentIds = new HashSet<>(ids);
+        for (String id : invalid) {
+            currentIds.remove(id);
+            mScheduledNotifications.remove(id);
         }
 
         // in case we have saved intents, clear them

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -71,7 +71,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
     static final String NOTIFICATION_IDS_SHARED_PREFS = "UNITY_STORED_NOTIFICATION_IDS";
     static final String NOTIFICATION_IDS_SHARED_PREFS_KEY = "UNITY_NOTIFICATION_IDS";
 
-    private void initialize(Activity activity) {
+    private void initialize(Activity activity, NotificationCallback notificationCallback) {
         if (mContext == null)
             mContext = activity.getApplicationContext();
         mActivity = activity;
@@ -79,6 +79,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
             mBackgroundThread = new UnityNotificationBackgroundThread(mContext, mScheduledNotifications);
         if (mRandom == null)
             mRandom = new Random();
+        mNotificationCallback = notificationCallback;
 
         try {
             ApplicationInfo ai = activity.getPackageManager().getApplicationInfo(activity.getPackageName(), PackageManager.GET_META_DATA);
@@ -117,12 +118,12 @@ public class UnityNotificationManager extends BroadcastReceiver {
     }
 
     // Called from managed code.
-    public static synchronized UnityNotificationManager getNotificationManagerImpl(Context context, Activity activity) {
+    public static synchronized UnityNotificationManager getNotificationManagerImpl(Activity activity, NotificationCallback notificationCallback) {
         if (mUnityNotificationManager == null) {
             mUnityNotificationManager = new UnityNotificationManager();
         }
 
-        mUnityNotificationManager.initialize(activity);
+        mUnityNotificationManager.initialize(activity, notificationCallback);
         return mUnityNotificationManager;
     }
 
@@ -133,11 +134,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
     // Get system notification service.
     public static NotificationManager getNotificationManager(Context context) {
         return (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-    }
-
-    // Called from managed code.
-    public void setNotificationCallback(NotificationCallback notificationCallback) {
-        UnityNotificationManager.mNotificationCallback = notificationCallback;
     }
 
     public void registerNotificationChannel(

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -344,10 +344,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
     }
 
     void scheduleAlarmWithNotification(Notification.Builder notificationBuilder, Intent intent, long fireTime) {
-        scheduleAlarmWithNotification(mOpenActivity, notificationBuilder, intent, fireTime);
-    }
-
-    private void scheduleAlarmWithNotification(Class activityClass, Notification.Builder notificationBuilder, Intent intent, long fireTime) {
         Bundle extras = notificationBuilder.getExtras();
         int id = extras.getInt(KEY_ID, -1);
         long repeatInterval = extras.getLong(KEY_REPEAT_INTERVAL, -1);
@@ -364,16 +360,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
     void scheduleAlarmWithNotification(Notification.Builder notificationBuilder) {
         long fireTime = notificationBuilder.getExtras().getLong(KEY_FIRE_TIME, 0L);
         Intent intent = buildNotificationIntent();
-
-        Class openActivity;
-        if (mOpenActivity == null) {
-            openActivity = UnityNotificationUtilities.getOpenAppActivity(mContext, true);
-        }
-        else {
-            openActivity = mUnityNotificationManager.mOpenActivity;
-        }
-
-        scheduleAlarmWithNotification(openActivity, notificationBuilder, intent, fireTime);
+        scheduleAlarmWithNotification(notificationBuilder, intent, fireTime);
     }
 
     private Notification buildNotificationForSending(Class openActivity, Notification.Builder builder) {

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -107,7 +107,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         mBackgroundThread.start();
     }
 
-    public static synchronized UnityNotificationManager getNotificationManagerImpl(Context context) {
+    static synchronized UnityNotificationManager getNotificationManagerImpl(Context context) {
         if (mUnityNotificationManager == null) {
             mUnityNotificationManager = new UnityNotificationManager();
         }

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -651,6 +651,10 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
+        getNotificationManagerImpl(context).onReceive(intent);
+    }
+
+    public void onReceive(Intent intent) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             if (KEY_NOTIFICATION_DISMISSED.equals(intent.getAction())) {
                 int removedId = intent.getIntExtra(KEY_NOTIFICATION_DISMISSED, -1);
@@ -660,7 +664,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
                 return;
             }
         }
-        Object notification = getNotificationOrBuilderForIntent(context, intent);
+        Object notification = getNotificationOrBuilderForIntent(mContext, intent);
         if (notification != null) {
             Notification notif = null;
             int id = -1;
@@ -677,19 +681,19 @@ public class UnityNotificationManager extends BroadcastReceiver {
                 }
 
                 Class openActivity;
-                if (mUnityNotificationManager == null || mUnityNotificationManager.mOpenActivity == null) {
-                    openActivity = UnityNotificationUtilities.getOpenAppActivity(context, true);
+                if (mOpenActivity == null) {
+                    openActivity = UnityNotificationUtilities.getOpenAppActivity(mContext, true);
                 }
                 else {
-                    openActivity = mUnityNotificationManager.mOpenActivity;
+                    openActivity = mOpenActivity;
                 }
 
                 id = builder.getExtras().getInt(KEY_ID, -1);
-                notif = buildNotificationForSending(context, openActivity, builder);
+                notif = buildNotificationForSending(mContext, openActivity, builder);
             }
 
             if (notif != null) {
-                UnityNotificationManager.notify(context, id, notif);
+                UnityNotificationManager.notify(mContext, id, notif);
             }
         }
     }

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -43,13 +43,13 @@ public class UnityNotificationManager extends BroadcastReceiver {
     protected static NotificationCallback mNotificationCallback;
     protected static UnityNotificationManager mUnityNotificationManager;
     private static ConcurrentHashMap<Integer, Notification.Builder> mScheduledNotifications = new ConcurrentHashMap();
-    private static HashSet<Integer> mVisibleNotifications = new HashSet<>();
 
     private Context mContext = null;
     private Activity mActivity = null;
     private Class mOpenActivity = null;
     private UnityNotificationBackgroundThread mBackgroundThread;
     private Random mRandom;
+    private HashSet<Integer> mVisibleNotifications;
 
     static final String TAG_UNITY = "UnityNotifications";
 
@@ -78,6 +78,8 @@ public class UnityNotificationManager extends BroadcastReceiver {
             mBackgroundThread = new UnityNotificationBackgroundThread(this, mScheduledNotifications);
         if (mRandom == null)
             mRandom = new Random();
+        if (mVisibleNotifications == null)
+            mVisibleNotifications = new HashSet<>();
         mNotificationCallback = notificationCallback;
 
         try {
@@ -113,6 +115,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         }
 
         mUnityNotificationManager.mContext = context.getApplicationContext();
+        mUnityNotificationManager.mVisibleNotifications = new HashSet<>();
         return mUnityNotificationManager;
     }
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -349,10 +349,10 @@ public class UnityNotificationManager extends BroadcastReceiver {
     }
 
     void scheduleAlarmWithNotification(Notification.Builder notificationBuilder, Intent intent, long fireTime) {
-        scheduleAlarmWithNotification(mContext, mOpenActivity, notificationBuilder, intent, fireTime);
+        scheduleAlarmWithNotification(mOpenActivity, notificationBuilder, intent, fireTime);
     }
 
-    static void scheduleAlarmWithNotification(Context context, Class activityClass, Notification.Builder notificationBuilder, Intent intent, long fireTime) {
+    private void scheduleAlarmWithNotification(Class activityClass, Notification.Builder notificationBuilder, Intent intent, long fireTime) {
         Bundle extras = notificationBuilder.getExtras();
         int id = extras.getInt(KEY_ID, -1);
         long repeatInterval = extras.getLong(KEY_REPEAT_INTERVAL, -1);
@@ -362,8 +362,8 @@ public class UnityNotificationManager extends BroadcastReceiver {
         mScheduledNotifications.putIfAbsent(Integer.valueOf(id), notificationBuilder);
         intent.putExtra(KEY_NOTIFICATION_ID, id);
 
-        PendingIntent broadcast = getBroadcastPendingIntent(context, id, intent, PendingIntent.FLAG_UPDATE_CURRENT);
-        UnityNotificationManager.scheduleNotificationIntentAlarm(context, repeatInterval, fireTime, broadcast);
+        PendingIntent broadcast = getBroadcastPendingIntent(mContext, id, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+        UnityNotificationManager.scheduleNotificationIntentAlarm(mContext, repeatInterval, fireTime, broadcast);
     }
 
     void scheduleAlarmWithNotification(Notification.Builder notificationBuilder) {
@@ -378,7 +378,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
             openActivity = mUnityNotificationManager.mOpenActivity;
         }
 
-        scheduleAlarmWithNotification(mContext, openActivity, notificationBuilder, intent, fireTime);
+        scheduleAlarmWithNotification(openActivity, notificationBuilder, intent, fireTime);
     }
 
     private Notification buildNotificationForSending(Class openActivity, Notification.Builder builder) {

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -185,7 +185,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         }
     }
 
-    protected static String getSharedPrefsNameByChannelId(String id)
+    private static String getSharedPrefsNameByChannelId(String id)
     {
         return String.format("unity_notification_channel_%s", id);
     }

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -190,15 +190,15 @@ public class UnityNotificationManager extends BroadcastReceiver {
         return String.format("unity_notification_channel_%s", id);
     }
 
-    private static NotificationChannelWrapper getNotificationChannel(Context context, String id) {
+    public NotificationChannelWrapper getNotificationChannel(String id) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            NotificationChannel ch = getNotificationManager(context).getNotificationChannel(id);
+            NotificationChannel ch = getNotificationManager(mContext).getNotificationChannel(id);
             if (ch == null)
                 return null;
             return notificationChannelToWrapper(ch);
         }
 
-        SharedPreferences prefs = context.getSharedPreferences(getSharedPrefsNameByChannelId(id), Context.MODE_PRIVATE);
+        SharedPreferences prefs = mContext.getSharedPreferences(getSharedPrefsNameByChannelId(id), Context.MODE_PRIVATE);
         NotificationChannelWrapper channel = new NotificationChannelWrapper();
 
         channel.id = id;
@@ -246,10 +246,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
         wrapper.lockscreenVisibility = channel.getLockscreenVisibility();
 
         return wrapper;
-    }
-
-    public NotificationChannelWrapper getNotificationChannel(String id) {
-        return UnityNotificationManager.getNotificationChannel(mContext, id);
     }
 
     public void deleteNotificationChannel(String id) {

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -660,7 +660,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
                 return;
             }
         }
-        Object notification = getNotificationOrBuilderForIntent(mContext, intent);
+        Object notification = getNotificationOrBuilderForIntent(intent);
         if (notification != null) {
             Notification notif = null;
             int id = -1;
@@ -853,7 +853,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
             }
         }
 
-        Object notification = getNotificationOrBuilderForIntent(mContext, intent);
+        Object notification = getNotificationOrBuilderForIntent(intent);
         if (notification == null)
             return null;
         if (notification instanceof Notification)
@@ -862,7 +862,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         return builder.build();
     }
 
-    public static Object getNotificationOrBuilderForIntent(Context context, Intent intent) {
+    private Object getNotificationOrBuilderForIntent(Intent intent) {
         Object notification = null;
         boolean sendable = false;
         if (intent.hasExtra(KEY_NOTIFICATION_ID)) {
@@ -872,8 +872,8 @@ public class UnityNotificationManager extends BroadcastReceiver {
                 sendable = true;
             } else {
                 // in case we don't have cached notification, deserialize from storage
-                SharedPreferences prefs = context.getSharedPreferences(getSharedPrefsNameByNotificationId(String.valueOf(id)), Context.MODE_PRIVATE);
-                notification = UnityNotificationUtilities.deserializeNotification(context, prefs);
+                SharedPreferences prefs = mContext.getSharedPreferences(getSharedPrefsNameByNotificationId(String.valueOf(id)), Context.MODE_PRIVATE);
+                notification = UnityNotificationUtilities.deserializeNotification(mContext, prefs);
             }
         } else if (intent.hasExtra(KEY_NOTIFICATION)) {
             // old code path where Notification object is in intent
@@ -887,7 +887,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
         Notification.Builder builder;
         if (notification instanceof Notification) {
-            builder = UnityNotificationUtilities.recoverBuilder(context, (Notification)notification);
+            builder = UnityNotificationUtilities.recoverBuilder(mContext, (Notification)notification);
         }
         else {
             builder = (Notification.Builder)notification;

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -40,7 +40,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import com.unity3d.player.UnityPlayer;
 
 public class UnityNotificationManager extends BroadcastReceiver {
-    protected static NotificationCallback mNotificationCallback;
     protected static UnityNotificationManager mUnityNotificationManager;
 
     private Context mContext = null;
@@ -50,6 +49,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
     private Random mRandom;
     private HashSet<Integer> mVisibleNotifications;
     private ConcurrentHashMap<Integer, Notification.Builder> mScheduledNotifications;
+    private NotificationCallback mNotificationCallback;
 
     static final String TAG_UNITY = "UnityNotifications";
 
@@ -74,6 +74,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         if (mContext == null)
             mContext = activity.getApplicationContext();
         mActivity = activity;
+        mNotificationCallback = notificationCallback;
         if (mScheduledNotifications == null)
             mScheduledNotifications = new ConcurrentHashMap();
         if (mBackgroundThread == null)
@@ -82,7 +83,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
             mRandom = new Random();
         if (mVisibleNotifications == null)
             mVisibleNotifications = new HashSet<>();
-        mNotificationCallback = notificationCallback;
 
         try {
             ApplicationInfo ai = activity.getPackageManager().getApplicationInfo(activity.getPackageName(), PackageManager.GET_META_DATA);

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -40,7 +40,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import com.unity3d.player.UnityPlayer;
 
 public class UnityNotificationManager extends BroadcastReceiver {
-    protected static UnityNotificationManager mUnityNotificationManager;
+    static UnityNotificationManager mUnityNotificationManager;
 
     private Context mContext = null;
     private Activity mActivity = null;

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -321,7 +321,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         return id;
     }
 
-    protected void performNotificationScheduling(int id, Notification.Builder notificationBuilder) {
+    void performNotificationScheduling(int id, Notification.Builder notificationBuilder) {
         Bundle extras = notificationBuilder.getExtras();
         long repeatInterval = extras.getLong(KEY_REPEAT_INTERVAL, -1);
         long fireTime = extras.getLong(KEY_FIRE_TIME, -1);
@@ -493,7 +493,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         UnityNotificationUtilities.serializeNotification(prefs, notification);
     }
 
-    protected static String getSharedPrefsNameByNotificationId(String id)
+    static String getSharedPrefsNameByNotificationId(String id)
     {
         return String.format("u_notification_data_%s", id);
     }

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -614,6 +614,9 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
+        // This method is called on OS created instance and that instance is recreated during various times
+        // for example sending app to background will cause new instance to be created when alarm fires
+        // since we also create one instance for our uses, always forward to that instance (creating if necessary)
         getNotificationManagerImpl(context).onReceive(intent);
     }
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -112,10 +112,10 @@ public class UnityNotificationManager extends BroadcastReceiver {
     static synchronized UnityNotificationManager getNotificationManagerImpl(Context context) {
         if (mUnityNotificationManager == null) {
             mUnityNotificationManager = new UnityNotificationManager();
+            mUnityNotificationManager.mContext = context.getApplicationContext();
+            mUnityNotificationManager.mVisibleNotifications = new HashSet<>();
         }
 
-        mUnityNotificationManager.mContext = context.getApplicationContext();
-        mUnityNotificationManager.mVisibleNotifications = new HashSet<>();
         return mUnityNotificationManager;
     }
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -347,7 +347,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         }
 
         if (fireNow) {
-            Notification notification = buildNotificationForSending(mContext, mOpenActivity, notificationBuilder);
+            Notification notification = buildNotificationForSending(mOpenActivity, notificationBuilder);
             notify(id, notification);
         }
     }
@@ -385,29 +385,29 @@ public class UnityNotificationManager extends BroadcastReceiver {
         scheduleAlarmWithNotification(context, openActivity, notificationBuilder, intent, fireTime);
     }
 
-    protected static Notification buildNotificationForSending(Context context, Class openActivity, Notification.Builder builder) {
+    private Notification buildNotificationForSending(Class openActivity, Notification.Builder builder) {
         int id = builder.getExtras().getInt(KEY_ID, -1);
-        Intent openAppIntent = buildOpenAppIntent(context, openActivity);
+        Intent openAppIntent = buildOpenAppIntent(openActivity);
         openAppIntent.putExtra(KEY_NOTIFICATION_ID, id);
-        PendingIntent pendingIntent = getActivityPendingIntent(context, id, openAppIntent, 0);
+        PendingIntent pendingIntent = getActivityPendingIntent(mContext, id, openAppIntent, 0);
         builder.setContentIntent(pendingIntent);
 
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             // Can't check StatusBar notifications pre-M, so ask to be notified when dismissed
-            Intent deleteIntent = new Intent(context, UnityNotificationManager.class);
+            Intent deleteIntent = new Intent(mContext, UnityNotificationManager.class);
             deleteIntent.setAction(KEY_NOTIFICATION_DISMISSED); // need action to distinguish intent from content one
             deleteIntent.putExtra(KEY_NOTIFICATION_DISMISSED, id);
-            PendingIntent deletePending = getBroadcastPendingIntent(context, id, deleteIntent, 0);
+            PendingIntent deletePending = getBroadcastPendingIntent(mContext, id, deleteIntent, 0);
             builder.setDeleteIntent(deletePending);
         }
 
-        finalizeNotificationForDisplay(context, builder);
+        finalizeNotificationForDisplay(builder);
         return builder.build();
     }
 
     // Build an Intent to open the given activity with the data from input Intent.
-    protected static Intent buildOpenAppIntent(Context context, Class className) {
-        Intent openAppIntent = new Intent(context, className);
+    private Intent buildOpenAppIntent(Class className) {
+        Intent openAppIntent = new Intent(mContext, className);
         openAppIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
 
         return openAppIntent;
@@ -682,7 +682,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
                 }
 
                 id = builder.getExtras().getInt(KEY_ID, -1);
-                notif = buildNotificationForSending(mContext, openActivity, builder);
+                notif = buildNotificationForSending(openActivity, builder);
             }
 
             if (notif != null) {
@@ -731,17 +731,17 @@ public class UnityNotificationManager extends BroadcastReceiver {
         return 0;
     }
 
-    public static void finalizeNotificationForDisplay(Context context, Notification.Builder notificationBuilder) {
+    private void finalizeNotificationForDisplay(Notification.Builder notificationBuilder) {
         String icon = notificationBuilder.getExtras().getString(KEY_SMALL_ICON);
-        int iconId = UnityNotificationUtilities.findResourceIdInContextByName(context, icon);
+        int iconId = UnityNotificationUtilities.findResourceIdInContextByName(mContext, icon);
         if (iconId == 0) {
-            iconId = context.getApplicationInfo().icon;
+            iconId = mContext.getApplicationInfo().icon;
         }
         notificationBuilder.setSmallIcon(iconId);
         icon = notificationBuilder.getExtras().getString(KEY_LARGE_ICON);
-        iconId = UnityNotificationUtilities.findResourceIdInContextByName(context, icon);
+        iconId = UnityNotificationUtilities.findResourceIdInContextByName(mContext, icon);
         if (iconId != 0) {
-            notificationBuilder.setLargeIcon(BitmapFactory.decodeResource(context.getResources(), iconId));
+            notificationBuilder.setLargeIcon(BitmapFactory.decodeResource(mContext.getResources(), iconId));
         }
     }
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
@@ -23,7 +23,7 @@ public class UnityNotificationRestartOnBootReceiver extends BroadcastReceiver {
     }
 
     private static void rescheduleSavedNotifications(Context context) {
-        List<Notification.Builder> saved_notifications = UnityNotificationManager.loadSavedNotifications(context);
+        List<Notification.Builder> saved_notifications = UnityNotificationManager.getNotificationManagerImpl(context).loadSavedNotifications();
 
         for (Notification.Builder notificationBuilder : saved_notifications) {
             Bundle extras = notificationBuilder.getExtras();

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
@@ -23,7 +23,8 @@ public class UnityNotificationRestartOnBootReceiver extends BroadcastReceiver {
     }
 
     private static void rescheduleSavedNotifications(Context context) {
-        List<Notification.Builder> saved_notifications = UnityNotificationManager.getNotificationManagerImpl(context).loadSavedNotifications();
+        UnityNotificationManager manager = UnityNotificationManager.getNotificationManagerImpl(context);
+        List<Notification.Builder> saved_notifications = manager.loadSavedNotifications();
 
         for (Notification.Builder notificationBuilder : saved_notifications) {
             Bundle extras = notificationBuilder.getExtras();
@@ -35,7 +36,7 @@ public class UnityNotificationRestartOnBootReceiver extends BroadcastReceiver {
             boolean isRepeatable = repeatInterval > 0;
 
             if (fireTimeDate.after(currentDate) || isRepeatable) {
-                UnityNotificationManager.scheduleAlarmWithNotification(notificationBuilder, context);
+                manager.scheduleAlarmWithNotification(notificationBuilder);
             }
         }
     }

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationUtilities.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationUtilities.java
@@ -542,7 +542,7 @@ public class UnityNotificationUtilities {
 
     private static Notification.Builder recoverBuilderCustom(Context context, Notification notification) {
         String channelID = notification.extras.getString(KEY_CHANNEL_ID);
-        Notification.Builder builder = UnityNotificationManager.createNotificationBuilder(context, channelID);
+        Notification.Builder builder = UnityNotificationManager.getNotificationManagerImpl(context).createNotificationBuilder(channelID);
         UnityNotificationManager.setNotificationIcon(builder, KEY_SMALL_ICON, notification.extras.getString(KEY_SMALL_ICON));
         String largeIcon = notification.extras.getString(KEY_LARGE_ICON);
         if (largeIcon != null && !largeIcon.isEmpty())

--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
@@ -347,12 +347,12 @@ class AndroidNotificationSendingTests
         yield return new WaitForSeconds(0.2f);
 
         var manager = managerClass.GetStatic<AndroidJavaObject>("mUnityNotificationManager");
+        // clear cached notifications to not mess up future tests
+        manager.Get<AndroidJavaObject>("mScheduledNotifications").Call("clear");
         // simulate reboot by directly cancelling scheduled alarms preserving saves
         manager.Call("cancelPendingNotificationIntent", id);
         // temporary null the manager, cause that's what we have in reality
         managerClass.SetStatic<AndroidJavaObject>("mUnityNotificationManager", null);
-        // also clear cached notifications, since they don't exist after reboot
-        managerClass.GetStatic<AndroidJavaObject>("mScheduledNotifications").Call("clear");
 
         yield return new WaitForSeconds(0.2f);
         // simulate reboot by calling reschedule method, that is called after reboot

--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
@@ -358,6 +358,10 @@ class AndroidNotificationSendingTests
         // simulate reboot by calling reschedule method, that is called after reboot
         rebootClass.CallStatic("rescheduleSavedNotifications", context);
 
+        var newManager = managerClass.GetStatic<AndroidJavaObject>("mUnityNotificationManager");
+        // new manager was supposed to be created, assign callback from original one to get notifications
+        newManager.Set("mNotificationCallback", manager.Get<AndroidJavaObject>("mNotificationCallback"));
+
         yield return WaitForNotification(120.0f);
 
         Debug.LogWarning("SendNotification_CanReschedule completed");

--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
@@ -346,14 +346,14 @@ class AndroidNotificationSendingTests
         int id = AndroidNotificationCenter.SendNotification(n, kDefaultTestChannel);
         yield return new WaitForSeconds(0.2f);
 
-        // temporary null the manager, cause that's what we have in reality
         var manager = managerClass.GetStatic<AndroidJavaObject>("mUnityNotificationManager");
+        // simulate reboot by directly cancelling scheduled alarms preserving saves
+        manager.Call("cancelPendingNotificationIntent", id);
+        // temporary null the manager, cause that's what we have in reality
         managerClass.SetStatic<AndroidJavaObject>("mUnityNotificationManager", null);
         // also clear cached notifications, since they don't exist after reboot
         managerClass.GetStatic<AndroidJavaObject>("mScheduledNotifications").Call("clear");
 
-        // simulate reboot by directly cancelling scheduled alarms preserving saves
-        managerClass.CallStatic("cancelPendingNotificationIntent", context, id);
         yield return new WaitForSeconds(0.2f);
         // simulate reboot by calling reschedule method, that is called after reboot
         rebootClass.CallStatic("rescheduleSavedNotifications", context);


### PR DESCRIPTION
The problem this PR is solving is that UnityNotificationManager class is used as the central manager for most notification stuff and as a receiver for alarms when notifications are supposed to be shown. The receiver objects are created by OS and they are recreated based on vairous conditions, while our own manager is supposed to be singleton instance. Some issues coming from that were solved via static variables in the class, which was error prone.
The changes in this PR are:
- have a single static instance of the manager, all other static variables converted to instance variables in this singleton
- receivers forward messages to the singleton instance
- a bunch of cleanup related to method visibility and reduction of static methods
- some minor cleanup

Note to QA:
- Android only
- various notification types shouldn't be affected, only scheduling and receiving
- testing required to check that scheduled notifications are received in all supported cases: app open, in background, killed, after device reboot (the first one is covered by automated tests and is least risky, can be skipped)
- essential to tests a range of supported OS versions
- tested by me on Nokia 7 Plus (10.0)