### PR TITLE
Expansion of Android permissions for notifications

### DIFF
--- a/TestProjects/Main/Assets/Scripts/AndroidTest.cs
+++ b/TestProjects/Main/Assets/Scripts/AndroidTest.cs
@@ -328,6 +328,10 @@ namespace Unity.Notifications.Tests.Sample
         {
             var isExact = AndroidNotificationCenter.UsingExactScheduling;
             m_LOGGER.Blue($"Scheduling at exact time: {isExact}");
+        }
+
+        void RequestExactScheduling()
+        {
             AndroidNotificationCenter.RequestExactScheduling();
         }
 

--- a/TestProjects/Main/Assets/Scripts/AndroidTest.cs
+++ b/TestProjects/Main/Assets/Scripts/AndroidTest.cs
@@ -177,6 +177,7 @@ namespace Unity.Notifications.Tests.Sample
             m_groups["General"]["Notification batch size: "+NotificationBatchSizes[_CurrentNotificationBatchSizeIndex]] = new Action(() => { ChangeNotificationBatchSize(NotificationBatchSizes); });
             m_groups["General"]["Reset notification counter"] = new Action(() => { NotificationCounter = 0; });
             m_groups["General"]["Request permission"] = new Action(() => { RequestNotificationPermission(); });
+            m_groups["General"]["Exact scheduling"] = new Action(() => { ExactScheduling(); });
 
             m_groups["Modify"] = new OrderedDictionary();
             //m_groups["Modify"]["Create notification preset"] = new Action(() => {  });
@@ -321,6 +322,13 @@ namespace Unity.Notifications.Tests.Sample
                     m_LOGGER.Red(request.Status.ToString());
                     break;
             }
+        }
+
+        void ExactScheduling()
+        {
+            var isExact = AndroidNotificationCenter.UsingExactScheduling;
+            m_LOGGER.Blue($"Scheduling at exact time: {isExact}");
+            AndroidNotificationCenter.RequestExactScheduling();
         }
 
 

--- a/TestProjects/Main/Assets/Scripts/AndroidTest.cs
+++ b/TestProjects/Main/Assets/Scripts/AndroidTest.cs
@@ -327,7 +327,9 @@ namespace Unity.Notifications.Tests.Sample
         void ExactScheduling()
         {
             var isExact = AndroidNotificationCenter.UsingExactScheduling;
+            var ignoringBattery = AndroidNotificationCenter.IgnoringBatteryOptimizations;
             m_LOGGER.Blue($"Scheduling at exact time: {isExact}");
+            m_LOGGER.Blue($"Ignoring battery optimizations: {ignoringBattery}");
         }
 
         void RequestExactScheduling()

--- a/TestProjects/Main/Assets/Scripts/AndroidTest.cs
+++ b/TestProjects/Main/Assets/Scripts/AndroidTest.cs
@@ -119,6 +119,7 @@ namespace Unity.Notifications.Tests.Sample
                     m_LOGGER.Green("Permission granted to post notifications");
                     break;
                 default:
+                    m_LOGGER.Blue("Should show reason for notifications: " + AndroidNotificationCenter.ShouldShowPermissionToPostRationale);
                     m_LOGGER.Red("No permission to post notifications: " + permission);
                     break;
             }

--- a/TestProjects/Main/Assets/Scripts/AndroidTest.cs
+++ b/TestProjects/Main/Assets/Scripts/AndroidTest.cs
@@ -178,6 +178,8 @@ namespace Unity.Notifications.Tests.Sample
             m_groups["General"]["Reset notification counter"] = new Action(() => { NotificationCounter = 0; });
             m_groups["General"]["Request permission"] = new Action(() => { RequestNotificationPermission(); });
             m_groups["General"]["Exact scheduling"] = new Action(() => { ExactScheduling(); });
+            m_groups["General"]["Request exact scheduling"] = new Action(() => { RequestExactScheduling(); });
+            m_groups["General"]["Ignore battery"] = new Action(() => { IgnoreBattery(); });
 
             m_groups["Modify"] = new OrderedDictionary();
             //m_groups["Modify"]["Create notification preset"] = new Action(() => {  });
@@ -335,6 +337,11 @@ namespace Unity.Notifications.Tests.Sample
         void RequestExactScheduling()
         {
             AndroidNotificationCenter.RequestExactScheduling();
+        }
+
+        void IgnoreBattery()
+        {
+            AndroidNotificationCenter.RequestIgnoreBatteryOptimizations();
         }
 
 

--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this package will be documented in this file.
 - [Android] - Added support for notification channel groups.
 - [Android] - Added support for BigPicture style.
 - [Android] - Icons now support local files and URIs.
+- [Android] - Added API to check if UI with permission rationale for notifications should be shown before requesting permission.
+- [Android] - Added APIs to request exact scheduling and bupasssing battery optimizations.
 - [iOS] - Added support for notification action icons (requires iOS 15).
 
 ## [2.1.1] - 2023-01-04

--- a/com.unity.mobile.notifications/Documentation~/Android.md
+++ b/com.unity.mobile.notifications/Documentation~/Android.md
@@ -36,9 +36,11 @@ On devices that use Android versions prior to 8.0, this package emulates the sam
 
 Before Android 6.0 notifications can be scheduled only at approximate time.
 
-Since Android 12.0 (API level 31) android.permission.SCHEDULE_EXACT_ALARM permission has to be added to the manifest to enable exact scheduling, see [documentation](https://developer.android.com/reference/android/Manifest.permission#SCHEDULE_EXACT_ALARM).
+Since Android 12.0 (API level 31) android.permission.SCHEDULE_EXACT_ALARM permission has to be added to the manifest to enable exact scheduling, see [documentation](https://developer.android.com/reference/android/Manifest.permission#SCHEDULE_EXACT_ALARM). Note, that adding this permission does not guarantee you'll be able to use exact scheduling. You can check it by calling AndroidNotificationCenter.UsingExactScheduling. You may need to request user permission to schedule at exact times by calling AndroidNotificationCenter.RequestExactScheduling().
 
 Since Android 13.0 (API level 33) the android.permission.USE_EXACT_ALARM is and alternative permission to enable exact scheduling.
+
+On devices with Android version less than 12 and battery saving on, exact scheduling may not work. It can be improved by requesting user to bypass battery saving via AndroidNotificationCenter.RequestIgnoreBatteryOptimizations() (query it via AndroidNotificationCenter.IgnoringBatteryOptimizations). To be able to request it, you need the [permission](https://developer.android.com/reference/android/Manifest.permission#REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).
 
 Android recommends to not use exact scheduling due to higher power consumption it entails. Use notification settings in Unity to enable the automatic addition of the mentioned permissions or to always use inexact scheduling.
 

--- a/com.unity.mobile.notifications/Editor/AndroidExactSchedulingOption.cs
+++ b/com.unity.mobile.notifications/Editor/AndroidExactSchedulingOption.cs
@@ -25,5 +25,7 @@ namespace Unity.Notifications
         /// Add USE_EXACT_ALARM permission to the manifest.
         /// </summary>
         AddUseExactAlarmPermission = 1 << 2,
+
+        AddRequestIgnoreBatteryOptimizationsPermission = 1 << 3,
     }
 }

--- a/com.unity.mobile.notifications/Editor/AndroidExactSchedulingOption.cs
+++ b/com.unity.mobile.notifications/Editor/AndroidExactSchedulingOption.cs
@@ -26,6 +26,10 @@ namespace Unity.Notifications
         /// </summary>
         AddUseExactAlarmPermission = 1 << 2,
 
+        /// <summary>
+        /// Add REQUEST_IGNORE_BATTERY_OPTIMIZATIONS permission to the manifest.
+        /// Required if you want to use <see cref="AndroidNotificationCenter.RequestIgnoreBatteryOptimizations()"/>.
+        /// </summary>
         AddRequestIgnoreBatteryOptimizationsPermission = 1 << 3,
     }
 }

--- a/com.unity.mobile.notifications/Editor/AndroidNotificationPostProcessor.cs
+++ b/com.unity.mobile.notifications/Editor/AndroidNotificationPostProcessor.cs
@@ -56,6 +56,14 @@ namespace Unity.Notifications
             }
         }
 
