### PR TITLE
Fix occasional crash on iOS

### DIFF
--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this package will be documented in this file.
 
+## [2.1.1] - UNRELEASED
+
+### Fixes:
+- [iOS] - Fix occasional crash when registering for push notifications.
+
 ## [2.1.0] - 2022-09-23
 
 ### Changes & Improvements:

--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this package will be documented in this file.
 
-## [UNRELEASED]
+## [Unreleased]
 
 ### Fixes:
 - [iOS] - Fix occasional crash when registering for push notifications.

--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this package will be documented in this file.
 
-## [2.1.1] - UNRELEASED
+## [UNRELEASED]
 
 ### Fixes:
 - [iOS] - Fix occasional crash when registering for push notifications.

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -52,13 +52,14 @@
 {
     struct iOSNotificationAuthorizationData authData;
     authData.granted = status == UNAuthorizationStatusAuthorized;
+    authData.error = NULL;
+    authData.deviceToken = NULL;
     NSString* deviceToken = nil;
     if (authData.granted)
     {
         deviceToken = [UnityNotificationManager deviceTokenFromNotification: notification];
         authData.deviceToken = [deviceToken UTF8String];
     }
-    authData.error = NULL;
 
     [_lock lock];
     _remoteNotificationsRegistered = status;


### PR DESCRIPTION
https://github.com/Unity-Technologies/com.unity.mobile.notifications/issues/205

authData.deviceToken is not initialized, so if response is not granted, it may be not null and in such case we crash trying to make a C# string from it.