### PR TITLE
Android API 33 support

### DIFF
--- a/TestProjects/Main/Assets/Scripts/AndroidTest.cs
+++ b/TestProjects/Main/Assets/Scripts/AndroidTest.cs
@@ -93,6 +93,8 @@ namespace Unity.Notifications.Tests.Sample
             ((Action)m_groups["Channels"]["Create Secondary Simple Channel"]).Invoke();
             ((Action)m_groups["Channels"]["Create Fancy Channel"]).Invoke();
             m_LOGGER.Clear().White("Welcome!");
+
+            HandleNotificationPermission();
             HandleLastNotificationIntent();
         }
 
@@ -103,7 +105,22 @@ namespace Unity.Notifications.Tests.Sample
                 .Gray($"isPaused = {isPaused}", 1);
             if (isPaused == false)
             {
+                HandleNotificationPermission();
                 HandleLastNotificationIntent();
+            }
+        }
+
+        private void HandleNotificationPermission()
+        {
+            var permission = AndroidNotificationCenter.UserPermissionToPost;
+            switch (permission)
+            {
+                case PermissionStatus.Allowed:
+                    m_LOGGER.Green("Permission granted to post notifications");
+                    break;
+                default:
+                    m_LOGGER.Red("No permission to post notifications: " + permission);
+                    break;
             }
         }
 
@@ -159,6 +176,7 @@ namespace Unity.Notifications.Tests.Sample
             m_groups["General"]["Open Settings"] = new Action(() => { AndroidNotificationCenter.OpenNotificationSettings(); });
             m_groups["General"]["Notification batch size: "+NotificationBatchSizes[_CurrentNotificationBatchSizeIndex]] = new Action(() => { ChangeNotificationBatchSize(NotificationBatchSizes); });
             m_groups["General"]["Reset notification counter"] = new Action(() => { NotificationCounter = 0; });
+            m_groups["General"]["Request permission"] = new Action(() => { RequestNotificationPermission(); });
 
             m_groups["Modify"] = new OrderedDictionary();
             //m_groups["Modify"]["Create notification preset"] = new Action(() => {  });
@@ -268,6 +286,31 @@ namespace Unity.Notifications.Tests.Sample
             ButtonCheckStatusExplicitID.interactable = false;
 
             m_gameObjectReferences.ButtonGroupTemplate.gameObject.SetActive(false);
+        }
+
+        void RequestNotificationPermission()
+        {
+            var permission = AndroidNotificationCenter.UserPermissionToPost;
+            if (permission == PermissionStatus.Allowed)
+                m_LOGGER.Green("Already authorized");
+            if (permission == PermissionStatus.DeniedDontAskAgain)
+                m_LOGGER.Red("Denied, don't ask again");
+            else
+            {
+                m_LOGGER.Blue("Requesting permission");
+                permission = AndroidNotificationCenter.RequestPermissionToPost();
+                switch (permission)
+                {
+                    case PermissionStatus.Allowed:
+                        m_LOGGER.Green("Permission granted");
+                        break;
+                    case PermissionStatus.RequestPending:
+                        return;
+                    default:
+                        m_LOGGER.Red(permission.ToString());
+                        break;
+                }
+            }
         }
 
 

--- a/com.unity.mobile.notifications/Editor/AndroidNotificationPostProcessor.cs
+++ b/com.unity.mobile.notifications/Editor/AndroidNotificationPostProcessor.cs
@@ -82,6 +82,8 @@ namespace Unity.Notifications
                 AppendAndroidPermissionField(manifestPath, manifestDoc, "android.permission.RECEIVE_BOOT_COMPLETED");
             }
 
+            AppendAndroidPermissionField(manifestPath, manifestDoc, "android.permission.POST_NOTIFICATIONS");
+
             manifestDoc.Save(manifestPath);
         }
 

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -547,6 +547,7 @@ namespace Unity.Notifications.Android
 
         private static AndroidJavaObject s_CurrentActivity;
         private static JniApi s_Jni;
+        private static int s_ApiLevel;
         private static bool s_Initialized = false;
 
         /// <summary>
@@ -574,6 +575,9 @@ namespace Unity.Notifications.Android
             var notificationManagerClass = new AndroidJavaClass("com.unity.androidnotifications.UnityNotificationManager");
             var notificationManager = notificationManagerClass.CallStatic<AndroidJavaObject>("getNotificationManagerImpl", s_CurrentActivity, new NotificationCallback());
             s_Jni = new JniApi(notificationManagerClass, notificationManager);