+        internal struct ManifestSettings
+        {
+            public bool UseCustomActivity;
+            public string CustomActivity;
+            public bool RescheduleOnRestart;
+            public AndroidExactSchedulingOption ExactAlarm;
+        }
+
         private void InjectAndroidManifest(string projectPath)
         {
             var manifestPath = string.Format("{0}/src/main/AndroidManifest.xml", projectPath);
@@ -65,19 +73,28 @@ namespace Unity.Notifications
             XmlDocument manifestDoc = new XmlDocument();
             manifestDoc.Load(manifestPath);
 
+            var settings = NotificationSettingsManager.Initialize().AndroidNotificationSettingsFlat;
+            var manifestSettings = new ManifestSettings()
+            {
+                UseCustomActivity = GetSetting<bool>(settings, NotificationSettings.AndroidSettings.USE_CUSTOM_ACTIVITY),
+                CustomActivity = GetSetting<string>(settings, NotificationSettings.AndroidSettings.CUSTOM_ACTIVITY_CLASS),
+                RescheduleOnRestart = GetSetting<bool>(settings, NotificationSettings.AndroidSettings.RESCHEDULE_ON_RESTART),
+                ExactAlarm = GetSetting<AndroidExactSchedulingOption>(settings, NotificationSettings.AndroidSettings.EXACT_ALARM),
+            };
+
+            InjectAndroidManifest(manifestPath, manifestDoc, manifestSettings);
+
+            manifestDoc.Save(manifestPath);
+        }
+
+        internal static void InjectAndroidManifest(string manifestPath, XmlDocument manifestDoc, ManifestSettings settings)
+        {
             InjectReceivers(manifestPath, manifestDoc);
 
-            var settings = NotificationSettingsManager.Initialize().AndroidNotificationSettingsFlat;
+            if (settings.UseCustomActivity)
+                AppendAndroidMetadataField(manifestPath, manifestDoc, "custom_notification_android_activity", settings.CustomActivity);
 
-            var useCustomActivity = GetSetting<bool>(settings, NotificationSettings.AndroidSettings.USE_CUSTOM_ACTIVITY);
-            if (useCustomActivity)
-            {
-                var customActivity = GetSetting<string>(settings, NotificationSettings.AndroidSettings.CUSTOM_ACTIVITY_CLASS);
-                AppendAndroidMetadataField(manifestPath, manifestDoc, "custom_notification_android_activity", customActivity);
-            }
-
-            var enableRescheduleOnRestart = GetSetting<bool>(settings, NotificationSettings.AndroidSettings.RESCHEDULE_ON_RESTART);
-            if (enableRescheduleOnRestart)
+            if (settings.RescheduleOnRestart)
             {
                 AppendAndroidMetadataField(manifestPath, manifestDoc, "reschedule_notifications_on_restart", "true");
                 AppendAndroidPermissionField(manifestPath, manifestDoc, "android.permission.RECEIVE_BOOT_COMPLETED");
@@ -85,13 +102,12 @@ namespace Unity.Notifications
 
             AppendAndroidPermissionField(manifestPath, manifestDoc, "android.permission.POST_NOTIFICATIONS");
 
-            var exactScheduling = GetSetting<AndroidExactSchedulingOption>(settings, NotificationSettings.AndroidSettings.EXACT_ALARM);
-            bool enableExact = (exactScheduling & AndroidExactSchedulingOption.ExactWhenAvailable) != 0;
+            bool enableExact = (settings.ExactAlarm & AndroidExactSchedulingOption.ExactWhenAvailable) != 0;
             AppendAndroidMetadataField(manifestPath, manifestDoc, "com.unity.androidnotifications.exact_scheduling", enableExact ? "1" : "0");
             if (enableExact)
             {
-                bool scheduleExact = (exactScheduling & AndroidExactSchedulingOption.AddScheduleExactPermission) != 0;
-                bool useExact = (exactScheduling & AndroidExactSchedulingOption.AddUseExactAlarmPermission) != 0;
+                bool scheduleExact = (settings.ExactAlarm & AndroidExactSchedulingOption.AddScheduleExactPermission) != 0;
+                bool useExact = (settings.ExactAlarm & AndroidExactSchedulingOption.AddUseExactAlarmPermission) != 0;
                 // as documented here: https://developer.android.com/reference/android/Manifest.permission#USE_EXACT_ALARM
                 // only one of these two attributes should be used or max sdk set so on any device it's one or the other
                 if (scheduleExact)
@@ -99,8 +115,6 @@ namespace Unity.Notifications
                 if (useExact)
                     AppendAndroidPermissionField(manifestPath, manifestDoc, "android.permission.USE_EXACT_ALARM");
             }
-
-            manifestDoc.Save(manifestPath);
         }
 
         private static T GetSetting<T>(List<NotificationSetting> settings, string key)

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -710,6 +710,11 @@ namespace Unity.Notifications.Android
             }
         }
 
+        /// <summary>
+        /// Whether notifications are scheduled at exact times.
+        /// Combines notification settings and actual device settings (since Android 12 exact scheduling is user controllable).
+        /// </summary>
+        /// <seealso cref="AndroidExactSchedulingOption"/>
         public static bool UsingExactScheduling
         {
             get
@@ -720,6 +725,13 @@ namespace Unity.Notifications.Android
             }
         }
 
+        /// <summary>
+        /// Request user permission to schedule alarms at exact times.
+        /// Only works on Android 12 and later, older versions can schedule at exact times without requesting it.
+        /// This may cause your app to use more battery.
+        /// App must have SCHEDULE_EXACT_ALARM permission to be able to request this.
+        /// </summary>
+        /// <seealso cref="AndroidExactSchedulingOption"/>
         public static void RequestExactScheduling()
         {
             if (!Initialize())
@@ -739,6 +751,11 @@ namespace Unity.Notifications.Android
                         s_CurrentActivity.Call("startActivity", intent);
         }
 
+        /// <summary>
+        /// Whether app is ignoring device battery optimization settings.
+        /// When device is in power saving or similar restricted mode, scheduled notifications may not appear or be late.
+        /// </summary>
+        /// <seealso cref="RequestIgnoreBatteryOptimizations()"/>
         public static bool IgnoringBatteryOptimizations
         {
             get
@@ -752,6 +769,12 @@ namespace Unity.Notifications.Android
             }
         }
 
+        /// <summary>
+        /// Request user to allow unrestricted background work for app.
+        /// UI for it is provided by OS and is manufacturer specific. Recommended to explain user what to do before requesting.
+        /// App must have REQUEST_IGNORE_BATTERY_OPTIMIZATIONS permission to be able to request this.
+        /// </summary>
+        /// <seealso cref="AndroidExactSchedulingOption"/>
         public static void RequestIgnoreBatteryOptimizations()
         {
             if (!Initialize())

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -739,6 +739,29 @@ namespace Unity.Notifications.Android
                         s_CurrentActivity.Call("startActivity", intent);
         }
 
+        public static bool IgnoringBatteryOptimizations
+        {
+            get
+            {
+                if (!Initialize())
+                    return false;
+                if (s_DeviceApiLevel < 23)
+                    return false;
+                using (var pm = s_CurrentActivity.Call<AndroidJavaObject>("getSystemService", "power"))
+                    return pm.Call<bool>("isIgnoringBatteryOptimizations", s_CurrentActivity.Call<string>("getPackageName"));
+            }
+        }
+
+        public static void RequestIgnoreBatteryOptimizations()
+        {
+            if (!Initialize())
+                return;
+            if (s_DeviceApiLevel < 23)
+                return;
+
+            StartActionForThisPackage("android.settings.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS");
+        }
+
         /// <summary>
         /// Register notification channel group.
         /// </summary>

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -727,10 +727,15 @@ namespace Unity.Notifications.Android
             if (s_DeviceApiLevel < 31)
                 return;
 
+            StartActionForThisPackage("android.settings.REQUEST_SCHEDULE_EXACT_ALARM");
+        }
+
+        private static void StartActionForThisPackage(string action)
+        {
             var packageName = s_CurrentActivity.Call<string>("getPackageName");
             using (var uriClass = new AndroidJavaClass("android.net.Uri"))
                 using (var uri = uriClass.CallStatic<AndroidJavaObject>("parse", $"package:{packageName}"))
-                    using (var intent = new AndroidJavaObject("android.content.Intent", "android.settings.REQUEST_SCHEDULE_EXACT_ALARM", uri))
+                    using (var intent = new AndroidJavaObject("android.content.Intent", action, uri))
                         s_CurrentActivity.Call("startActivity", intent);
         }
 

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -694,6 +694,17 @@ namespace Unity.Notifications.Android
             }
         }
 
+        internal static bool CanRequestPermissionToPost
+        {
+            get
+            {
+                if (!Initialize())
+                    return false;
+                // on lower target SDK OS asks permission automatically, can't ask manually
+                return s_TargetApiLevel >= API_POST_NOTIFICATIONS_PERMISSION_REQUIRED;
+            }
+        }
+
         /// <summary>
         /// Register notification channel group.
         /// </summary>

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -746,9 +746,9 @@ namespace Unity.Notifications.Android
         {
             var packageName = s_CurrentActivity.Call<string>("getPackageName");
             using (var uriClass = new AndroidJavaClass("android.net.Uri"))
-                using (var uri = uriClass.CallStatic<AndroidJavaObject>("parse", $"package:{packageName}"))
-                    using (var intent = new AndroidJavaObject("android.content.Intent", action, uri))
-                        s_CurrentActivity.Call("startActivity", intent);
+            using (var uri = uriClass.CallStatic<AndroidJavaObject>("parse", $"package:{packageName}"))
+            using (var intent = new AndroidJavaObject("android.content.Intent", action, uri))
+                s_CurrentActivity.Call("startActivity", intent);
         }
 
         /// <summary>

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -711,6 +711,30 @@ namespace Unity.Notifications.Android
         }
 
         /// <summary>
