### PR TITLE
Android channel groups

### DIFF
--- a/TestProjects/Main/Assets/Scripts/AndroidTest.cs
+++ b/TestProjects/Main/Assets/Scripts/AndroidTest.cs
@@ -203,34 +203,44 @@ namespace Unity.Notifications.Tests.Sample
             m_groups["Channels"]["List All Channels"] = new Action(() => { ListAllChannels(); });
             m_groups["Channels"]["Create Default Simple Channel"] = new Action(() => {
                 CreateChannel(
+                    new AndroidNotificationChannelGroup()
+                    {
+                        Id = "Main",
+                        Name = "Main"
+                    },
                     new AndroidNotificationChannel()
                     {
                         Id = "default_channel",
                         Name = "Default Channel",
                         Importance = Importance.Default,
-                        Description = "Default Notifications"
+                        Description = "Default Notifications",
+                        Group = "Main",
                     }
                 );
             });
             m_groups["Channels"]["Create Secondary Simple Channel"] = new Action(() => {
                 CreateChannel(
+                    SecondaryGroup(),
                     new AndroidNotificationChannel()
                     {
                         Id = "secondary_channel",
                         Name = "Secondary Channel",
                         Importance = Importance.Low,
-                        Description = "Secondary Notifications"
+                        Description = "Secondary Notifications",
+                        Group = "SecondaryGroup",
                     }
                 );
             });
             m_groups["Channels"]["Create Fancy Channel"] = new Action(() => {
                 CreateChannel(
+                    SecondaryGroup(),
                     new AndroidNotificationChannel()
                     {
                         Id = "fancy_channel",
                         Name = "Fancy Channel",
                         Importance = Importance.High,
                         Description = "Fancy Notifications",
+                        Group = "SecondaryGroup",
                         CanBypassDnd = true,
                         CanShowBadge = true,
                         EnableLights = true,
@@ -286,6 +296,16 @@ namespace Unity.Notifications.Tests.Sample
             ButtonCheckStatusExplicitID.interactable = false;
 
             m_gameObjectReferences.ButtonGroupTemplate.gameObject.SetActive(false);
+        }
+
+        AndroidNotificationChannelGroup SecondaryGroup()
+        {
+            return new AndroidNotificationChannelGroup()
+            {
+                Id = "SecondaryGroup",
+                Name = "Different channels",
+                Description = "Group for other channels",
+            };
         }
 
         void RequestNotificationPermission()
@@ -403,11 +423,12 @@ namespace Unity.Notifications.Tests.Sample
             }
         }
 
-        public void CreateChannel(AndroidNotificationChannel channel)
+        public void CreateChannel(AndroidNotificationChannelGroup group, AndroidNotificationChannel channel)
         {
             m_LOGGER
                 .Blue($"[{DateTime.Now.ToString("HH:mm:ss.ffffff")}] Call {MethodBase.GetCurrentMethod().Name}")
                 .Properties(channel, 1);
+            AndroidNotificationCenter.RegisterNotificationChannelGroup(group);
             AndroidNotificationCenter.RegisterNotificationChannel(channel);
         }
 

--- a/TestProjects/Main/ProjectSettings/ProjectSettings.asset
+++ b/TestProjects/Main/ProjectSettings/ProjectSettings.asset
@@ -17,7 +17,7 @@ PlayerSettings:
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}
-  m_ShowUnitySplashScreen: 1
+  m_ShowUnitySplashScreen: 0
   m_ShowUnitySplashLogo: 1
   m_SplashScreenOverlayOpacity: 1
   m_SplashScreenAnimation: 1

--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Changes & Improvements:
+- [Android] - Added support for notification channel groups.
+
 ### Fixes:
 - [iOS] - Fix occasional crash when registering for push notifications.
 

--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 All notable changes to this package will be documented in this file.
 
-## [2.1.1] - 2023-01-04
+## [Unreleased]
 
 ### Changes & Improvements:
 - [Android] - Added support for notification channel groups.
+
+## [2.1.1] - 2023-01-04
 
 ### Fixes:
 - [Android] - No longer use DeniedAndDontAskAgain permission response, only Denied.

--- a/com.unity.mobile.notifications/Documentation~/Android.md
+++ b/com.unity.mobile.notifications/Documentation~/Android.md
@@ -4,13 +4,22 @@
 
 Starting in Android 8.0, all notifications must be assigned to a notification channel. The Unity Mobile Notifications package provides a set of APIs to manage notification channels. The example below shows how to create a notification channel.
 
