### PR TITLE
Make logcat capture command always succeed

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -83,7 +83,7 @@ test_Android_{{ editor.version }}:
        utr.bat --testproject=TestProjects\Main --editor-location=.Editor --suite=playmode --platform=android --scripting-backend=il2cpp  --architecture=arm64--artifacts_path=upm-ci~/test-results/android --timeout=900 --player-load-path=build/players
   after:
     - start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-    - powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > upm-ci~/test-results/android/android_device_log.txt
+    - powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d; exit 0 > upm-ci~/test-results/android/android_device_log.txt
   artifacts:
     packages:
       paths:


### PR DESCRIPTION
In rare case test runs fail because command for capturing logcat fails or gets stuck for some reason. This is bad, because logcat is only captured to make it easier to debug things when something goes wrong, it is not essential. It is particularly bad when everything else is green, as in such case there is no use for logcat.
Modifying the command to always exit with success code, so that we don't have false-positives.