+        /// Returns true if app should show UI explaining why it need permission to post notifications.
+        /// The UI should be shown before requesting the permission.
+        /// </summary>
+        public static bool ShouldShowPermissionToPostRationale
+        {
+            get
+            {
+                if (!Initialize())
+                    return false;
+
+                if (CanRequestPermissionToPost)
+                {
+#if UNITY_2023_1_OR_NEWER
+                    return Permission.ShouldShowRequestPermissionRationale(PERMISSION_POST_NOTIFICATIONS);
+#else
+                    return s_CurrentActivity.Call<bool>("shouldShowRequestPermissionRationale", PERMISSION_POST_NOTIFICATIONS);
+#endif
+                }
+
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Whether notifications are scheduled at exact times.
         /// Combines notification settings and actual device settings (since Android 12 exact scheduling is user controllable).
         /// </summary>

--- a/com.unity.mobile.notifications/Runtime/Android/NotificationPermission.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/NotificationPermission.cs
@@ -61,18 +61,20 @@ namespace Unity.Notifications.Android
                 case PermissionStatus.NotRequested:
                 case PermissionStatus.Denied:
                 case PermissionStatus.DeniedDontAskAgain:  // this one is no longer used, but might be found in settings
-                    Status = PermissionStatus.RequestPending;
-                    RequestPermission();
+                    Status = RequestPermission();
                     break;
             }
         }
 
-        void RequestPermission()
+        PermissionStatus RequestPermission()
         {
+            if (!AndroidNotificationCenter.CanRequestPermissionToPost)
+                return PermissionStatus.Denied;
             var callbacks = new PermissionCallbacks();
             callbacks.PermissionGranted += (unused) => PermissionResponse(PermissionStatus.Allowed);
             callbacks.PermissionDenied += (unused) => PermissionResponse(PermissionStatus.Denied);
             Permission.RequestUserPermission(AndroidNotificationCenter.PERMISSION_POST_NOTIFICATIONS, callbacks);
+            return PermissionStatus.RequestPending;
         }
 
         void PermissionResponse(PermissionStatus status)

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -592,6 +592,11 @@ public class UnityNotificationManager extends BroadcastReceiver {
         }
     }
 