+Notification channels can be grouped together. This is not required, but it may look better in the Settings UI.
+
 ```c#
+var group = new AndroidNotificationChannelGroup()
+{
+    Id = "Main",
+    Name = "Main notifications",
+};
+AndroidNotificationCenter.RegisterNotificationChannelGroup(group);
 var channel = new AndroidNotificationChannel()
 {
     Id = "channel_id",
     Name = "Default Channel",
     Importance = Importance.Default,
     Description = "Generic notifications",
+    Group = "Main",  // must be same as Id of previously registered group
 };
 AndroidNotificationCenter.RegisterNotificationChannel(channel);
 ```

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -170,6 +170,11 @@ namespace Unity.Notifications.Android
             return klass.CallStatic<string>(getNotificationChannelId, notification);
         }
 
+        public void RegisterNotificationChannelGroup(AndroidNotificationChannelGroup group)
+        {
+            self.Call("registerNotificationChannelGroup", group.Id, group.Name, group.Description);
+        }
+
         public void RegisterNotificationChannel(AndroidNotificationChannel channel)
         {
             self.Call("registerNotificationChannel",
@@ -189,6 +194,11 @@ namespace Unity.Notifications.Android
         public AndroidJavaObject[] GetNotificationChannels()
         {
             return self.Call<AndroidJavaObject[]>("getNotificationChannels");
+        }
+
+        public void DeleteNotificationChannelGroup(string id)
+        {
+            self.Call("deleteNotificationChannelGroup", id);
         }
 
         public void DeleteNotificationChannel(string channelId)
@@ -635,6 +645,32 @@ namespace Unity.Notifications.Android
 
                 return permissionStatus;
             }
+        }
+
+        /// <summary>
+        /// Register notification channel group.
+        /// </summary>
+        public static void RegisterNotificationChannelGroup(AndroidNotificationChannelGroup group)
+        {
+            if (!Initialize())
+                return;
+
+            if (string.IsNullOrEmpty(group.Id))
+                throw new Exception("Notification channel group ID is not specified.");
+            if (string.IsNullOrEmpty(group.Name))
+                throw new Exception("Notification channel group name is not specified.");
+
+            s_Jni.NotificationManager.RegisterNotificationChannelGroup(group);
+        }
+
+        /// <summary>
+        /// Delete notification channel group and all the channels in it.
+        /// </summary>
+        /// <param name="id">The ID of the group.</param>
+        public static void DeleteNotificationChannelGroup(string id)
+        {
+            if (Initialize())
+                s_Jni.NotificationManager.DeleteNotificationChannelGroup(id);
         }
 
         /// <summary>

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -187,7 +187,8 @@ namespace Unity.Notifications.Android
                 channel.CanBypassDnd,
                 channel.CanShowBadge,
                 channel.VibrationPattern,
-                (int)channel.LockScreenVisibility
+                (int)channel.LockScreenVisibility,
+                channel.Group
             );
         }
 
@@ -742,6 +743,7 @@ namespace Unity.Notifications.Android
                 ch.CanShowBadge = channel.Get<bool>("canShowBadge");
                 ch.VibrationPattern = channel.Get<long[]>("vibrationPattern");
                 ch.LockScreenVisibility = channel.Get<int>("lockscreenVisibility").ToLockScreenVisibility();
+                ch.Group = channel.Get<string>("group");
 
                 channels[i] = ch;
             }

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationChannel.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationChannel.cs
@@ -152,4 +152,26 @@ namespace Unity.Notifications.Android
             this.LockScreenVisibility = LockScreenVisibility.Public;
         }
     }
+
+    /// <summary>
+    /// Notification channel group description.
+    /// It is optional to put channels into groups, but looks nicer in Settings UI.
+    /// </summary>
+    public struct AndroidNotificationChannelGroup
+    {
+        /// <summary>
+        /// A unique ID for this group. Will rename the group if already exists.
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// A user visible name for this group.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// A description for this group.
+        /// </summary>
+        public string Description { get; set; }
+    }
 }

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationChannel.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationChannel.cs
@@ -76,6 +76,11 @@ namespace Unity.Notifications.Android
         public string Description { get; set; }
 
         /// <summary>
+        /// The ID of the registered channel group this channel belongs to.
+        /// </summary>
+        public string Group { get; set; }
+
+        /// <summary>
         /// Importance level which is applied to all notifications sent to the channel.
         /// This can be changed by users in the settings app. Android uses importance to determine how much the notification should interrupt the user (visually and audibly).
         /// The higher the importance of a notification, the more interruptive the notification will be.
@@ -141,6 +146,7 @@ namespace Unity.Notifications.Android
             Id = id;
             Name = name;
             Description = description;
