### PR TITLE
Fix exception on missing UTC flag

### DIFF
--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to this package will be documented in this file.
 
 ### Fixes:
 - [Android] - No longer use DeniedAndDontAskAgain permission response, only Denied.
-- [iOS] - Fix occasional crash when registering for push notifications.
+- [iOS] - [issue 205](https://github.com/Unity-Technologies/com.unity.mobile.notifications/issues/205) Fix occasional crash when registering for push notifications.
+- [iOS] - [issue 242](https://github.com/Unity-Technologies/com.unity.mobile.notifications/issues/242) Fix exception when OriginalUtc key is missing in data (for example notification was scheduled using older package version).
 
 ## [2.1.0] - 2022-09-23
 

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
@@ -389,8 +389,19 @@ namespace Unity.Notifications.iOS
                                 UtcTime = true,
                                 Repeats = data.trigger.calendar.repeats != 0
                             };
-                            if (userInfo != null && userInfo["OriginalUtc"] == "0")
-                                trigger = trigger.ToLocal();
+                            if (userInfo != null)
+                            {
+                                string utc;
+                                if (userInfo.TryGetValue("OriginalUtc", out utc))
+                                {
+                                    if (utc == "0")
+                                        trigger = trigger.ToLocal();
+                                }
+                                else
+                                    trigger.UtcTime = false;
+                            }
+                            else
+                                trigger.UtcTime = false;
                             return trigger;
                         }
                     case iOSNotificationTriggerType.Location:

--- a/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
@@ -388,4 +388,26 @@ class iOSNotificationTests
         Assert.AreEqual(trigger2.Minute, retTrigger.Minute);
         Assert.AreEqual(trigger2.UtcTime, retTrigger.UtcTime);
     }
+
+    [Test]
+    public void iOSNotificationCalendarTrigger_HandlesMissingUtcField()
+    {
+        var original = new iOSNotificationCalendarTrigger()
+        {
+            Day = 5,
+        };
+
+        var notification = new iOSNotification()
+        {
+            Trigger = original,
+        };
+
+        // clear UserInfo, where UTC flag is stored
+        notification.UserInfo.Clear();
+
+        Assert.AreEqual(iOSNotificationTriggerType.Calendar, notification.Trigger.Type);
+        var result = (iOSNotificationCalendarTrigger)notification.Trigger;
+        Assert.AreEqual(5, result.Day);
+        Assert.IsFalse(result.UtcTime);
+    }
 }


### PR DESCRIPTION
https://github.com/Unity-Technologies/com.unity.mobile.notifications/issues/242

If user tampers with UserInfo dictionary or a notification is received that was sent not by Unity or scheduled by older version of this package, the "OriginalUtc" item can be missing. We shouldn't throw in such case.