+    public boolean canScheduleExactAlarms() {
+        AlarmManager alarmManager = (AlarmManager) mContext.getSystemService(Context.ALARM_SERVICE);
+        return canScheduleExactAlarms(alarmManager);
+    }
+
     // Call AlarmManager to set the broadcast intent with fire time and interval.
     private void scheduleNotificationIntentAlarm(long repeatInterval, long fireTime, PendingIntent broadcast) {
         AlarmManager alarmManager = (AlarmManager) mContext.getSystemService(Context.ALARM_SERVICE);

--- a/com.unity.mobile.notifications/Tests/Editor/PostprocessorTests.cs
+++ b/com.unity.mobile.notifications/Tests/Editor/PostprocessorTests.cs
@@ -35,23 +35,23 @@ namespace Unity.Notifications.Tests
   <uses-feature android:name=""android.hardware.touchscreen.multitouch"" android:required=""false"" />
   <uses-feature android:name=""android.hardware.touchscreen.multitouch.distinct"" android:required=""false"" />
 </manifest>";
-      const string kRescheduleOnRestartFalse = "<meta-data android:name=\"reschedule_notifications_on_restart\" android:value=\"false\" />";
-      const string kRescheduleOnRestartTrue = "<meta-data android:name=\"reschedule_notifications_on_restart\" android:value=\"true\" />";
-      const string kExactSchedulingOn = "<meta-data android:name=\"com.unity.androidnotifications.exact_scheduling\" android:value=\"1\" />";
-      const string kExactSchedulingOff = "<meta-data android:name=\"com.unity.androidnotifications.exact_scheduling\" android:value=\"0\" />";
-      const string kReceiveBookCompletedPermission = "<uses-permission android:name=\"android.permission.RECEIVE_BOOT_COMPLETED\" />";
-      const string kScheduleExactAlarmPermission = "<uses-permission android:name=\"android.permission.SCHEDULE_EXACT_ALARM\" />";
-      const string kUseExactAlarmPermission = "<uses-permission android:name=\"android.permission.USE_EXACT_ALARM\" />";
-      const string kRequestIgnoreBatteryOptimizationsPermission = "<uses-permission-sdk-23 android:name=\"android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS\" />";
+        const string kRescheduleOnRestartFalse = "<meta-data android:name=\"reschedule_notifications_on_restart\" android:value=\"false\" />";
+        const string kRescheduleOnRestartTrue = "<meta-data android:name=\"reschedule_notifications_on_restart\" android:value=\"true\" />";
+        const string kExactSchedulingOn = "<meta-data android:name=\"com.unity.androidnotifications.exact_scheduling\" android:value=\"1\" />";
+        const string kExactSchedulingOff = "<meta-data android:name=\"com.unity.androidnotifications.exact_scheduling\" android:value=\"0\" />";
+        const string kReceiveBookCompletedPermission = "<uses-permission android:name=\"android.permission.RECEIVE_BOOT_COMPLETED\" />";
+        const string kScheduleExactAlarmPermission = "<uses-permission android:name=\"android.permission.SCHEDULE_EXACT_ALARM\" />";
+        const string kUseExactAlarmPermission = "<uses-permission android:name=\"android.permission.USE_EXACT_ALARM\" />";
+        const string kRequestIgnoreBatteryOptimizationsPermission = "<uses-permission-sdk-23 android:name=\"android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS\" />";
 
-      string GetSourceXml(string metaDataExtra, string permissionExtra)
-      {
-          if (metaDataExtra == null)
-              metaDataExtra = "";
-          if (permissionExtra == null)
-              permissionExtra = "";
-          return string.Format(kManifestTemplate, metaDataExtra, permissionExtra);
-      }
+        string GetSourceXml(string metaDataExtra, string permissionExtra)
+        {
+            if (metaDataExtra == null)
+                metaDataExtra = "";
+            if (permissionExtra == null)
+                permissionExtra = "";
+            return string.Format(kManifestTemplate, metaDataExtra, permissionExtra);
+        }
 
 #if UNITY_ANDROID
         [Test]

--- a/com.unity.mobile.notifications/Tests/Editor/PostprocessorTests.cs
+++ b/com.unity.mobile.notifications/Tests/Editor/PostprocessorTests.cs
@@ -42,6 +42,7 @@ namespace Unity.Notifications.Tests
       const string kReceiveBookCompletedPermission = "<uses-permission android:name=\"android.permission.RECEIVE_BOOT_COMPLETED\" />";
       const string kScheduleExactAlarmPermission = "<uses-permission android:name=\"android.permission.SCHEDULE_EXACT_ALARM\" />";
       const string kUseExactAlarmPermission = "<uses-permission android:name=\"android.permission.USE_EXACT_ALARM\" />";
+      const string kRequestIgnoreBatteryOptimizationsPermission = "<uses-permission-sdk-23 android:name=\"android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS\" />";
 
       string GetSourceXml(string metaDataExtra, string permissionExtra)
       {
@@ -145,6 +146,13 @@ namespace Unity.Notifications.Tests
             InjectAndroidManifest_AddsPermissionWhenEnabled(AndroidExactSchedulingOption.AddUseExactAlarmPermission, kUseExactAlarmPermission);
         }
 
+        [Test]
+        public void InjectAndroidManifest_AddsBatteryOptimizationsWhenEnabled()
+        {
+            InjectAndroidManifest_AddsPermissionWhenEnabled(AndroidExactSchedulingOption.AddRequestIgnoreBatteryOptimizationsPermission, kRequestIgnoreBatteryOptimizationsPermission);
+            //InjectAndroidManifest_AddsPermissionWhenEnabled(AndroidExactSchedulingOption.AddRequestIgnoreBatteryOptimizationsPermission, "android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS");
+        }
+
         public void InjectAndroidManifest_AddsPermissionWhenEnabled(AndroidExactSchedulingOption flag, string permission)
         {
             string sourceXmlContent = GetSourceXml(null, null);
@@ -171,6 +179,12 @@ namespace Unity.Notifications.Tests
         public void InjectAndroidManifest_DoesNotAddUseExactWhenExactNotEnabled()
         {
             InjectAndroidManifest_DoesNotAddPermissionWhenExactNotEnabled("android.permission.USE_EXACT_ALARM");
+        }
+
+        [Test]
+        public void InjectAndroidManifest_DoesNotAddBatteryOptimizationsWhenExactNotEnabled()
+        {
+            InjectAndroidManifest_DoesNotAddPermissionWhenExactNotEnabled("android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS");
         }
 
         public void InjectAndroidManifest_DoesNotAddPermissionWhenExactNotEnabled(string permission)

--- a/com.unity.mobile.notifications/Tests/Editor/PostprocessorTests.cs
+++ b/com.unity.mobile.notifications/Tests/Editor/PostprocessorTests.cs
@@ -41,6 +41,7 @@ namespace Unity.Notifications.Tests
       const string kExactSchedulingOff = "<meta-data android:name=\"com.unity.androidnotifications.exact_scheduling\" android:value=\"0\" />";
       const string kReceiveBookCompletedPermission = "<uses-permission android:name=\"android.permission.RECEIVE_BOOT_COMPLETED\" />";
       const string kScheduleExactAlarmPermission = "<uses-permission android:name=\"android.permission.SCHEDULE_EXACT_ALARM\" />";
+      const string kUseExactAlarmPermission = "<uses-permission android:name=\"android.permission.USE_EXACT_ALARM\" />";
 
       string GetSourceXml(string metaDataExtra, string permissionExtra)
       {
@@ -135,22 +136,44 @@ namespace Unity.Notifications.Tests
         [Test]
         public void InjectAndroidManifest_AddsScheduleExactWhenEnabled()
         {
+            InjectAndroidManifest_AddsPermissionWhenEnabled(AndroidExactSchedulingOption.AddScheduleExactPermission, kScheduleExactAlarmPermission);
+        }
+
+        [Test]
+        public void InjectAndroidManifest_AddsUseExactWhenEnabled()
+        {
+            InjectAndroidManifest_AddsPermissionWhenEnabled(AndroidExactSchedulingOption.AddUseExactAlarmPermission, kUseExactAlarmPermission);
+        }
+
+        public void InjectAndroidManifest_AddsPermissionWhenEnabled(AndroidExactSchedulingOption flag, string permission)
+        {
             string sourceXmlContent = GetSourceXml(null, null);
             XmlDocument xmlDoc = new XmlDocument();
             xmlDoc.LoadXml(sourceXmlContent);
             var settings = new AndroidNotificationPostProcessor.ManifestSettings()
             {
-                ExactAlarm = AndroidExactSchedulingOption.ExactWhenAvailable | AndroidExactSchedulingOption.AddScheduleExactPermission,
+                ExactAlarm = AndroidExactSchedulingOption.ExactWhenAvailable | flag,
             };
 
             AndroidNotificationPostProcessor.InjectAndroidManifest("test", xmlDoc, settings);
 
             Assert.IsTrue(xmlDoc.InnerXml.Contains(kExactSchedulingOn));
-            Assert.IsTrue(xmlDoc.InnerXml.Contains(kScheduleExactAlarmPermission));
+            Assert.IsTrue(xmlDoc.InnerXml.Contains(permission));
         }
 
         [Test]
         public void InjectAndroidManifest_DoesNotAddScheduleExactWhenExactNotEnabled()
+        {
+            InjectAndroidManifest_DoesNotAddPermissionWhenExactNotEnabled("android.permission.SCHEDULE_EXACT_ALARM");
+        }
+
+        [Test]
+        public void InjectAndroidManifest_DoesNotAddUseExactWhenExactNotEnabled()
+        {
+            InjectAndroidManifest_DoesNotAddPermissionWhenExactNotEnabled("android.permission.USE_EXACT_ALARM");
+        }
+
+        public void InjectAndroidManifest_DoesNotAddPermissionWhenExactNotEnabled(string permission)
         {
             string sourceXmlContent = GetSourceXml(null, null);
             XmlDocument xmlDoc = new XmlDocument();
@@ -164,7 +187,7 @@ namespace Unity.Notifications.Tests
             AndroidNotificationPostProcessor.InjectAndroidManifest("test", xmlDoc, settings);
 
             Assert.IsTrue(xmlDoc.InnerXml.Contains(kExactSchedulingOff));
-            Assert.IsFalse(xmlDoc.InnerXml.Contains("android.permission.SCHEDULE_EXACT_ALARM"));
+            Assert.IsFalse(xmlDoc.InnerXml.Contains(permission));
         }
 
 #endif

--- a/com.unity.mobile.notifications/Tests/Editor/PostprocessorTests.cs
+++ b/com.unity.mobile.notifications/Tests/Editor/PostprocessorTests.cs
@@ -11,410 +11,122 @@ namespace Unity.Notifications.Tests
             Assert.AreEqual(true, true);
         }
 
+        const string kManifestTemplate = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<manifest xmlns:android=""http://schemas.android.com/apk/res/android"" package=""com.UnityTestRunner.UnityTestRunner"" xmlns:tools=""http://schemas.android.com/tools"" android:installLocation=""preferExternal"">
+  <supports-screens android:smallScreens=""true"" android:normalScreens=""true"" android:largeScreens=""true"" android:xlargeScreens=""true"" android:anyDensity=""true"" />
+  <application android:theme=""@style/UnityThemeSelector"" android:icon=""@mipmap/app_icon"" android:label=""@string/app_name"" android:isGame=""true"" android:banner=""@drawable/app_banner"">
+    <activity android:label=""@string/app_name"" android:screenOrientation=""fullSensor"" android:launchMode=""singleTask"" android:configChanges=""mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale|layoutDirection|density"" android:hardwareAccelerated=""false"" android:name=""com.UnityTestRunner.UnityTestRunner.UnityPlayerActivity"">
+      <intent-filter>
+        <action android:name=""android.intent.action.MAIN"" />
+        <category android:name=""android.intent.category.LAUNCHER"" />
+        <category android:name=""android.intent.category.LEANBACK_LAUNCHER"" />
+      </intent-filter>
+      <meta-data android:name=""unityplayer.UnityActivity"" android:value=""true"" />
+    </activity>
+    <meta-data android:name=""unity.build-id"" android:value=""8a616d3b-0433-49d8-bbaf-fd1415e8701e"" />
+    <meta-data android:name=""unity.splash-mode"" android:value=""0"" />
+    <meta-data android:name=""unity.splash-enable"" android:value=""True"" />{0}
+  </application>
+  <uses-feature android:glEsVersion=""0x00020000"" />
+  <uses-permission android:name=""android.permission.INTERNET"" />
+  <uses-permission android:name=""android.permission.WRITE_EXTERNAL_STORAGE"" android:maxSdkVersion=""18"" />
+  <uses-permission android:name=""android.permission.READ_EXTERNAL_STORAGE"" android:maxSdkVersion=""18"" />{1}
+  <uses-feature android:name=""android.hardware.touchscreen"" android:required=""false"" />
+  <uses-feature android:name=""android.hardware.touchscreen.multitouch"" android:required=""false"" />
+  <uses-feature android:name=""android.hardware.touchscreen.multitouch.distinct"" android:required=""false"" />
+</manifest>";
+      const string kRescheduleOnRestartFalse = "<meta-data android:name=\"reschedule_notifications_on_restart\" android:value=\"false\" />";
+      const string kRescheduleOnRestartTrue = "<meta-data android:name=\"reschedule_notifications_on_restart\" android:value=\"true\" />";
+      const string kReceiveBookCompletedPermission = "<uses-permission android:name=\"android.permission.RECEIVE_BOOT_COMPLETED\" />";
+
+      string GetSourceXml(string metaDataExtra, string permissionExtra)
+      {
+          if (metaDataExtra == null)
+              metaDataExtra = "";
+          if (permissionExtra == null)
+              permissionExtra = "";
+          return string.Format(kManifestTemplate, metaDataExtra, permissionExtra);
+      }
+
 #if UNITY_ANDROID
         [Test]
         public void AppendMetadataToManifest_WhenSameValue_Works()
         {
-            string sourceXmlContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
-<manifest xmlns:android=""http://schemas.android.com/apk/res/android"" package=""com.UnityTestRunner.UnityTestRunner"" xmlns:tools=""http://schemas.android.com/tools"" android:installLocation=""preferExternal"">
-  <supports-screens android:smallScreens=""true"" android:normalScreens=""true"" android:largeScreens=""true"" android:xlargeScreens=""true"" android:anyDensity=""true"" />
-  <application android:theme=""@style/UnityThemeSelector"" android:icon=""@mipmap/app_icon"" android:label=""@string/app_name"" android:isGame=""true"" android:banner=""@drawable/app_banner"">
-    <activity android:label=""@string/app_name"" android:screenOrientation=""fullSensor"" android:launchMode=""singleTask"" android:configChanges=""mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale|layoutDirection|density"" android:hardwareAccelerated=""false"" android:name=""com.UnityTestRunner.UnityTestRunner.UnityPlayerActivity"">
-      <intent-filter>
-        <action android:name=""android.intent.action.MAIN"" />
-        <category android:name=""android.intent.category.LAUNCHER"" />
-        <category android:name=""android.intent.category.LEANBACK_LAUNCHER"" />
-      </intent-filter>
-      <meta-data android:name=""unityplayer.UnityActivity"" android:value=""true"" />
-    </activity>
-    <meta-data android:name=""unity.build-id"" android:value=""8a616d3b-0433-49d8-bbaf-fd1415e8701e"" />
-    <meta-data android:name=""unity.splash-mode"" android:value=""0"" />
-    <meta-data android:name=""unity.splash-enable"" android:value=""True"" />
-    <meta-data android:name=""reschedule_notifications_on_restart"" android:value=""true""/>
-  </application>
-  <uses-feature android:glEsVersion=""0x00020000"" />
-  <uses-permission android:name=""android.permission.INTERNET"" />
-  <uses-permission android:name=""android.permission.WRITE_EXTERNAL_STORAGE"" android:maxSdkVersion=""18"" />
-  <uses-permission android:name=""android.permission.READ_EXTERNAL_STORAGE"" android:maxSdkVersion=""18"" />
-  <uses-feature android:name=""android.hardware.touchscreen"" android:required=""false"" />
-  <uses-feature android:name=""android.hardware.touchscreen.multitouch"" android:required=""false"" />
-  <uses-feature android:name=""android.hardware.touchscreen.multitouch.distinct"" android:required=""false"" />
-</manifest>";
-
-            string targetXmlContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
-<manifest xmlns:android=""http://schemas.android.com/apk/res/android"" package=""com.UnityTestRunner.UnityTestRunner"" xmlns:tools=""http://schemas.android.com/tools"" android:installLocation=""preferExternal"">
-  <supports-screens android:smallScreens=""true"" android:normalScreens=""true"" android:largeScreens=""true"" android:xlargeScreens=""true"" android:anyDensity=""true"" />
-  <application android:theme=""@style/UnityThemeSelector"" android:icon=""@mipmap/app_icon"" android:label=""@string/app_name"" android:isGame=""true"" android:banner=""@drawable/app_banner"">
-    <activity android:label=""@string/app_name"" android:screenOrientation=""fullSensor"" android:launchMode=""singleTask"" android:configChanges=""mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale|layoutDirection|density"" android:hardwareAccelerated=""false"" android:name=""com.UnityTestRunner.UnityTestRunner.UnityPlayerActivity"">
-      <intent-filter>
-        <action android:name=""android.intent.action.MAIN"" />
-        <category android:name=""android.intent.category.LAUNCHER"" />
-        <category android:name=""android.intent.category.LEANBACK_LAUNCHER"" />
-      </intent-filter>
-      <meta-data android:name=""unityplayer.UnityActivity"" android:value=""true"" />
-    </activity>
-    <meta-data android:name=""unity.build-id"" android:value=""8a616d3b-0433-49d8-bbaf-fd1415e8701e"" />
-    <meta-data android:name=""unity.splash-mode"" android:value=""0"" />
-    <meta-data android:name=""unity.splash-enable"" android:value=""True"" />
-    <meta-data android:name=""reschedule_notifications_on_restart"" android:value=""true""/>
-  </application>
-  <uses-feature android:glEsVersion=""0x00020000"" />
-  <uses-permission android:name=""android.permission.INTERNET"" />
-  <uses-permission android:name=""android.permission.WRITE_EXTERNAL_STORAGE"" android:maxSdkVersion=""18"" />
-  <uses-permission android:name=""android.permission.READ_EXTERNAL_STORAGE"" android:maxSdkVersion=""18"" />
-  <uses-feature android:name=""android.hardware.touchscreen"" android:required=""false"" />
-  <uses-feature android:name=""android.hardware.touchscreen.multitouch"" android:required=""false"" />
-  <uses-feature android:name=""android.hardware.touchscreen.multitouch.distinct"" android:required=""false"" />
-</manifest>";
-
+            string sourceXmlContent = GetSourceXml(kRescheduleOnRestartTrue, null);
             XmlDocument xmlDoc = new XmlDocument();
             xmlDoc.LoadXml(sourceXmlContent);
 
 
             AndroidNotificationPostProcessor.AppendAndroidMetadataField(null, xmlDoc, "reschedule_notifications_on_restart", "true");
 
-            XmlDocument targetXmlDoc = new XmlDocument();
-            targetXmlDoc.LoadXml(targetXmlContent);
-
-            Assert.AreEqual(targetXmlDoc.InnerXml, xmlDoc.InnerXml);
+            Assert.IsTrue(xmlDoc.InnerXml.Contains(kRescheduleOnRestartTrue));
         }
 
         [Test]
         public void AppendMetadataToManifest_WhenOtherValue_Works()
         {
-            string sourceXmlContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
-<manifest xmlns:android=""http://schemas.android.com/apk/res/android"" package=""com.UnityTestRunner.UnityTestRunner"" xmlns:tools=""http://schemas.android.com/tools"" android:installLocation=""preferExternal"">
-  <supports-screens android:smallScreens=""true"" android:normalScreens=""true"" android:largeScreens=""true"" android:xlargeScreens=""true"" android:anyDensity=""true"" />
-  <application android:theme=""@style/UnityThemeSelector"" android:icon=""@mipmap/app_icon"" android:label=""@string/app_name"" android:isGame=""true"" android:banner=""@drawable/app_banner"">
-    <activity android:label=""@string/app_name"" android:screenOrientation=""fullSensor"" android:launchMode=""singleTask"" android:configChanges=""mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale|layoutDirection|density"" android:hardwareAccelerated=""false"" android:name=""com.UnityTestRunner.UnityTestRunner.UnityPlayerActivity"">
-      <intent-filter>
-        <action android:name=""android.intent.action.MAIN"" />
-        <category android:name=""android.intent.category.LAUNCHER"" />
-        <category android:name=""android.intent.category.LEANBACK_LAUNCHER"" />
-      </intent-filter>
-      <meta-data android:name=""unityplayer.UnityActivity"" android:value=""true"" />
-    </activity>
-    <meta-data android:name=""unity.build-id"" android:value=""8a616d3b-0433-49d8-bbaf-fd1415e8701e"" />
-    <meta-data android:name=""unity.splash-mode"" android:value=""0"" />
-    <meta-data android:name=""unity.splash-enable"" android:value=""True"" />
-    <meta-data android:name=""reschedule_notifications_on_restart"" android:value=""false""/>
-  </application>
-  <uses-feature android:glEsVersion=""0x00020000"" />
-  <uses-permission android:name=""android.permission.INTERNET"" />
-  <uses-permission android:name=""android.permission.WRITE_EXTERNAL_STORAGE"" android:maxSdkVersion=""18"" />
-  <uses-permission android:name=""android.permission.READ_EXTERNAL_STORAGE"" android:maxSdkVersion=""18"" />
-  <uses-feature android:name=""android.hardware.touchscreen"" android:required=""false"" />
-  <uses-feature android:name=""android.hardware.touchscreen.multitouch"" android:required=""false"" />
-  <uses-feature android:name=""android.hardware.touchscreen.multitouch.distinct"" android:required=""false"" />
-</manifest>";
-
-            string targetXmlContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
-<manifest xmlns:android=""http://schemas.android.com/apk/res/android"" package=""com.UnityTestRunner.UnityTestRunner"" xmlns:tools=""http://schemas.android.com/tools"" android:installLocation=""preferExternal"">
-  <supports-screens android:smallScreens=""true"" android:normalScreens=""true"" android:largeScreens=""true"" android:xlargeScreens=""true"" android:anyDensity=""true"" />
-  <application android:theme=""@style/UnityThemeSelector"" android:icon=""@mipmap/app_icon"" android:label=""@string/app_name"" android:isGame=""true"" android:banner=""@drawable/app_banner"">
-    <activity android:label=""@string/app_name"" android:screenOrientation=""fullSensor"" android:launchMode=""singleTask"" android:configChanges=""mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale|layoutDirection|density"" android:hardwareAccelerated=""false"" android:name=""com.UnityTestRunner.UnityTestRunner.UnityPlayerActivity"">
-      <intent-filter>
-        <action android:name=""android.intent.action.MAIN"" />
-        <category android:name=""android.intent.category.LAUNCHER"" />
-        <category android:name=""android.intent.category.LEANBACK_LAUNCHER"" />
-      </intent-filter>
-      <meta-data android:name=""unityplayer.UnityActivity"" android:value=""true"" />
-    </activity>
-    <meta-data android:name=""unity.build-id"" android:value=""8a616d3b-0433-49d8-bbaf-fd1415e8701e"" />
-    <meta-data android:name=""unity.splash-mode"" android:value=""0"" />
-    <meta-data android:name=""unity.splash-enable"" android:value=""True"" />
-    <meta-data android:name=""reschedule_notifications_on_restart"" android:value=""true""/>
-  </application>
-  <uses-feature android:glEsVersion=""0x00020000"" />
-  <uses-permission android:name=""android.permission.INTERNET"" />
-  <uses-permission android:name=""android.permission.WRITE_EXTERNAL_STORAGE"" android:maxSdkVersion=""18"" />
-  <uses-permission android:name=""android.permission.READ_EXTERNAL_STORAGE"" android:maxSdkVersion=""18"" />
-  <uses-feature android:name=""android.hardware.touchscreen"" android:required=""false"" />
-  <uses-feature android:name=""android.hardware.touchscreen.multitouch"" android:required=""false"" />
-  <uses-feature android:name=""android.hardware.touchscreen.multitouch.distinct"" android:required=""false"" />
-</manifest>";
-
+            string sourceXmlContent = GetSourceXml(kRescheduleOnRestartFalse, null);
             XmlDocument xmlDoc = new XmlDocument();
             xmlDoc.LoadXml(sourceXmlContent);
 
 
             AndroidNotificationPostProcessor.AppendAndroidMetadataField(null, xmlDoc, "reschedule_notifications_on_restart", "true");
 
-            XmlDocument targetXmlDoc = new XmlDocument();
-            targetXmlDoc.LoadXml(targetXmlContent);
-
-            Assert.AreEqual(targetXmlDoc.InnerXml, xmlDoc.InnerXml);
+            Assert.IsFalse(xmlDoc.InnerXml.Contains(kRescheduleOnRestartFalse));
+            Assert.IsTrue(xmlDoc.InnerXml.Contains(kRescheduleOnRestartTrue));
         }
 
         [Test]
         public void AppendMetadataToManifest_WhenNotPresent_Works()
         {
-            string sourceXmlContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
-<manifest xmlns:android=""http://schemas.android.com/apk/res/android"" package=""com.UnityTestRunner.UnityTestRunner"" xmlns:tools=""http://schemas.android.com/tools"" android:installLocation=""preferExternal"">
-  <supports-screens android:smallScreens=""true"" android:normalScreens=""true"" android:largeScreens=""true"" android:xlargeScreens=""true"" android:anyDensity=""true"" />
-  <application android:theme=""@style/UnityThemeSelector"" android:icon=""@mipmap/app_icon"" android:label=""@string/app_name"" android:isGame=""true"" android:banner=""@drawable/app_banner"">
-    <activity android:label=""@string/app_name"" android:screenOrientation=""fullSensor"" android:launchMode=""singleTask"" android:configChanges=""mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale|layoutDirection|density"" android:hardwareAccelerated=""false"" android:name=""com.UnityTestRunner.UnityTestRunner.UnityPlayerActivity"">
-      <intent-filter>
-        <action android:name=""android.intent.action.MAIN"" />
-        <category android:name=""android.intent.category.LAUNCHER"" />
-        <category android:name=""android.intent.category.LEANBACK_LAUNCHER"" />
-      </intent-filter>
-      <meta-data android:name=""unityplayer.UnityActivity"" android:value=""true"" />
-    </activity>
-    <meta-data android:name=""unity.build-id"" android:value=""8a616d3b-0433-49d8-bbaf-fd1415e8701e"" />
-    <meta-data android:name=""unity.splash-mode"" android:value=""0"" />
-    <meta-data android:name=""unity.splash-enable"" android:value=""True"" />
-  </application>
-  <uses-feature android:glEsVersion=""0x00020000"" />
-  <uses-permission android:name=""android.permission.INTERNET"" />
-  <uses-permission android:name=""android.permission.WRITE_EXTERNAL_STORAGE"" android:maxSdkVersion=""18"" />
-  <uses-permission android:name=""android.permission.READ_EXTERNAL_STORAGE"" android:maxSdkVersion=""18"" />
-  <uses-feature android:name=""android.hardware.touchscreen"" android:required=""false"" />
-  <uses-feature android:name=""android.hardware.touchscreen.multitouch"" android:required=""false"" />
-  <uses-feature android:name=""android.hardware.touchscreen.multitouch.distinct"" android:required=""false"" />
-</manifest>";
-
-            string targetXmlContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
-<manifest xmlns:android=""http://schemas.android.com/apk/res/android"" package=""com.UnityTestRunner.UnityTestRunner"" xmlns:tools=""http://schemas.android.com/tools"" android:installLocation=""preferExternal"">
-  <supports-screens android:smallScreens=""true"" android:normalScreens=""true"" android:largeScreens=""true"" android:xlargeScreens=""true"" android:anyDensity=""true"" />
-  <application android:theme=""@style/UnityThemeSelector"" android:icon=""@mipmap/app_icon"" android:label=""@string/app_name"" android:isGame=""true"" android:banner=""@drawable/app_banner"">
-    <activity android:label=""@string/app_name"" android:screenOrientation=""fullSensor"" android:launchMode=""singleTask"" android:configChanges=""mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale|layoutDirection|density"" android:hardwareAccelerated=""false"" android:name=""com.UnityTestRunner.UnityTestRunner.UnityPlayerActivity"">
-      <intent-filter>
-        <action android:name=""android.intent.action.MAIN"" />
-        <category android:name=""android.intent.category.LAUNCHER"" />
-        <category android:name=""android.intent.category.LEANBACK_LAUNCHER"" />
-      </intent-filter>
-      <meta-data android:name=""unityplayer.UnityActivity"" android:value=""true"" />
-    </activity>
-    <meta-data android:name=""unity.build-id"" android:value=""8a616d3b-0433-49d8-bbaf-fd1415e8701e"" />
-    <meta-data android:name=""unity.splash-mode"" android:value=""0"" />
-    <meta-data android:name=""unity.splash-enable"" android:value=""True"" />
-    <meta-data android:name=""reschedule_notifications_on_restart"" android:value=""true""/>
-  </application>
-  <uses-feature android:glEsVersion=""0x00020000"" />
-  <uses-permission android:name=""android.permission.INTERNET"" />
-  <uses-permission android:name=""android.permission.WRITE_EXTERNAL_STORAGE"" android:maxSdkVersion=""18"" />
-  <uses-permission android:name=""android.permission.READ_EXTERNAL_STORAGE"" android:maxSdkVersion=""18"" />
-  <uses-feature android:name=""android.hardware.touchscreen"" android:required=""false"" />
-  <uses-feature android:name=""android.hardware.touchscreen.multitouch"" android:required=""false"" />
-  <uses-feature android:name=""android.hardware.touchscreen.multitouch.distinct"" android:required=""false"" />
-</manifest>";
-
+            string sourceXmlContent = GetSourceXml(null, null);
             XmlDocument xmlDoc = new XmlDocument();
             xmlDoc.LoadXml(sourceXmlContent);
 
 
             AndroidNotificationPostProcessor.AppendAndroidMetadataField(null, xmlDoc, "reschedule_notifications_on_restart", "true");
 
-            XmlDocument targetXmlDoc = new XmlDocument();
-            targetXmlDoc.LoadXml(targetXmlContent);
-
-            Assert.AreEqual(targetXmlDoc.InnerXml, xmlDoc.InnerXml);
+            Assert.IsTrue(xmlDoc.InnerXml.Contains(kRescheduleOnRestartTrue));
         }
 
         [Test]
         public void AppendMetadataToManifest_WhenOtherFieldPresentWorks()
         {
-            string sourceXmlContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
-<manifest xmlns:android=""http://schemas.android.com/apk/res/android"" package=""com.UnityTestRunner.UnityTestRunner"" xmlns:tools=""http://schemas.android.com/tools"" android:installLocation=""preferExternal"">
-  <supports-screens android:smallScreens=""true"" android:normalScreens=""true"" android:largeScreens=""true"" android:xlargeScreens=""true"" android:anyDensity=""true"" />
-  <application android:theme=""@style/UnityThemeSelector"" android:icon=""@mipmap/app_icon"" android:label=""@string/app_name"" android:isGame=""true"" android:banner=""@drawable/app_banner"">
-    <activity android:label=""@string/app_name"" android:screenOrientation=""fullSensor"" android:launchMode=""singleTask"" android:configChanges=""mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale|layoutDirection|density"" android:hardwareAccelerated=""false"" android:name=""com.UnityTestRunner.UnityTestRunner.UnityPlayerActivity"">
-      <intent-filter>
-        <action android:name=""android.intent.action.MAIN"" />
-        <category android:name=""android.intent.category.LAUNCHER"" />
-        <category android:name=""android.intent.category.LEANBACK_LAUNCHER"" />
-      </intent-filter>
-      <meta-data android:name=""unityplayer.UnityActivity"" android:value=""true"" />
-    </activity>
-    <meta-data android:name=""unity.build-id"" android:value=""8a616d3b-0433-49d8-bbaf-fd1415e8701e"" />
-    <meta-data android:name=""unity.splash-mode"" android:value=""0"" />
-    <meta-data android:name=""unity.splash-enable"" android:value=""True"" />
-    <meta-data android:name=""reschedule_notifications_on_restart"" android:value=""true""/>
-  </application>
-  <uses-feature android:glEsVersion=""0x00020000"" />
-  <uses-permission android:name=""android.permission.INTERNET"" />
-  <uses-permission android:name=""android.permission.WRITE_EXTERNAL_STORAGE"" android:maxSdkVersion=""18"" />
-  <uses-permission android:name=""android.permission.READ_EXTERNAL_STORAGE"" android:maxSdkVersion=""18"" />
-  <uses-feature android:name=""android.hardware.touchscreen"" android:required=""false"" />
-  <uses-feature android:name=""android.hardware.touchscreen.multitouch"" android:required=""false"" />
-  <uses-feature android:name=""android.hardware.touchscreen.multitouch.distinct"" android:required=""false"" />
-</manifest>";
-
-            string targetXmlContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
-<manifest xmlns:android=""http://schemas.android.com/apk/res/android"" package=""com.UnityTestRunner.UnityTestRunner"" xmlns:tools=""http://schemas.android.com/tools"" android:installLocation=""preferExternal"">
-  <supports-screens android:smallScreens=""true"" android:normalScreens=""true"" android:largeScreens=""true"" android:xlargeScreens=""true"" android:anyDensity=""true"" />
-  <application android:theme=""@style/UnityThemeSelector"" android:icon=""@mipmap/app_icon"" android:label=""@string/app_name"" android:isGame=""true"" android:banner=""@drawable/app_banner"">
-    <activity android:label=""@string/app_name"" android:screenOrientation=""fullSensor"" android:launchMode=""singleTask"" android:configChanges=""mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale|layoutDirection|density"" android:hardwareAccelerated=""false"" android:name=""com.UnityTestRunner.UnityTestRunner.UnityPlayerActivity"">
-      <intent-filter>
-        <action android:name=""android.intent.action.MAIN"" />
-        <category android:name=""android.intent.category.LAUNCHER"" />
-        <category android:name=""android.intent.category.LEANBACK_LAUNCHER"" />
-      </intent-filter>
-      <meta-data android:name=""unityplayer.UnityActivity"" android:value=""true"" />
-    </activity>
-    <meta-data android:name=""unity.build-id"" android:value=""8a616d3b-0433-49d8-bbaf-fd1415e8701e"" />
-    <meta-data android:name=""unity.splash-mode"" android:value=""0"" />
-    <meta-data android:name=""unity.splash-enable"" android:value=""True"" />
-    <meta-data android:name=""reschedule_notifications_on_restart"" android:value=""true""/>
-    <meta-data android:name=""do_something"" android:value=""true""/>
-  </application>
-  <uses-feature android:glEsVersion=""0x00020000"" />
-  <uses-permission android:name=""android.permission.INTERNET"" />
-  <uses-permission android:name=""android.permission.WRITE_EXTERNAL_STORAGE"" android:maxSdkVersion=""18"" />
-  <uses-permission android:name=""android.permission.READ_EXTERNAL_STORAGE"" android:maxSdkVersion=""18"" />
-  <uses-feature android:name=""android.hardware.touchscreen"" android:required=""false"" />
-  <uses-feature android:name=""android.hardware.touchscreen.multitouch"" android:required=""false"" />
-  <uses-feature android:name=""android.hardware.touchscreen.multitouch.distinct"" android:required=""false"" />
-</manifest>";
-
+            string sourceXmlContent = GetSourceXml(kRescheduleOnRestartTrue, null);
             XmlDocument xmlDoc = new XmlDocument();
             xmlDoc.LoadXml(sourceXmlContent);
 
 
             AndroidNotificationPostProcessor.AppendAndroidMetadataField(null, xmlDoc, "do_something", "true");
 
-            XmlDocument targetXmlDoc = new XmlDocument();
-            targetXmlDoc.LoadXml(targetXmlContent);
-
-            Assert.AreEqual(targetXmlDoc.InnerXml, xmlDoc.InnerXml);
+            Assert.IsTrue(xmlDoc.InnerXml.Contains(kRescheduleOnRestartTrue));
+            Assert.IsTrue(xmlDoc.InnerXml.Contains("<meta-data android:name=\"do_something\" android:value=\"true\" />"));
         }
 
         [Test]
         public void AppendPermissionToManifest_WhenNoPresentWorks()
         {
-            string sourceXmlContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
-<manifest xmlns:android=""http://schemas.android.com/apk/res/android"" package=""com.UnityTestRunner.UnityTestRunner"" xmlns:tools=""http://schemas.android.com/tools"" android:installLocation=""preferExternal"">
-  <supports-screens android:smallScreens=""true"" android:normalScreens=""true"" android:largeScreens=""true"" android:xlargeScreens=""true"" android:anyDensity=""true"" />
-  <application android:theme=""@style/UnityThemeSelector"" android:icon=""@mipmap/app_icon"" android:label=""@string/app_name"" android:isGame=""true"" android:banner=""@drawable/app_banner"">
-    <activity android:label=""@string/app_name"" android:screenOrientation=""fullSensor"" android:launchMode=""singleTask"" android:configChanges=""mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale|layoutDirection|density"" android:hardwareAccelerated=""false"" android:name=""com.UnityTestRunner.UnityTestRunner.UnityPlayerActivity"">
-      <intent-filter>
-        <action android:name=""android.intent.action.MAIN"" />
-        <category android:name=""android.intent.category.LAUNCHER"" />
-        <category android:name=""android.intent.category.LEANBACK_LAUNCHER"" />
-      </intent-filter>
-      <meta-data android:name=""unityplayer.UnityActivity"" android:value=""true"" />
-    </activity>
-    <meta-data android:name=""unity.build-id"" android:value=""8a616d3b-0433-49d8-bbaf-fd1415e8701e"" />
-    <meta-data android:name=""unity.splash-mode"" android:value=""0"" />
-    <meta-data android:name=""unity.splash-enable"" android:value=""True"" />
-    <meta-data android:name=""reschedule_notifications_on_restart"" android:value=""true""/>
-  </application>
-  <uses-feature android:glEsVersion=""0x00020000"" />
-  <uses-permission android:name=""android.permission.INTERNET"" />
-  <uses-permission android:name=""android.permission.WRITE_EXTERNAL_STORAGE"" android:maxSdkVersion=""18"" />
-  <uses-permission android:name=""android.permission.READ_EXTERNAL_STORAGE"" android:maxSdkVersion=""18"" />
-  <uses-feature android:name=""android.hardware.touchscreen"" android:required=""false"" />
-  <uses-feature android:name=""android.hardware.touchscreen.multitouch"" android:required=""false"" />
-  <uses-feature android:name=""android.hardware.touchscreen.multitouch.distinct"" android:required=""false"" />
-</manifest>";
-
-            string targetXmlContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
-<manifest xmlns:android=""http://schemas.android.com/apk/res/android"" package=""com.UnityTestRunner.UnityTestRunner"" xmlns:tools=""http://schemas.android.com/tools"" android:installLocation=""preferExternal"">
-  <supports-screens android:smallScreens=""true"" android:normalScreens=""true"" android:largeScreens=""true"" android:xlargeScreens=""true"" android:anyDensity=""true"" />
-  <application android:theme=""@style/UnityThemeSelector"" android:icon=""@mipmap/app_icon"" android:label=""@string/app_name"" android:isGame=""true"" android:banner=""@drawable/app_banner"">
-    <activity android:label=""@string/app_name"" android:screenOrientation=""fullSensor"" android:launchMode=""singleTask"" android:configChanges=""mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale|layoutDirection|density"" android:hardwareAccelerated=""false"" android:name=""com.UnityTestRunner.UnityTestRunner.UnityPlayerActivity"">
-      <intent-filter>
-        <action android:name=""android.intent.action.MAIN"" />
-        <category android:name=""android.intent.category.LAUNCHER"" />
-        <category android:name=""android.intent.category.LEANBACK_LAUNCHER"" />
-      </intent-filter>
-      <meta-data android:name=""unityplayer.UnityActivity"" android:value=""true"" />
-    </activity>
-    <meta-data android:name=""unity.build-id"" android:value=""8a616d3b-0433-49d8-bbaf-fd1415e8701e"" />
-    <meta-data android:name=""unity.splash-mode"" android:value=""0"" />
-    <meta-data android:name=""unity.splash-enable"" android:value=""True"" />
-    <meta-data android:name=""reschedule_notifications_on_restart"" android:value=""true""/>
-  </application>
-  <uses-feature android:glEsVersion=""0x00020000"" />
-  <uses-permission android:name=""android.permission.INTERNET"" />
-  <uses-permission android:name=""android.permission.WRITE_EXTERNAL_STORAGE"" android:maxSdkVersion=""18"" />
-  <uses-permission android:name=""android.permission.READ_EXTERNAL_STORAGE"" android:maxSdkVersion=""18"" />
-  <uses-feature android:name=""android.hardware.touchscreen"" android:required=""false"" />
-  <uses-feature android:name=""android.hardware.touchscreen.multitouch"" android:required=""false"" />
-  <uses-feature android:name=""android.hardware.touchscreen.multitouch.distinct"" android:required=""false"" />
-  <uses-permission android:name=""android.permission.RECEIVE_BOOT_COMPLETED""/>
-</manifest>";
-
+            string sourceXmlContent = GetSourceXml(null, null);
             XmlDocument xmlDoc = new XmlDocument();
             xmlDoc.LoadXml(sourceXmlContent);
 
 
             AndroidNotificationPostProcessor.AppendAndroidPermissionField(null, xmlDoc, "android.permission.RECEIVE_BOOT_COMPLETED");
 
-            XmlDocument targetXmlDoc = new XmlDocument();
-            targetXmlDoc.LoadXml(targetXmlContent);
-
-            Assert.AreEqual(targetXmlDoc.InnerXml, xmlDoc.InnerXml);
+            Assert.IsTrue(xmlDoc.InnerXml.Contains(kReceiveBookCompletedPermission));
         }
 
         [Test]
         public void AppendPermissionToManifest_WhenAlreadyPresentWorks()
         {
-            string sourceXmlContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
-<manifest xmlns:android=""http://schemas.android.com/apk/res/android"" package=""com.UnityTestRunner.UnityTestRunner"" xmlns:tools=""http://schemas.android.com/tools"" android:installLocation=""preferExternal"">
-  <supports-screens android:smallScreens=""true"" android:normalScreens=""true"" android:largeScreens=""true"" android:xlargeScreens=""true"" android:anyDensity=""true"" />
-  <application android:theme=""@style/UnityThemeSelector"" android:icon=""@mipmap/app_icon"" android:label=""@string/app_name"" android:isGame=""true"" android:banner=""@drawable/app_banner"">
-    <activity android:label=""@string/app_name"" android:screenOrientation=""fullSensor"" android:launchMode=""singleTask"" android:configChanges=""mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale|layoutDirection|density"" android:hardwareAccelerated=""false"" android:name=""com.UnityTestRunner.UnityTestRunner.UnityPlayerActivity"">
-      <intent-filter>
-        <action android:name=""android.intent.action.MAIN"" />
-        <category android:name=""android.intent.category.LAUNCHER"" />
-        <category android:name=""android.intent.category.LEANBACK_LAUNCHER"" />
-      </intent-filter>
-      <meta-data android:name=""unityplayer.UnityActivity"" android:value=""true"" />
-    </activity>
-    <meta-data android:name=""unity.build-id"" android:value=""8a616d3b-0433-49d8-bbaf-fd1415e8701e"" />
-    <meta-data android:name=""unity.splash-mode"" android:value=""0"" />
-    <meta-data android:name=""unity.splash-enable"" android:value=""True"" />
-    <meta-data android:name=""reschedule_notifications_on_restart"" android:value=""true""/>
-  </application>
-  <uses-feature android:glEsVersion=""0x00020000"" />
-  <uses-permission android:name=""android.permission.INTERNET"" />
-  <uses-permission android:name=""android.permission.WRITE_EXTERNAL_STORAGE"" android:maxSdkVersion=""18"" />
-  <uses-permission android:name=""android.permission.READ_EXTERNAL_STORAGE"" android:maxSdkVersion=""18"" />
-  <uses-permission android:name=""android.permission.RECEIVE_BOOT_COMPLETED""/>
-  <uses-feature android:name=""android.hardware.touchscreen"" android:required=""false"" />
-  <uses-feature android:name=""android.hardware.touchscreen.multitouch"" android:required=""false"" />
-  <uses-feature android:name=""android.hardware.touchscreen.multitouch.distinct"" android:required=""false"" />
-</manifest>";
-
-            string targetXmlContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
-<manifest xmlns:android=""http://schemas.android.com/apk/res/android"" package=""com.UnityTestRunner.UnityTestRunner"" xmlns:tools=""http://schemas.android.com/tools"" android:installLocation=""preferExternal"">
-  <supports-screens android:smallScreens=""true"" android:normalScreens=""true"" android:largeScreens=""true"" android:xlargeScreens=""true"" android:anyDensity=""true"" />
-  <application android:theme=""@style/UnityThemeSelector"" android:icon=""@mipmap/app_icon"" android:label=""@string/app_name"" android:isGame=""true"" android:banner=""@drawable/app_banner"">
-    <activity android:label=""@string/app_name"" android:screenOrientation=""fullSensor"" android:launchMode=""singleTask"" android:configChanges=""mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale|layoutDirection|density"" android:hardwareAccelerated=""false"" android:name=""com.UnityTestRunner.UnityTestRunner.UnityPlayerActivity"">
-      <intent-filter>
-        <action android:name=""android.intent.action.MAIN"" />
-        <category android:name=""android.intent.category.LAUNCHER"" />
-        <category android:name=""android.intent.category.LEANBACK_LAUNCHER"" />
-      </intent-filter>
-      <meta-data android:name=""unityplayer.UnityActivity"" android:value=""true"" />
-    </activity>
-    <meta-data android:name=""unity.build-id"" android:value=""8a616d3b-0433-49d8-bbaf-fd1415e8701e"" />
-    <meta-data android:name=""unity.splash-mode"" android:value=""0"" />
-    <meta-data android:name=""unity.splash-enable"" android:value=""True"" />
-    <meta-data android:name=""reschedule_notifications_on_restart"" android:value=""true""/>
-  </application>
-  <uses-feature android:glEsVersion=""0x00020000"" />
-  <uses-permission android:name=""android.permission.INTERNET"" />
-  <uses-permission android:name=""android.permission.WRITE_EXTERNAL_STORAGE"" android:maxSdkVersion=""18"" />
-  <uses-permission android:name=""android.permission.READ_EXTERNAL_STORAGE"" android:maxSdkVersion=""18"" />
-<uses-permission android:name=""android.permission.RECEIVE_BOOT_COMPLETED""/>
-  <uses-feature android:name=""android.hardware.touchscreen"" android:required=""false"" />
-  <uses-feature android:name=""android.hardware.touchscreen.multitouch"" android:required=""false"" />
-  <uses-feature android:name=""android.hardware.touchscreen.multitouch.distinct"" android:required=""false"" />
-</manifest>";
-
+            string sourceXmlContent = GetSourceXml(null, kReceiveBookCompletedPermission);
             XmlDocument xmlDoc = new XmlDocument();
             xmlDoc.LoadXml(sourceXmlContent);
 
 
             AndroidNotificationPostProcessor.AppendAndroidPermissionField(null, xmlDoc, "android.permission.RECEIVE_BOOT_COMPLETED");
 
-            XmlDocument targetXmlDoc = new XmlDocument();
-            targetXmlDoc.LoadXml(targetXmlContent);
-
-            Assert.AreEqual(targetXmlDoc.InnerXml, xmlDoc.InnerXml);
+            Assert.IsTrue(xmlDoc.InnerXml.Contains(kReceiveBookCompletedPermission));
         }
 
 #endif


### PR DESCRIPTION
Addresses: https://github.com/Unity-Technologies/com.unity.mobile.notifications/issues/231

Sometimes scheduled notifications do not arrive or are late, may even not arrive at all until you open the app. Only was able to reproduce it with battery saving on.

Changes:
- new flag for exact scheduling to add battery ignore permission to the manifest
- new public APIs to query if using exact scheduling and if ignoring batter optimizations
- new API to request exact scheduling (required on Android 12+ with SCHEDULE_EXACT permission)
- new API to request app being excluded from battery saving
- new API for notification permission rationale

Testing guide:
- find devices to reproduce the issue on; likely you need Android 12 or later and battery to be put to one of more restrictive power saving options; make sure you disable exact scheduling in notification settings, best to schedule notification couple minutes in the future, kill app and lock device, best if notification does not show up at all until you launch app again; some devices need to be unplugged from computer to be truly in power saving mode;
- there are two permissions for exact scheduling: SCHEDULE_EXACT_ALARM and USE_EXACT_ALARM. The later is Android 13 and should be enough for notifications to show up. The first one is since Android 12 and it allows app to request it, but you have control over it
- requesting exact scheduling or batter ignore requires relevant permission, set the corresponding flag in notification settings
- try requesting either exact scheduling or batter exempt (only one a the time, uninstall the app between tests or make sure settings are correct), I expect either to make notification arrive (but I'm not entirely sure, Samsung devices seem to be the most problematic here)
- there are 3 new buttons in Main test project: two for making relevant requests and one for querying both;
- test project on each focus gain prints notification permission status; only relevant on Android 13; if no permission given, it will print whether a UI with permission rationale should be shows (this is typically false initially and becomes true after permission was denied once).

Tested on:
- Asus ROG (8.1)
- Nokia 7 Plus (10)
- Galaxy S22 (12)
- Pixel 5 (13)
S22 was best for testing, as there with battery saving on inexact notifications didn't arrive at all until app is brought to foreground (at least withing reasonable amount time, didn't wait for hours).