### PR TITLE
iOS Location improvements and fixes

### DIFF
--- a/TestProjects/Main/Assets/Resources/iOSNotifications/LocationTrigger/Location Triggered.asset
+++ b/TestProjects/Main/Assets/Resources/iOSNotifications/LocationTrigger/Location Triggered.asset
@@ -13,18 +13,19 @@ MonoBehaviour:
   m_Name: Location Triggered
   m_EditorClassIdentifier: 
   ButtonName: Send A Notification (Location Trigger)
-  Identifier: 
+  Identifier: loc_not
   CategoryIdentifier: category_indentifier
   ThreadIdentifier: thread_identifier
   Title: Location Notification Title
   Subtitle: This is a subtitle
   Body: And this is the body of this notification
-  ShowInForeground: 0
+  ShowInForeground: 1
   PresentationOptions: 6
   Badge: -1
   Data: This notification also includes some data
-  CenterX: 22.2847
-  CenterY: 114.1582
+  Latitude: 22.2847
+  Longitude: 114.1582
   Radius: 5000
   NotifyOnEntry: 1
   NotifyOnExit: 1
+  Repeats: 1

--- a/TestProjects/Main/Assets/Scripts/ScriptableObjects/iOSNotificationTemplateLocationTrigger.cs
+++ b/TestProjects/Main/Assets/Scripts/ScriptableObjects/iOSNotificationTemplateLocationTrigger.cs
@@ -34,11 +34,12 @@ namespace Unity.Notifications.Tests.Sample
 
         [Space(10)]
         [Header("Location Trigger")]
-        public float CenterX = 0f;
-        public float CenterY = 0f;
+        public double Latitude = 0f;
+        public double Longitude = 0f;
         public float Radius = 2f;
         public bool NotifyOnEntry = true;
         public bool NotifyOnExit = false;
+        public bool Repeats = false;
 #endif
     }
 }

--- a/TestProjects/Main/Assets/Scripts/iOSTest.cs
+++ b/TestProjects/Main/Assets/Scripts/iOSTest.cs
@@ -321,10 +321,12 @@ namespace Unity.Notifications.Tests.Sample
                             Data = template.Data,
                             Trigger = new iOSNotificationLocationTrigger()
                             {
-                                Center = new Vector2(template.CenterX, template.CenterY),
+                                Latitude = template.Latitude,
+                                Longitude = template.Longitude,
                                 Radius = template.Radius,
                                 NotifyOnEntry = template.NotifyOnEntry,
-                                NotifyOnExit = template.NotifyOnExit
+                                NotifyOnExit = template.NotifyOnExit,
+                                Repeats = template.Repeats,
                             }
                         }
                     );

--- a/TestProjects/Main/Assets/Scripts/iOSTest.cs
+++ b/TestProjects/Main/Assets/Scripts/iOSTest.cs
@@ -344,13 +344,13 @@ namespace Unity.Notifications.Tests.Sample
                 Transform buttonGroup =
                     GameObject.Instantiate(m_gameObjectReferences.ButtonGroupTemplate, m_gameObjectReferences.ButtonScrollViewContent);
                 Transform buttonGroupName = buttonGroup.GetChild(0).transform;
