### PR TITLE
Android permission fixes

### DIFF
--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this package will be documented in this file.
 ## [Unreleased]
 
 ### Fixes:
+- [Android] - No longer use DeniedAndDontAskAgain permission response, only Denied.
 - [iOS] - Fix occasional crash when registering for push notifications.
 
 ## [2.1.0] - 2022-09-23

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -631,6 +631,9 @@ namespace Unity.Notifications.Android
                         permissionStatus = PermissionStatus.Denied;
                         SetPostPermissionSetting(permissionStatus);
                         break;
+                    case PermissionStatus.DeniedDontAskAgain:  // no longer used, revert to Denied
+                        permissionStatus = PermissionStatus.Denied;
+                        break;
                 }
 
                 return permissionStatus;

--- a/com.unity.mobile.notifications/Runtime/Android/NotificationPermission.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/NotificationPermission.cs
@@ -23,7 +23,7 @@ namespace Unity.Notifications.Android
         Denied = 2,
 
         /// <summary>
-        /// User denied permission and expressed intent to not be prompted again.
+        /// No longer used. User denied permission and expressed intent to not be prompted again.
         /// </summary>
         DeniedDontAskAgain = 3,
 
@@ -53,7 +53,6 @@ namespace Unity.Notifications.Android
         /// Create a new request.
         /// Will show user a dialog asking for permission if that is required to post notifications and user hasn't permanently denied it already.
         /// </summary>
-        /// <see cref="PermissionStatus.DeniedDontAskAgain"/>
         public PermissionRequest()
         {
             Status = AndroidNotificationCenter.UserPermissionToPost;
@@ -61,6 +60,7 @@ namespace Unity.Notifications.Android
             {
                 case PermissionStatus.NotRequested:
                 case PermissionStatus.Denied:
+                case PermissionStatus.DeniedDontAskAgain:  // this one is no longer used, but might be found in settings
                     Status = PermissionStatus.RequestPending;
                     RequestPermission();
                     break;
@@ -72,7 +72,6 @@ namespace Unity.Notifications.Android
             var callbacks = new PermissionCallbacks();
             callbacks.PermissionGranted += (unused) => PermissionResponse(PermissionStatus.Allowed);
             callbacks.PermissionDenied += (unused) => PermissionResponse(PermissionStatus.Denied);
-            callbacks.PermissionDeniedAndDontAskAgain += (unused) => PermissionResponse(PermissionStatus.DeniedDontAskAgain);
             Permission.RequestUserPermission(AndroidNotificationCenter.PERMISSION_POST_NOTIFICATIONS, callbacks);
         }
 


### PR DESCRIPTION
Removing uses of DeniedDontAskAgain, similar to Unity trunk. On Android 13 we don't reliably detect if it's a permanent dismiss, or a soft dismiss by swiping. And this is the only Android version where permission is required.

The changes after this release:
- AndroidNotificationCenter.UserPermissionToPost now should never return DeniedDontAskAgain
- PermissonRequest should work even if we have saved DeniedDontAskAgain is prefs

Testing required:
- Build master version using target SDK 33, request for permission and dismiss the dialog by swiping; you should get a permanent deny and not be able to request again
- Replacing the app with version from this PR should let to request again and again until Deny button is pressed twice, after which you can only go to settings and enable there
- the Main test project is just fine for this, has buttons to request permission and to open settings.