### PR TITLE
Backport Android 12+ fixes to 1.4.x series

### DIFF
--- a/add_sample.sh
+++ b/add_sample.sh
@@ -10,7 +10,7 @@ mkdir Samples
 
 cd Samples
 
-git clone https://github.com/Unity-Technologies/NotificationsSamples.git tmp
+git clone -b release-1-4 https://github.com/Unity-Technologies/NotificationsSamples.git tmp
 
 rm -rf tmp/Assets/Editor
 rm tmp/Assets/Editor.meta

--- a/com.unity.mobile.notifications/Documentation~/Android.md
+++ b/com.unity.mobile.notifications/Documentation~/Android.md
@@ -23,6 +23,27 @@ After you create a notification channel, you can't change its behavior. For more
 
 On devices that use Android versions prior to 8.0, this package emulates the same behavior by applying notification channel properties, such as `Importance`, to individual notifications.
 
+## Schedule notifications at exact time
+
+Before Android 6.0 notifications can be scheduled only at approximate time.
+
+Since Android 12.0 (API level 31) android.permission.SCHEDULE_EXACT_ALARM permission has to be added to the manifest to enable exact scheduling, see [documentation](https://developer.android.com/reference/android/Manifest.permission#SCHEDULE_EXACT_ALARM).
+
+Since Android 13.0 (API level 33) the android.permission.USE_EXACT_ALARM is and alternative permission to enable exact scheduling.
+
+Unity will schedule notifications at exact times when this is possible.
+
+## Permission to post notifications
+
+Since Android 13.0 it is required to ask user permission to show notifications. When application targets SDK that is less than 33, operating system will ask for permission automatically when application is launched. When targetting SDK 33 or greater, it is up to application itself to ask for permission, otherwise notifications will not show up in the tray. You can request users permission using Unity [Permission](https://docs.unity3d.com/2019.4/Documentation/ScriptReference/Android.Permission.html) struct:
+
+```c#
+if (!Permission.HasUserAuthorizedPermission("android.permission.POST_NOTIFICATIONS"))
+{
+    Permission.RequestUserPermission("android.permission.POST_NOTIFICATIONS");
+}
+```
+
 ## Manage notifications
 
 This package provides a set of APIs to manage notifications. These APIs allow you to perform actions such as sending, updating, and deleting notifications. For more notification-related APIs, see [AndroidNotificationCenter](../api/Unity.Notifications.Android.AndroidNotificationCenter.html).

--- a/com.unity.mobile.notifications/Editor/AndroidNotificationPostProcessor.cs
+++ b/com.unity.mobile.notifications/Editor/AndroidNotificationPostProcessor.cs
@@ -68,6 +68,8 @@ namespace Unity.Notifications
                 AppendAndroidPermissionField(manifestPath, manifestDoc, "android.permission.RECEIVE_BOOT_COMPLETED");
             }
 
+            AppendAndroidPermissionField(manifestPath, manifestDoc, "android.permission.POST_NOTIFICATIONS");
+
             manifestDoc.Save(manifestPath);
         }
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -384,7 +384,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         try {
             if (mCanScheduleExactAlarms == null)
                 mCanScheduleExactAlarms = AlarmManager.class.getMethod("canScheduleExactAlarms");
-            return (boolean)canScheduleExactAlarms.invoke(alarmManager);
+            return (boolean)mCanScheduleExactAlarms.invoke(alarmManager);
         } catch (NoSuchMethodException ex) {
             Log.e("UnityNotifications", "No AlarmManager.canScheduleExactAlarms() on Android 31+ device, should not happen", ex);
             return false;

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -37,6 +37,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
     protected Activity mActivity = null;
     protected Class mOpenActivity = null;
     protected boolean mRescheduleOnRestart = false;
+    protected static Method mCanScheduleExactAlarms;
 
     protected static final String NOTIFICATION_CHANNELS_SHARED_PREFS = "UNITY_NOTIFICATIONS";
     protected static final String NOTIFICATION_CHANNELS_SHARED_PREFS_KEY = "ChannelIDs";
@@ -381,7 +382,8 @@ public class UnityNotificationManager extends BroadcastReceiver {
             return true;
 
         try {
-            Method canScheduleExactAlarms = AlarmManager.class.getMethod("canScheduleExactAlarms");
+            if (mCanScheduleExactAlarms == null)
+                mCanScheduleExactAlarms = AlarmManager.class.getMethod("canScheduleExactAlarms");
             return (boolean)canScheduleExactAlarms.invoke(alarmManager);
         } catch (NoSuchMethodException ex) {
             Log.e("UnityNotifications", "No AlarmManager.canScheduleExactAlarms() on Android 31+ device, should not happen", ex);


### PR DESCRIPTION
We still support 1.4.x notification version as it is compatible with API levels that are minimum on 2020.3.
The changes backported are for exact scheduling and notification permission.

To keep changes to minimum, not doing anything related to scheduling related permissions, just document that one of the two is required to support exact scheduling on Android 12+. User has to add it manually.
Add POST_NOTIFICATIONS to manifest. Not adding permission request API, just documenting how to request it.

QA: the only real change here is that Android 13 devices work fine with target SDK less than 33 and with 33 (in the later case one has to manually request the permission, test project has button for that).