### PR TITLE
Android notification permission API rework

### DIFF
--- a/TestProjects/Main/Assets/Scripts/AndroidTest.cs
+++ b/TestProjects/Main/Assets/Scripts/AndroidTest.cs
@@ -290,26 +290,16 @@ namespace Unity.Notifications.Tests.Sample
 
         void RequestNotificationPermission()
         {
-            var permission = AndroidNotificationCenter.UserPermissionToPost;
-            if (permission == PermissionStatus.Allowed)
-                m_LOGGER.Green("Already authorized");
-            if (permission == PermissionStatus.DeniedDontAskAgain)
-                m_LOGGER.Red("Denied, don't ask again");
-            else
+            var request = new PermissionRequest();
+            switch (request.Status)
             {
-                m_LOGGER.Blue("Requesting permission");
-                permission = AndroidNotificationCenter.RequestPermissionToPost();
-                switch (permission)
-                {
-                    case PermissionStatus.Allowed:
-                        m_LOGGER.Green("Permission granted");
-                        break;
-                    case PermissionStatus.RequestPending:
-                        return;
-                    default:
-                        m_LOGGER.Red(permission.ToString());
-                        break;
-                }
+                case PermissionStatus.Allowed:
+                    m_LOGGER.Green("Already allowed");
+                    break;
+                case PermissionStatus.Denied:
+                case PermissionStatus.DeniedDontAskAgain:
+                    m_LOGGER.Red(request.Status.ToString());
+                    break;
             }
         }
 

--- a/com.unity.mobile.notifications/Documentation~/Android.md
+++ b/com.unity.mobile.notifications/Documentation~/Android.md
@@ -23,6 +23,20 @@ After you create a notification channel, you can't change its behavior. For more
 
 On devices that use Android versions prior to 8.0, this package emulates the same behavior by applying notification channel properties, such as `Importance`, to individual notifications.
 
+## Request permission to post notifications
+
+Starting with Android 13.0 (API level 33) notifications can not be posted without users permission. They can still be scheduled, but will work silently with no UI shown to the user. You can request the permission by running this method in the coroutine:
+
+```c#
+IEnumerator RequestNotificationPermission()
+{
+    var request = new PermissionRequest();
+    while (request.Status == PermissionStatus.RequestPending)
+        yield return null;
+    // here use request.Status to determine users response
+}
+```
+
 ## Manage notifications
 
 This package provides a set of APIs to manage notifications. These APIs allow you to perform actions such as sending, updating, and deleting notifications. For more notification-related APIs, see [AndroidNotificationCenter](../api/Unity.Notifications.Android.AndroidNotificationCenter.html).

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -15,37 +15,6 @@ using JniFieldID = System.String;
 namespace Unity.Notifications.Android
 {
     /// <summary>
-    /// Represents a status of the Android runtime permission.
-    /// </summary>
-    public enum PermissionStatus
-    {
-        /// <summary>
-        /// No permission as user was not prompted for it.
-        /// </summary>
-        NotRequested = 0,
-
-        /// <summary>
-        /// User gave permission.
-        /// </summary>
-        Allowed = 1,
-
-        /// <summary>
-        /// User denied permission.
-        /// </summary>
-        Denied = 2,
-
-        /// <summary>
-        /// User denied permission and expressed intent to not be prompted again.
-        /// </summary>
-        DeniedDontAskAgain = 3,
-
-        /// <summary>
-        /// A request for permission was made and user hasn't responded yet.
-        /// </summary>
-        RequestPending = 4,
-    }
-
-    /// <summary>
     /// Current status of a scheduled notification, can be queried using CheckScheduledNotificationStatus.
     /// </summary>
     public enum NotificationStatus
@@ -568,7 +537,7 @@ namespace Unity.Notifications.Android
     public class AndroidNotificationCenter
     {
         private static int API_POST_NOTIFICATIONS_PERMISSION_REQUIRED = 33;
-        private static string PERMISSION_POST_NOTIFICATIONS = "android.permission.POST_NOTIFICATIONS";
+        internal static string PERMISSION_POST_NOTIFICATIONS = "android.permission.POST_NOTIFICATIONS";
 
         /// <summary>
         /// A PlayerPrefs key used to save users reply to POST_NOTIFICATIONS request (integer value of the PermissionStatus).
@@ -627,7 +596,7 @@ namespace Unity.Notifications.Android
             return s_Initialized;
         }
 
-        static void SetPostPermissionSetting(PermissionStatus status)
+        internal static void SetPostPermissionSetting(PermissionStatus status)
         {
             PlayerPrefs.SetInt(SETTING_POST_NOTIFICATIONS_PERMISSION, (int)status);
         }
@@ -666,36 +635,6 @@ namespace Unity.Notifications.Android
 
                 return permissionStatus;
             }