+            Group = null;
             this.Importance = importance;
 
             CanBypassDnd = false;

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -177,7 +177,8 @@ public class UnityNotificationManager extends BroadcastReceiver {
             boolean canBypassDnd,
             boolean canShowBadge,
             long[] vibrationPattern,
-            int lockscreenVisibility) {
+            int lockscreenVisibility,
+            String group) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             NotificationChannel channel = new NotificationChannel(id, name, importance);
             channel.setDescription(description);
@@ -187,6 +188,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
             channel.setShowBadge(canShowBadge);
             channel.setVibrationPattern(vibrationPattern);
             channel.setLockscreenVisibility(lockscreenVisibility);
+            channel.setGroup(group);
 
             getNotificationManager().createNotificationChannel(channel);
         } else {
@@ -212,6 +214,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
             editor.putBoolean("canShowBadge", canShowBadge);
             editor.putString("vibrationPattern", Arrays.toString(vibrationPattern));
             editor.putInt("lockscreenVisibility", lockscreenVisibility);
+            editor.putString("group", group);
 
             editor.apply();
         }
@@ -242,6 +245,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         channel.canBypassDnd = prefs.getBoolean("canBypassDnd", false);
         channel.canShowBadge = prefs.getBoolean("canShowBadge", false);
         channel.lockscreenVisibility = prefs.getInt("lockscreenVisibility", VISIBILITY_PUBLIC);
+        channel.group = prefs.getString("group", null);
         String[] vibrationPatternStr = prefs.getString("vibrationPattern", "[]").split(",");
 
         long[] vibrationPattern = new long[vibrationPatternStr.length];
@@ -276,6 +280,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         wrapper.canShowBadge = channel.canShowBadge();
         wrapper.vibrationPattern = channel.getVibrationPattern();
         wrapper.lockscreenVisibility = channel.getLockscreenVisibility();
+        wrapper.group = channel.getGroup();
 
         return wrapper;
     }
@@ -948,6 +953,7 @@ class NotificationChannelWrapper {
     public boolean canShowBadge;
     public long[] vibrationPattern;
     public int lockscreenVisibility;
+    public String group;
 }
 
 // Implemented in C# to receive callback on notification show

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -6,6 +6,7 @@ import android.app.ActivityManager;
 import android.app.AlarmManager;
 import android.app.Notification;
 import android.app.NotificationChannel;
+import android.app.NotificationChannelGroup;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
@@ -145,6 +146,25 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
     public int getTargetSdk() {
         return mContext.getApplicationInfo().targetSdkVersion;
+    }
+
+    public void registerNotificationChannelGroup(String id, String name, String description) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannelGroup group = new NotificationChannelGroup(id, name);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                group.setDescription(description);
+            }
+
+            getNotificationManager().createNotificationChannelGroup(group);
+        }
+    }
+
+    public void deleteNotificationChannelGroup(String id) {
+        if (id == null)
+            return;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            getNotificationManager().deleteNotificationChannelGroup(id);
+        }
     }
 
     public void registerNotificationChannel(

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -164,6 +164,11 @@ public class UnityNotificationManager extends BroadcastReceiver {
             return;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             getNotificationManager().deleteNotificationChannelGroup(id);
+        } else {
+            for (NotificationChannelWrapper c : getNotificationChannels()) {
+                if (id.equals(c.group))
+                    deleteNotificationChannel(c.id);
+            }
         }
     }
 

--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSimpleTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSimpleTests.cs
@@ -54,6 +54,7 @@ class AndroidNotificationSimpleTests
         c.Name = "SerializeDeserializeNotification channel";
         c.Description = "SerializeDeserializeNotification channel";
         c.Importance = Importance.High;
+        c.Group = "Default";
         c.CanBypassDnd = true;
         c.CanShowBadge = true;
         c.EnableLights = true;

--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSimpleTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSimpleTests.cs
@@ -43,12 +43,46 @@ class AndroidNotificationSimpleTests
     [OneTimeSetUp]
     public void BeforeAllTests()
     {
+        var c = CreateNotificationChannelWithAllParameters();
+        AndroidNotificationCenter.RegisterNotificationChannel(c);
+    }
+
+    AndroidNotificationChannel CreateNotificationChannelWithAllParameters()
+    {
         var c = new AndroidNotificationChannel();
         c.Id = kChannelId;
         c.Name = "SerializeDeserializeNotification channel";
         c.Description = "SerializeDeserializeNotification channel";
         c.Importance = Importance.High;
-        AndroidNotificationCenter.RegisterNotificationChannel(c);
+        c.CanBypassDnd = true;
+        c.CanShowBadge = true;
+        c.EnableLights = true;
+        c.EnableVibration = true;
+        c.VibrationPattern = new long[] { 5, 10 };
+        c.LockScreenVisibility = LockScreenVisibility.Public;
+        return c;
+    }
+
+    [Test]
+    public void AllAndroidNotificationChannelParametersAreTested()
+    {
+        var channel = CreateNotificationChannelWithAllParameters();
+        AndroidNotificationChannel defVals = default;
+
+        foreach (var field in typeof(AndroidNotificationChannel).GetFields())
+        {
+            var v1 = field.GetValue(channel);
+            var v2 = field.GetValue(defVals);
+            if (object.Equals(v1, v2))
+                Assert.Fail("Unassigned field " + field.Name);
+        }
+        foreach (var prop in typeof(AndroidNotificationChannel).GetProperties())
+        {
+            var v1 = prop.GetValue(channel);
+            var v2 = prop.GetValue(defVals);
+            if (object.Equals(v1, v2))
+                Assert.Fail("Unassigned property " + prop.Name);
+        }
     }
 
     [Test]