+
+            using (var version = new AndroidJavaClass("android/os/Build$VERSION"))
+                s_ApiLevel = version.GetStatic<int>("SDK_INT");
 
             s_Initialized = true;
 #endif

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -588,7 +588,7 @@ namespace Unity.Notifications.Android
 
         private static AndroidJavaObject s_CurrentActivity;
         private static JniApi s_Jni;
-        private static int s_ApiLevel;
+        private static int s_DeviceApiLevel;
         private static bool s_Initialized = false;
 
         /// <summary>
@@ -618,7 +618,7 @@ namespace Unity.Notifications.Android
             s_Jni = new JniApi(notificationManagerClass, notificationManager);
 
             using (var version = new AndroidJavaClass("android/os/Build$VERSION"))
-                s_ApiLevel = version.GetStatic<int>("SDK_INT");
+                s_DeviceApiLevel = version.GetStatic<int>("SDK_INT");
 
             s_Initialized = true;
 #endif
@@ -640,7 +640,7 @@ namespace Unity.Notifications.Android
             {
                 if (!Initialize())
                     return PermissionStatus.Denied;
-                if (s_ApiLevel < API_POST_NOTIFICATIONS_PERMISSION_REQUIRED)
+                if (s_DeviceApiLevel < API_POST_NOTIFICATIONS_PERMISSION_REQUIRED)
                     return PermissionStatus.Allowed;
 
                 var permissionStatus = (PermissionStatus)PlayerPrefs.GetInt(SETTING_POST_NOTIFICATIONS_PERMISSION, (int)PermissionStatus.NotRequested);

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Android;
 
 #if UNITY_2022_2_OR_NEWER
 using JniMethodID = System.IntPtr;
@@ -13,6 +14,37 @@ using JniFieldID = System.String;
 
 namespace Unity.Notifications.Android
 {
+    /// <summary>
+    /// Represents a status of the Android runtime permission.
+    /// </summary>
+    public enum PermissionStatus
+    {
+        /// <summary>
+        /// No permission as user was not prompted for it.
+        /// </summary>
+        NotRequested = 0,
+
+        /// <summary>
+        /// User gave permission.
+        /// </summary>
+        Allowed = 1,
+
+        /// <summary>
+        /// User denied permission.
+        /// </summary>
+        Denied = 2,
+
+        /// <summary>
+        /// User denied permission and expressed intent to not be prompted again.
+        /// </summary>
+        DeniedDontAskAgain = 3,
+
+        /// <summary>
+        /// A request for permission was made and user hasn't responded yet.
+        /// </summary>
+        RequestPending = 4,
+    }
+
     /// <summary>
     /// Current status of a scheduled notification, can be queried using CheckScheduledNotificationStatus.
     /// </summary>
@@ -535,6 +567,15 @@ namespace Unity.Notifications.Android
     /// </summary>
     public class AndroidNotificationCenter
     {
+        private static int API_POST_NOTIFICATIONS_PERMISSION_REQUIRED = 33;
+        private static string PERMISSION_POST_NOTIFICATIONS = "android.permission.POST_NOTIFICATIONS";
+
+        /// <summary>
+        /// A PlayerPrefs key used to save users reply to POST_NOTIFICATIONS request (integer value of the PermissionStatus).
+        /// </summary>
+        /// <see cref="PermissionStatus"/>
+        public static string SETTING_POST_NOTIFICATIONS_PERMISSION = "com.unity.androidnotifications.PostNotificationsPermission";
+
         /// <summary>
         /// The delegate type for the notification received callbacks.
         /// </summary>
@@ -582,6 +623,71 @@ namespace Unity.Notifications.Android
             s_Initialized = true;
 #endif
             return s_Initialized;
+        }
+
+        static void SetPostPermissionStting(PermissionStatus status)
+        {
+            PlayerPrefs.SetInt(SETTING_POST_NOTIFICATIONS_PERMISSION, (int)status);
+        }
+
+        /// <summary>
+        /// Has user given permission to post notifications.
+        /// Before Android 13 (API 33) no permission is required.
+        /// </summary>
+        public static PermissionStatus UserPermissionToPost
+        {
+            get
+            {
+                if (!Initialize())
+                    return PermissionStatus.Denied;
+                if (s_ApiLevel < API_POST_NOTIFICATIONS_PERMISSION_REQUIRED)
+                    return PermissionStatus.Allowed;
+
+                var permissionStatus = (PermissionStatus)PlayerPrefs.GetInt(SETTING_POST_NOTIFICATIONS_PERMISSION, (int)PermissionStatus.NotRequested);
+                var allowed = Permission.HasUserAuthorizedPermission(PERMISSION_POST_NOTIFICATIONS);
+                if (allowed)
+                {
+                    if (permissionStatus != PermissionStatus.Allowed)
+                        SetPostPermissionStting(PermissionStatus.Allowed);
+                    return PermissionStatus.Allowed;
+                }
+
+                switch (permissionStatus)
+                {
+                    case PermissionStatus.NotRequested:
+                        break;
+                    case PermissionStatus.Allowed:
+                        permissionStatus = PermissionStatus.Denied;
+                        SetPostPermissionStting(permissionStatus);
+                        break;
+                }
+
+                return permissionStatus;
+            }
+        }
+
+        /// <summary>
+        /// Request user permission to post notifications.
+        /// Before Android 13 (API 33) will allow immediately.
+        /// May succeed or fail immediately. Users response is saved to PlayerPrefs.
+        /// Respects users wish to not be asked again.
+        /// </summary>
+        /// <returns>PermissionStatus.RequestPending if user is prompted for permission or immediately known reply.</returns>
+        /// <seealso cref="SETTING_POST_NOTIFICATIONS_PERMISSION"/>
+        public static PermissionStatus RequestPermissionToPost()
+        {
+            var permissionStatus = UserPermissionToPost;
+            if (permissionStatus == PermissionStatus.Allowed)
+                return permissionStatus;
+            if (permissionStatus == PermissionStatus.DeniedDontAskAgain)
+                return permissionStatus;
+
+            var callbacks = new PermissionCallbacks();
+            callbacks.PermissionGranted += (unused) => SetPostPermissionStting(PermissionStatus.Allowed);
+            callbacks.PermissionDenied += (unused) => SetPostPermissionStting(PermissionStatus.Denied);
+            callbacks.PermissionDeniedAndDontAskAgain += (unused) => SetPostPermissionStting(PermissionStatus.DeniedDontAskAgain);
+            Permission.RequestUserPermission(PERMISSION_POST_NOTIFICATIONS, callbacks);
+            return PermissionStatus.RequestPending;
         }
 
         /// <summary>

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -77,7 +77,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         mNotificationCallback = notificationCallback;
         if (mScheduledNotifications == null)
             mScheduledNotifications = new ConcurrentHashMap();
-        if (mBackgroundThread == null)
+        if (mBackgroundThread == null || !mBackgroundThread.isAlive())
             mBackgroundThread = new UnityNotificationBackgroundThread(this, mScheduledNotifications);
         if (mRandom == null)
             mRandom = new Random();
@@ -108,7 +108,8 @@ public class UnityNotificationManager extends BroadcastReceiver {
             Log.e(TAG_UNITY, "Failed to load meta-data, NullPointer: " + e.getMessage());
         }
 
-        mBackgroundThread.start();
+        if (!mBackgroundThread.isAlive())
+            mBackgroundThread.start();
     }
 
     static synchronized UnityNotificationManager getNotificationManagerImpl(Context context) {

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -138,6 +138,10 @@ public class UnityNotificationManager extends BroadcastReceiver {
         return (NotificationManager) mContext.getSystemService(Context.NOTIFICATION_SERVICE);
     }
 
+    public int getTargetSdk() {
+        return mContext.getApplicationInfo().targetSdkVersion;
+    }
+
     public void registerNotificationChannel(
             String id,
             String name,


### PR DESCRIPTION
https://jira.unity3d.com/browse/MNB-13
Android 13 addes a new runtime permission for posting notifications. If target SDK is less than 33, OS will ask for permission on first launch, while for 33 and later the request has to be made from code.
Changes by this PR:
- add permission to manifest (otherwise notifications don't work at all)
- introduce new APIs for checking and asking for permission to post notifications
- new button in test project to request permission
- minor unrelated thread safety issue in Java, that was noticed

Here's how it works:
- On devices with older Android versions nothing changes, new APIs do nothing and report that notifications are allowed.
- On Android 13 permission needs to be requested, otherwise notifications work silently (no UI show up, but callbacks are still received, just like iOS Provisional authorization)
- Permission can be denied with "Don't ask again", on Pixel 5 this is done by denying twice; when this is done, no permission is asked again; uninstall the app to reset
- Permission can be given in settings (test projects Open Settings button gets you there); when this is used, it is allow or deny don't ask for the app, this can be used to overrule earlier allow/permanent deny
- Permission has to requested by app if both device and application targetSDK are 33, if targetSDK is lower, permission is asked for automatically on first launch and app cannot ask for it at runtime

Tested on devices:
- Asus ROG Phone (8.1)
- Pixel 5 (13)

No special requests for testing, just double check based on info above.