-        }
-
-        /// <summary>
-        /// Request user permission to post notifications.
-        /// Before Android 13 (API 33) will allow immediately.
-        /// May succeed or fail immediately. Users response is saved to PlayerPrefs.
-        /// Respects users wish to not be asked again.
-        /// </summary>
-        /// <returns>PermissionStatus.RequestPending if user is prompted for permission or immediately known reply.</returns>
-        /// <seealso cref="SETTING_POST_NOTIFICATIONS_PERMISSION"/>
-        public static PermissionStatus RequestPermissionToPost()
-        {
-            var permissionStatus = UserPermissionToPost;
-            if (permissionStatus == PermissionStatus.Allowed)
-                return permissionStatus;
-            if (permissionStatus == PermissionStatus.DeniedDontAskAgain)
-                return permissionStatus;
-            // Can only request permission if applications target SDK is 33, not actual device SDK
-            if (s_TargetApiLevel < API_POST_NOTIFICATIONS_PERMISSION_REQUIRED)
-            {
-                // don't change setting here, in case app gets updated
-                return PermissionStatus.DeniedDontAskAgain;
-            }
-
-            var callbacks = new PermissionCallbacks();
-            callbacks.PermissionGranted += (unused) => SetPostPermissionSetting(PermissionStatus.Allowed);
-            callbacks.PermissionDenied += (unused) => SetPostPermissionSetting(PermissionStatus.Denied);
-            callbacks.PermissionDeniedAndDontAskAgain += (unused) => SetPostPermissionSetting(PermissionStatus.DeniedDontAskAgain);
-            Permission.RequestUserPermission(PERMISSION_POST_NOTIFICATIONS, callbacks);
-            return PermissionStatus.RequestPending;
         }
 
         /// <summary>

--- a/com.unity.mobile.notifications/Runtime/Android/NotificationPermission.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/NotificationPermission.cs
@@ -1,0 +1,85 @@
+using UnityEngine.Android;
+
+namespace Unity.Notifications.Android
+{
+    /// <summary>
+    /// Represents a status of the Android runtime permission.
+    /// </summary>
+    public enum PermissionStatus
+    {
+        /// <summary>
+        /// No permission as user was not prompted for it.
+        /// </summary>
+        NotRequested = 0,
+
+        /// <summary>
+        /// User gave permission.
+        /// </summary>
+        Allowed = 1,
+
+        /// <summary>
+        /// User denied permission.
+        /// </summary>
+        Denied = 2,
+
+        /// <summary>
+        /// User denied permission and expressed intent to not be prompted again.
+        /// </summary>
+        DeniedDontAskAgain = 3,
+
+        /// <summary>
+        /// A request for permission was made and user hasn't responded yet.
+        /// </summary>
+        RequestPending = 4,
+    }
+
+    /// <summary>
+    /// A class to request permission to post notifications.
+    /// Before Android 13 (API 33) it is not required and Status will become Allowed immediately.
+    /// May succeed or fail immediately. Users response is saved to PlayerPrefs.
+    /// Respects users wish to not be asked again.
+    /// </summary>
+    /// <seealso cref="AndroidNotificationCenter.UserPermissionToPost"/>
+    /// <seealso cref="AndroidNotificationCenter.SETTING_POST_NOTIFICATIONS_PERMISSION"/>
+    public class PermissionRequest
+    {
+        /// <summary>
+        /// The status of this request.
+        /// Value other than RequestPending means request has completed.
+        /// </summary>
+        public PermissionStatus Status { get; set; }
+
+        /// <summary>
+        /// Create a new request.
+        /// Will show user a dialog asking for permission if that is required to post notifications and user hasn't permanently denied it already.
+        /// </summary>
+        /// <see cref="PermissionStatus.DeniedDontAskAgain"/>
+        public PermissionRequest()
+        {
+            Status = AndroidNotificationCenter.UserPermissionToPost;
+            switch (Status)
+            {
+                case PermissionStatus.NotRequested:
+                case PermissionStatus.Denied:
+                    Status = PermissionStatus.RequestPending;
+                    RequestPermission();
+                    break;
+            }
+        }
+
+        void RequestPermission()
+        {
+            var callbacks = new PermissionCallbacks();
+            callbacks.PermissionGranted += (unused) => PermissionResponse(PermissionStatus.Allowed);
+            callbacks.PermissionDenied += (unused) => PermissionResponse(PermissionStatus.Denied);
+            callbacks.PermissionDeniedAndDontAskAgain += (unused) => PermissionResponse(PermissionStatus.DeniedDontAskAgain);
+            Permission.RequestUserPermission(AndroidNotificationCenter.PERMISSION_POST_NOTIFICATIONS, callbacks);
+        }
+
+        void PermissionResponse(PermissionStatus status)
+        {
+            Status = status;
+            AndroidNotificationCenter.SetPostPermissionSetting(status);
+        }
+    }
+}

--- a/com.unity.mobile.notifications/Runtime/Android/NotificationPermission.cs.meta
+++ b/com.unity.mobile.notifications/Runtime/Android/NotificationPermission.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 110fbd120961b4105a52b39fc24273be
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
When updating the sample project I noticed shortcomings in notification permission API and inconsistency with iOS.
This PR corrects it by making android permission request similar to iOS with dedicated request class.
The property for querying was left, since I find it useful.