@@ -77,9 +111,34 @@ class AndroidNotificationSimpleTests
     {
         var channel = AndroidNotificationCenter.GetNotificationChannel(kChannelId);
         Assert.IsNotNull(channel);
-        Assert.AreEqual("SerializeDeserializeNotification channel", channel.Name);
-        Assert.AreEqual("SerializeDeserializeNotification channel", channel.Description);
-        Assert.AreEqual(Importance.High, channel.Importance);
+
+        var expected = CreateNotificationChannelWithAllParameters();
+
+        foreach (var field in typeof(AndroidNotificationChannel).GetFields())
+        {
+            var v1 = field.GetValue(channel);
+            var v2 = field.GetValue(expected);
+            if (!object.Equals(v1, v2))
+                Assert.Fail($"Unexpected value for field {field.Name}; expected {v2}, was {v1}");
+        }
+        foreach (var prop in typeof(AndroidNotificationChannel).GetProperties())
+        {
+            if (prop.Name == "CanBypassDnd") // this one returns the actual value, not the requested one (may differ)
+                continue;
+            if (prop.Name == "VibrationPattern")
+            {
+                Assert.IsNotNull(channel.VibrationPattern);
+                Assert.AreEqual(expected.VibrationPattern.Length, channel.VibrationPattern.Length);
+                for (int i = 0; i < expected.VibrationPattern.Length; ++i)
+                    Assert.AreEqual(expected.VibrationPattern[i], channel.VibrationPattern[i]);
+                continue;
+            }
+
+            var v1 = prop.GetValue(channel);
+            var v2 = prop.GetValue(expected);
+            if (!object.Equals(v1, v2))
+                Assert.Fail($"Unexpected value for property {prop.Name}; expected {v2}, was {v1}");
+        }
     }
 
     [Test]

--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSimpleTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSimpleTests.cs
@@ -44,6 +44,12 @@ class AndroidNotificationSimpleTests
     public void BeforeAllTests()
     {
         var c = CreateNotificationChannelWithAllParameters();
+        var group = new AndroidNotificationChannelGroup()
+        {
+            Id = c.Group,
+            Name = "the group",
+        };
+        AndroidNotificationCenter.RegisterNotificationChannelGroup(group);
         AndroidNotificationCenter.RegisterNotificationChannel(c);
     }
 
@@ -170,6 +176,31 @@ class AndroidNotificationSimpleTests
             foreach (var channel in channels)
                 AndroidNotificationCenter.RegisterNotificationChannel(channel);
         }
+    }
+
+    [Test]
+    [UnityPlatform(RuntimePlatform.Android)]
+    public void DeleteNotificationChannelGroup_GroupIsDeleted()
+    {
+        var group = new AndroidNotificationChannelGroup()
+        {
+            Id = "TestDelete",
+            Name = "Group for deletion",
+        };
+        AndroidNotificationCenter.RegisterNotificationChannelGroup(group);
+        var channel = new AndroidNotificationChannel()
+        {
+            Id = "Temp",
+            Name = "Group testing",
+            Description = "Testing group",
+            Importance = Importance.Low,
+            Group = "TestDelete",
+        };
+        AndroidNotificationCenter.RegisterNotificationChannel(channel);
+
+        AndroidNotificationCenter.DeleteNotificationChannelGroup("TestDelete");
+        var ch = AndroidNotificationCenter.GetNotificationChannel("Temp");
+        Assert.IsNull(ch.Id);
     }
 
     [Test]


### PR DESCRIPTION
Android notification channels can be put into groups. This is optional and we did not support this previously. But on Android 13 in Settings all channels are put to the "Other" group which does not look nice in UI.

Changes made by this PR:
- Introduced new APIs for registering and deleting groups
- Channel receives Group property to assign it to the group
- On pre-Oreo devices group registration does nothing, while group deletion emulates the behavior by deleting all the emulated channels with this group.
- The test project now also assigns channels to groups.