-                Transform buttonGameObject = buttonGroup.GetChild(1).transform;
+                Transform buttonGameObject = buttonGroup.GetChild(1).GetChild(0).transform;
                 // Set group name
                 buttonGroupName.GetComponentInChildren<Text>().text = group.Key.ToString();
                 // Instantiate buttons
                 foreach (DictionaryEntry test in group.Value)
                 {
-                    Transform button = GameObject.Instantiate(buttonGameObject, buttonGroup);
+                    Transform button = GameObject.Instantiate(buttonGameObject, buttonGroup.GetChild(1));
                     button.gameObject.GetComponentInChildren<Text>().text = test.Key.ToString();
                     button.GetComponent<Button>().onClick.AddListener(delegate
                     {

--- a/TestProjects/Main/SimulateLocation.gpx
+++ b/TestProjects/Main/SimulateLocation.gpx
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<gpx version="1.1" creator="Xcode">
+    <!-- A location used by location trigger button -->
+    <wpt lat="22.2847" lon="114.1582">
+        <name>Somewhere</name>
+    </wpt>
+</gpx>

--- a/com.unity.mobile.notifications/Documentation~/iOS.md
+++ b/com.unity.mobile.notifications/Documentation~/iOS.md
@@ -123,7 +123,8 @@ In the example below, the center coordinate is defined using the WGS 84 system. 
 ```c#
 var locationTrigger = new iOSNotificationLocationTrigger()
 {
-    Center = new Vector2(2.294498f, 48.858263f),
+    Latitude = 48.858263,
+    Longitude = 2.294498,
     Radius = 250f,
     NotifyOnEntry = true,
     NotifyOnExit = false,

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.h
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.h
@@ -64,8 +64,8 @@ typedef struct iOSNotificationData
 
         struct
         {
-            float centerX;
-            float centerY;
+            double latitude;
+            double longitude;
             float radius;
             unsigned char notifyOnEntry;
             unsigned char notifyOnExit;

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.h
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.h
@@ -69,6 +69,7 @@ typedef struct iOSNotificationData
             float radius;
             unsigned char notifyOnEntry;
             unsigned char notifyOnExit;
+            unsigned char repeats;
         } location;
     } trigger;
 } iOSNotificationData;

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
@@ -169,6 +169,7 @@ iOSNotificationData UNNotificationRequestToiOSNotificationData(UNNotificationReq
         notificationData.trigger.location.radius = region.radius;
         notificationData.trigger.location.notifyOnExit = region.notifyOnEntry;
         notificationData.trigger.location.notifyOnEntry = region.notifyOnExit;
+        notificationData.trigger.location.repeats = locationTrigger.repeats;
 #endif
     }
     else if ([request.trigger isKindOfClass: [UNPushNotificationTrigger class]])

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
@@ -164,8 +164,8 @@ iOSNotificationData UNNotificationRequestToiOSNotificationData(UNNotificationReq
         UNLocationNotificationTrigger* locationTrigger = (UNLocationNotificationTrigger*)request.trigger;
         CLCircularRegion *region = (CLCircularRegion*)locationTrigger.region;
 
-        notificationData.trigger.location.centerX = region.center.latitude;
-        notificationData.trigger.location.centerY = region.center.longitude;
+        notificationData.trigger.location.latitude = region.center.latitude;
+        notificationData.trigger.location.longitude = region.center.longitude;
         notificationData.trigger.location.radius = region.radius;
         notificationData.trigger.location.notifyOnExit = region.notifyOnEntry;
         notificationData.trigger.location.notifyOnEntry = region.notifyOnExit;

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -342,7 +342,7 @@ bool validateAuthorizationStatus(UnityNotificationManager* manager)
         region.notifyOnEntry = data->trigger.location.notifyOnEntry;
         region.notifyOnExit = data->trigger.location.notifyOnExit;
 
-        trigger = [UNLocationNotificationTrigger triggerWithRegion: region repeats: NO];
+        trigger = [UNLocationNotificationTrigger triggerWithRegion: region repeats: data->trigger.location.repeats];
 #else
         return;
 #endif

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -335,7 +335,7 @@ bool validateAuthorizationStatus(UnityNotificationManager* manager)
     else if (data->triggerType == LOCATION_TRIGGER)
     {
 #if UNITY_USES_LOCATION
-        CLLocationCoordinate2D center = CLLocationCoordinate2DMake(data->trigger.location.centerX, data->trigger.location.centerY);
+        CLLocationCoordinate2D center = CLLocationCoordinate2DMake(data->trigger.location.latitude, data->trigger.location.longitude);
 
         CLCircularRegion* region = [[CLCircularRegion alloc] initWithCenter: center
                                     radius: data->trigger.location.radius identifier: identifier];

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
@@ -82,8 +82,8 @@ namespace Unity.Notifications.iOS
     [StructLayout(LayoutKind.Sequential)]
     internal struct LocationTriggerData
     {
-        public float centerX;
-        public float centerY;
+        public double latitude;
+        public double longitude;
         public float radius;
         public Byte notifyOnEntry;
         public Byte notifyOnExit;
@@ -348,8 +348,8 @@ namespace Unity.Notifications.iOS
                     case iOSNotificationTriggerType.Location:
                         {
                             var trigger = (iOSNotificationLocationTrigger)value;
-                            data.trigger.location.centerX = trigger.Center.x;
-                            data.trigger.location.centerY = trigger.Center.y;
+                            data.trigger.location.latitude = trigger.Latitude;
+                            data.trigger.location.longitude = trigger.Longitude;
                             data.trigger.location.notifyOnEntry = (byte)(trigger.NotifyOnEntry ? 1 : 0);
                             data.trigger.location.notifyOnExit = (byte)(trigger.NotifyOnExit ? 1 : 0);
                             data.trigger.location.radius = trigger.Radius;
@@ -394,7 +394,8 @@ namespace Unity.Notifications.iOS
                     case iOSNotificationTriggerType.Location:
                         return new iOSNotificationLocationTrigger()
                         {
-                            Center = new Vector2(data.trigger.location.centerX, data.trigger.location.centerY),
+                            Latitude = data.trigger.location.latitude,
+                            Longitude = data.trigger.location.longitude,
                             Radius = data.trigger.location.radius,
                             NotifyOnEntry = data.trigger.location.notifyOnEntry != 0,
                             NotifyOnExit = data.trigger.location.notifyOnExit != 0

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
@@ -87,6 +87,7 @@ namespace Unity.Notifications.iOS
         public float radius;
         public Byte notifyOnEntry;
         public Byte notifyOnExit;
+        public Byte repeats;
     }
 
     [StructLayout(LayoutKind.Explicit)]
@@ -353,6 +354,7 @@ namespace Unity.Notifications.iOS
                             data.trigger.location.notifyOnEntry = (byte)(trigger.NotifyOnEntry ? 1 : 0);
                             data.trigger.location.notifyOnExit = (byte)(trigger.NotifyOnExit ? 1 : 0);
                             data.trigger.location.radius = trigger.Radius;
+                            data.trigger.location.repeats = (byte)(trigger.Repeats ? 1 : 0);
                             break;
                         }
                     case iOSNotificationTriggerType.Push:
@@ -398,7 +400,8 @@ namespace Unity.Notifications.iOS
                             Longitude = data.trigger.location.longitude,
                             Radius = data.trigger.location.radius,
                             NotifyOnEntry = data.trigger.location.notifyOnEntry != 0,
-                            NotifyOnExit = data.trigger.location.notifyOnExit != 0
+                            NotifyOnExit = data.trigger.location.notifyOnExit != 0,
+                            Repeats = data.trigger.location.repeats != 0,
                         };
                     case iOSNotificationTriggerType.Push:
                         return new iOSNotificationPushTrigger();

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationTriggers.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationTriggers.cs
@@ -62,7 +62,28 @@ namespace Unity.Notifications.iOS
         /// <summary>
         /// The center point of the geographic area.
         /// </summary>
-        public Vector2 Center { get; set; }
+        public Vector2 Center
+        {
+            get
+            {
+                return new Vector2((float)Latitude, (float)Longitude);
+            }
+            set
+            {
+                Latitude = value.x;
+                Longitude = value.y;
+            }
+        }
+
+        /// <summary>
+        /// The latitude of the center point of the geographic area.
+        /// </summary>
+        public double Latitude { get; set; }
+
+        /// <summary>
+        /// The longitude of the center point of the geographic area.
+        /// </summary>
+        public double Longitude { get; set; }
 
         /// <summary>
         /// The radius (measured in meters) that defines the geographic area’s outer boundary.

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationTriggers.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationTriggers.cs
@@ -62,6 +62,7 @@ namespace Unity.Notifications.iOS
         /// <summary>
         /// The center point of the geographic area.
         /// </summary>
+        [Obsolete("Use Latitude and Longitude", false)]
         public Vector2 Center
         {
             get

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationTriggers.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationTriggers.cs
@@ -99,6 +99,11 @@ namespace Unity.Notifications.iOS
         /// When this property is enabled, a device crossing from inside the region to outside the region triggers the delivery of a notification
         /// </summary>
         public bool NotifyOnExit { get; set; }
+
+        /// <summary>
+        /// Whether the notification should repeat.
+        /// </summary>
+        public bool Repeats { get; set; }
     }
 
     /// <summary>


### PR DESCRIPTION
* After test project update for Android, it got broken for iOS. This PR fixes it.
* We used Vector2 to specify the location in location trigger, which has a couple of problems:
  - Uses floats while Apple API uses doubles - risk of precision loss (with number being degrees can be meaningful)
  - Sort-of swapped with X being latitude and Y being longitude; looking at map you'd expect the opposite
  This PR introduces proper properties for Latitude and Longitude
* Apple API has repeat capability for location trigger, we didn't expose it, now we do
* The location button in test project was changed to be repeatable and work in foreground for easier testing

QA:
* iOS only changes
* Stuff already tested, no real need to test, but probably worth trying out
* No automated test possible ATM due to testing framework issues (same problem as with push tests)
* I could not get location simulation working on Simulator
* To test on real device:
  - Use Debug -> Simulate Location in Xcode
  - Add the .gpx file to Xcode project (available in test project, use Debug -> Simulate Location -> Add GPS... in Xcode); when done, a new item will appear in the same menu
  - Looks like you need to simulate some location twice to get "enterred" event: first some location outside, then a desired location; for simplicity best to have a repeatable trigger with both enter and leave events, then simply jump around the locations.