### PR TITLE
iOS notification content update

### DIFF
--- a/TestProjects/Main/Assets/Resources/iOSNotifications/TimeIntervalTrigger/Passive.asset
+++ b/TestProjects/Main/Assets/Resources/iOSNotifications/TimeIntervalTrigger/Passive.asset
@@ -1,0 +1,31 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4fc6c74f6df364b36b9afcbfd8cfbca3, type: 3}
+  m_Name: Passive
+  m_EditorClassIdentifier: 
+  ButtonName: Passive notification
+  Identifier: 
+  CategoryIdentifier: 
+  ThreadIdentifier: 
+  Title: Passive notification
+  Subtitle: 
+  Body: Does not alert on iOS 15+
+  ShowInForeground: 0
+  PresentationOptions: 6
+  Badge: -1
+  Data: 
+  TimeTriggerInterval: 20
+  Repeats: 0
+  SoundType: 0
+  InterruptionLevel: 2
+  UserInfo: []
+  Attachments: []

--- a/TestProjects/Main/Assets/Resources/iOSNotifications/TimeIntervalTrigger/Passive.asset.meta
+++ b/TestProjects/Main/Assets/Resources/iOSNotifications/TimeIntervalTrigger/Passive.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 12b9fad86d7d24fc58a05d613b0ab17a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/Main/Assets/Scripts/ScriptableObjects/iOSNotificationTemplateTimeTrigger.cs
+++ b/TestProjects/Main/Assets/Scripts/ScriptableObjects/iOSNotificationTemplateTimeTrigger.cs
@@ -37,6 +37,7 @@ namespace Unity.Notifications.Tests.Sample
         public Int32 TimeTriggerInterval;
         public bool Repeats = false;
         public NotificationSoundType SoundType;
+        public NotificationInterruptionLevel InterruptionLevel;
 
         [Serializable]
         public struct UserDataItem

--- a/TestProjects/Main/Assets/Scripts/iOSTest.cs
+++ b/TestProjects/Main/Assets/Scripts/iOSTest.cs
@@ -238,6 +238,7 @@ namespace Unity.Notifications.Tests.Sample
                         Badge = template.Badge,
                         Data = template.Data,
                         SoundType = template.SoundType,
+                        InterruptionLevel = template.InterruptionLevel,
                         Trigger = new iOSNotificationTimeIntervalTrigger()
                         {
                             TimeInterval = TimeSpan.FromSeconds(template.TimeTriggerInterval),

--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this package will be documented in this file.
 - [Android] - Added support for BigPicture style.
 - [Android] - Icons now support local files and URIs.
 - [iOS] - Added support for notification action icons (requires iOS 15).
+- [iOS] - Added property to set interruption level (requires iOS 15).
+- [iOS] - Added property to set relevance score (requires iOS 15).
 
 ## [2.1.1] - 2023-01-04
 

--- a/com.unity.mobile.notifications/Documentation~/index.md
+++ b/com.unity.mobile.notifications/Documentation~/index.md
@@ -6,6 +6,7 @@ The Unity Mobile Notifications package adds support for scheduling local one-tim
 
 - Compatible with Unity 2020.3 or above.
 - Compatible with Android 5 (API 21) and iOS 10.0+.
+- Requires Xcode with SDK for iOS 15.2 or newer.
 
 ### Supported features
 

--- a/com.unity.mobile.notifications/Editor/NotificationSettings.cs
+++ b/com.unity.mobile.notifications/Editor/NotificationSettings.cs
@@ -182,6 +182,7 @@ namespace Unity.Notifications
             internal static readonly string PUSH_NOTIFICATION_PRESENTATION = "UnityRemoteNotificationForegroundPresentationOptions";
             internal static readonly string USE_APS_RELEASE = "UnityUseAPSReleaseEnvironment";
             internal static readonly string USE_LOCATION_TRIGGER = "UnityUseLocationNotificationTrigger";
+            internal static readonly string ADD_TIME_SENSITIVE_ENTITLEMENT = "UnityAddTimeSensitiveEntitlement";
 
             /// <summary>
             /// It's recommended to make the authorization request during the app's launch cycle. If this is enabled the user will be shown the authorization pop-up immediately when the app launches. If it’s unchecked you’ll need to manually create an AuthorizationRequest before your app can send or receive notifications.
@@ -285,6 +286,21 @@ namespace Unity.Notifications
                 set
                 {
                     SetSettingValue<bool>(BuildTargetGroup.iOS, USE_LOCATION_TRIGGER, value);
+                }
+            }
+
+            /// <summary>
+            /// Add entitlement to enable notifications with time-sensitive interruption level.
+            /// </summary>
+            public static bool AddTimeSensitiveEntitlement
+            {
+                get
+                {
+                    return GetSettingValue<bool>(BuildTargetGroup.iOS, ADD_TIME_SENSITIVE_ENTITLEMENT);
+                }
+                set
+                {
+                    SetSettingValue<bool>(BuildTargetGroup.iOS, ADD_TIME_SENSITIVE_ENTITLEMENT, value);
                 }
             }
         }

--- a/com.unity.mobile.notifications/Editor/NotificationSettingsManager.cs
+++ b/com.unity.mobile.notifications/Editor/NotificationSettingsManager.cs
@@ -143,7 +143,12 @@ namespace Unity.Notifications
                     "Include CoreLocation Framework",
                     "Include the CoreLocation framework to use the iOSNotificationLocationTrigger in your project.",
                     settingsManager.GetOrAddNotificationSettingValue(NotificationSettings.iOSSettings.USE_LOCATION_TRIGGER, false, false),
-                    false)
+                    false),
+                new NotificationSetting(NotificationSettings.iOSSettings.ADD_TIME_SENSITIVE_ENTITLEMENT,
+                    "Enable time sensitive notifications",
+                    "Enable to add entitlement for notifications with time sensitive interruption level",
+                    settingsManager.GetOrAddNotificationSettingValue(NotificationSettings.iOSSettings.ADD_TIME_SENSITIVE_ENTITLEMENT, false, false),
+                    false),
             };
 
             // Create the settings for Android.

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.h
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.h
@@ -46,6 +46,7 @@ typedef struct iOSNotificationData
     float soundVolume;
     char* soundName;
     int interruptionLevel;
+    double relevanceScore;
 
     void* userInfo;
     void* attachments;

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.h
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.h
@@ -25,6 +25,14 @@ enum UnitySoundType
     kSoundTypeNone = 4,
 };
 
+enum UnityNotificationInterruptionLevel
+{
+    kInterruptionLevelActive = 0,
+    kInterruptionLevelCritical = 1,
+    kInterruptionLevelPassive = 2,
+    kInterruptionLevelTimeSensitive = 3,
+};
+
 typedef struct iOSNotificationData
 {
     char* identifier;
@@ -37,6 +45,7 @@ typedef struct iOSNotificationData
     int soundType;
     float soundVolume;
     char* soundName;
+    int interruptionLevel;
 
     void* userInfo;
     void* attachments;

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
@@ -86,6 +86,23 @@ void initiOSNotificationData(iOSNotificationData* notificationData)
     notificationData->userInfo = NULL;
 }
 
+static enum UnityNotificationInterruptionLevel InterruptionLevelToUnity(UNNotificationInterruptionLevel level)
+API_AVAILABLE(ios(15.0))
+{
+    switch (level)
+    {
+        case UNNotificationInterruptionLevelActive:
+        default:
+            return kInterruptionLevelActive;
+        case UNNotificationInterruptionLevelCritical:
+            return kInterruptionLevelCritical;
+        case UNNotificationInterruptionLevelPassive:
+            return kInterruptionLevelPassive;
+        case UNNotificationInterruptionLevelTimeSensitive:
+            return kInterruptionLevelTimeSensitive;
+    }
+}
+
 static void parseCustomizedData(iOSNotificationData* notificationData, UNNotificationRequest* request)
 {
     NSDictionary* userInfo = request.content.userInfo;
@@ -133,6 +150,11 @@ iOSNotificationData UNNotificationRequestToiOSNotificationData(UNNotificationReq
 
     if (content.threadIdentifier != nil && content.threadIdentifier.length > 0)
         notificationData.threadIdentifier = strdup([content.threadIdentifier UTF8String]);
+
+    if (@available(iOS 15.0, *))
+        notificationData.interruptionLevel = InterruptionLevelToUnity(content.interruptionLevel);
+    else
+        notificationData.interruptionLevel = kInterruptionLevelActive;
 
     if ([request.trigger isKindOfClass: [UNTimeIntervalNotificationTrigger class]])
     {

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
@@ -81,6 +81,7 @@ void initiOSNotificationData(iOSNotificationData* notificationData)
     notificationData->soundType = kSoundTypeDefault;
     notificationData->soundVolume = -1.0f;
     notificationData->soundName = NULL;
+    notificationData->interruptionLevel = kInterruptionLevelActive;
     notificationData->triggerType = PUSH_TRIGGER;
     notificationData->userInfo = NULL;
 }

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
@@ -82,6 +82,7 @@ void initiOSNotificationData(iOSNotificationData* notificationData)
     notificationData->soundVolume = -1.0f;
     notificationData->soundName = NULL;
     notificationData->interruptionLevel = kInterruptionLevelActive;
+    notificationData->relevanceScore = 0;
     notificationData->triggerType = PUSH_TRIGGER;
     notificationData->userInfo = NULL;
 }
@@ -152,9 +153,15 @@ iOSNotificationData UNNotificationRequestToiOSNotificationData(UNNotificationReq
         notificationData.threadIdentifier = strdup([content.threadIdentifier UTF8String]);
 
     if (@available(iOS 15.0, *))
+    {
         notificationData.interruptionLevel = InterruptionLevelToUnity(content.interruptionLevel);
+        notificationData.relevanceScore = content.relevanceScore;
+    }
     else
+    {
         notificationData.interruptionLevel = kInterruptionLevelActive;
+        notificationData.relevanceScore = 0;
+    }
 
     if ([request.trigger isKindOfClass: [UNTimeIntervalNotificationTrigger class]])
     {

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -301,6 +301,8 @@ bool validateAuthorizationStatus(UnityNotificationManager* manager)
     UNNotificationSound* sound = [self soundForNotification: data];
     if (sound != nil)
         content.sound = sound;
+    if (@available(iOS 15.0, *))
+        content.interruptionLevel = [self unityInterruptionLevelToIos: data->interruptionLevel];
 
     content.attachments = (__bridge_transfer NSArray<UNNotificationAttachment*>*)data->attachments;
     data->attachments = NULL;
@@ -404,6 +406,24 @@ bool validateAuthorizationStatus(UnityNotificationManager* manager)
             if (soundName != nil)
                 return [UNNotificationSound soundNamed: soundName];
             return UNNotificationSound.defaultSound;
+    }
+}
+
+- (UNNotificationInterruptionLevel)unityInterruptionLevelToIos:(int)level
+API_AVAILABLE(ios(15.0))
+{
+    switch (level)
+    {
+        case kInterruptionLevelActive:
+            return UNNotificationInterruptionLevelActive;
+        case kInterruptionLevelCritical:
+            return UNNotificationInterruptionLevelCritical;
+        case kInterruptionLevelPassive:
+            return UNNotificationInterruptionLevelPassive;
+        case kInterruptionLevelTimeSensitive:
+            return UNNotificationInterruptionLevelTimeSensitive;
+        default:
+            return UNNotificationInterruptionLevelActive;
     }
 }
 

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -413,7 +413,7 @@ bool validateAuthorizationStatus(UnityNotificationManager* manager)
 }
 
 - (UNNotificationInterruptionLevel)unityInterruptionLevelToIos:(int)level
-API_AVAILABLE(ios(15.0))
+    API_AVAILABLE(ios(15.0))
 {
     switch (level)
     {

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -302,7 +302,10 @@ bool validateAuthorizationStatus(UnityNotificationManager* manager)
     if (sound != nil)
         content.sound = sound;
     if (@available(iOS 15.0, *))
+    {
         content.interruptionLevel = [self unityInterruptionLevelToIos: data->interruptionLevel];
+        content.relevanceScore = data->relevanceScore;
+    }
 
     content.attachments = (__bridge_transfer NSArray<UNNotificationAttachment*>*)data->attachments;
     data->attachments = NULL;

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
@@ -123,6 +123,7 @@ namespace Unity.Notifications.iOS
         public float soundVolume;
         public string soundName;
         public Int32 interruptionLevel;
+        public double relevanceScore;
 
         public IntPtr userInfo;
         public IntPtr attachments;
@@ -284,6 +285,12 @@ namespace Unity.Notifications.iOS
         {
             get { return (NotificationInterruptionLevel)data.interruptionLevel; }
             set { data.interruptionLevel = (int)value; }
+        }
+
+        public double RelevanceScore
+        {
+            get { return data.relevanceScore; }
+            set { data.relevanceScore = value; }
         }
 
         /// <summary>
@@ -472,6 +479,7 @@ namespace Unity.Notifications.iOS
             ShowInForeground = false;
             ForegroundPresentationOption = PresentationOption.Alert | PresentationOption.Sound;
             InterruptionLevel = NotificationInterruptionLevel.Active;
+            RelevanceScore = 0;
         }
 
         internal iOSNotification(iOSNotificationWithUserInfo data)

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
@@ -60,11 +60,31 @@ namespace Unity.Notifications.iOS
         None = 4,
     }
 
+    /// <summary>
+    /// Importance and delivery timing of a notification.
+    /// See Apple documentation for details. Available since iOS 15, always Active on lower versions.
+    /// </summary>
+    /// <see cref="https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel?language=objc"/>
     public enum NotificationInterruptionLevel
     {
+        /// <summary>
+        /// Default level. The system presents the notification immediately, lights up the screen, and can play a sound.
+        /// </summary>
         Active = 0,
+
+        /// <summary>
+        /// The system presents the notification immediately, lights up the screen, and bypasses the mute switch to play a sound.
+        /// </summary>
         Critical = 1,
+
+        /// <summary>
+        /// The system adds the notification to the notification list without lighting up the screen or playing a sound.
+        /// </summary>
         Passive = 2,
+
+        /// <summary>
+        /// The system presents the notification immediately, lights up the screen, and can play a sound, but won’t break through system notification controls.
+        /// </summary>
         TimeSensitive = 3,
     }
 
@@ -281,12 +301,19 @@ namespace Unity.Notifications.iOS
         /// <see href="https://developer.apple.com/documentation/usernotifications/unnotificationsound/2963118-defaultcriticalsoundwithaudiovol?language=objc"/>
         public float? SoundVolume { get; set; }
 
+        /// <summary>
+        /// The notification’s importance and required delivery timing.
+        /// </summary>
         public NotificationInterruptionLevel InterruptionLevel
         {
             get { return (NotificationInterruptionLevel)data.interruptionLevel; }
             set { data.interruptionLevel = (int)value; }
         }
 
+        /// <summary>
+        /// The score the system uses to determine if the notification is the summary’s featured notification.
+        /// </summary>
+        /// <see cref="https://developer.apple.com/documentation/usernotifications/unnotificationcontent/3821031-relevancescore?language=objc"/>
         public double RelevanceScore
         {
             get { return data.relevanceScore; }

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
@@ -60,6 +60,14 @@ namespace Unity.Notifications.iOS
         None = 4,
     }
 
+    public enum NotificationInterruptionLevel
+    {
+        Active = 0,
+        Critical = 1,
+        Passive = 2,
+        TimeSensitive = 3,
+    }
+
     [StructLayout(LayoutKind.Sequential)]
     internal struct TimeTriggerData
     {
@@ -114,6 +122,7 @@ namespace Unity.Notifications.iOS
         public Int32 soundType;
         public float soundVolume;
         public string soundName;
+        public Int32 interruptionLevel;
 
         public IntPtr userInfo;
         public IntPtr attachments;
@@ -270,6 +279,12 @@ namespace Unity.Notifications.iOS
         /// </summary>
         /// <see href="https://developer.apple.com/documentation/usernotifications/unnotificationsound/2963118-defaultcriticalsoundwithaudiovol?language=objc"/>
         public float? SoundVolume { get; set; }
+
+        public NotificationInterruptionLevel InterruptionLevel
+        {
+            get { return (NotificationInterruptionLevel)data.interruptionLevel; }
+            set { data.interruptionLevel = (int)value; }
+        }
 
         /// <summary>
         /// Arbitrary string data which can be retrieved when the notification is used to open the app or is received while the app is running.
@@ -456,6 +471,7 @@ namespace Unity.Notifications.iOS
             Data = "";
             ShowInForeground = false;
             ForegroundPresentationOption = PresentationOption.Alert | PresentationOption.Sound;
+            InterruptionLevel = NotificationInterruptionLevel.Active;
         }
 
         internal iOSNotification(iOSNotificationWithUserInfo data)

--- a/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
@@ -243,7 +243,7 @@ class iOSNotificationTests
     void CompareNotifications(iOSNotification expected, iOSNotification actual)
     {
         // these don't roundtrip or are tested separately
-        var ignoredProps = new []
+        var ignoredProps = new[]
         {
             "Attachments",
             "SoundName",
@@ -273,7 +273,7 @@ class iOSNotificationTests
                             Assert.Fail($"Expected property {prop.Name} to be non-zero");
                     }
                 }
-                else if(prop.PropertyType.IsEnum)
+                else if (prop.PropertyType.IsEnum)
                 {
                     int intVal = (int)v2;
                     if (intVal == 0)

--- a/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
@@ -267,7 +267,7 @@ class iOSNotificationTests
                     }
                     else
                     {
-                        int intVal = (int)v2;
+                        int intVal = ((IConvertible)v2).ToInt32(System.Globalization.CultureInfo.InvariantCulture);
                         if (intVal == 0)
                             Assert.Fail($"Expected property {prop.Name} to be non-zero");
                     }

--- a/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
@@ -227,6 +227,7 @@ class iOSNotificationTests
             Body = "body",
             Badge = 2,
             InterruptionLevel = NotificationInterruptionLevel.Critical,
+            RelevanceScore = 1.0,
             ShowInForeground = true,
             ForegroundPresentationOption = PresentationOption.Alert,
         };

--- a/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.TestTools;
 using NUnit.Framework;
@@ -203,6 +204,92 @@ class iOSNotificationTests
     public IEnumerator SendNotificationUsingCalendarTriggerUtcTime_NotificationIsReceived()
     {
         yield return SendNotificationUsingCalendarTrigger_NotificationIsReceived("SendNotificationUsingCalendarTriggerUtcTime_NotificationIsReceived", true);
+    }
+
+    [UnityTest]
+    [UnityPlatform(RuntimePlatform.IPhonePlayer)]
+    public IEnumerator SendNotification_AllPropertiesRoundtrip()
+    {
+        var trigger = new iOSNotificationTimeIntervalTrigger()
+        {
+            TimeInterval = new TimeSpan(0, 0, 5),
+            Repeats = false,
+        };
+
+        var notification = new iOSNotification()
+        {
+            Trigger = trigger,
+            Identifier = "roundtrip",
+            CategoryIdentifier = "category",
+            ThreadIdentifier = "thread",
+            Title = "Title",
+            Subtitle = "subtitle",
+            Body = "body",
+            Badge = 2,
+            InterruptionLevel = NotificationInterruptionLevel.Critical,
+            ShowInForeground = true,
+            ForegroundPresentationOption = PresentationOption.Alert,
+        };
+
+        iOSNotificationCenter.ScheduleNotification(notification);
+
+        yield return WaitForNotification(10.0f);
+        Assert.AreEqual(1, receivedNotificationCount);
+        Assert.IsNotNull(lastReceivedNotification);
+        CompareNotifications(notification, lastReceivedNotification);
+    }
+
+    void CompareNotifications(iOSNotification expected, iOSNotification actual)
+    {
+        // these don't roundtrip or are tested separately
+        var ignoredProps = new []
+        {
+            "Attachments",
+            "SoundName",
+            "SoundType",
+            "SoundVolume",
+            "UserInfo",
+        };
+        foreach (var prop in typeof(iOSNotification).GetProperties())
+        {
+            if (ignoredProps.Contains(prop.Name))
+                continue;
+            var v1 = prop.GetValue(expected);
+            var v2 = prop.GetValue(actual);
+            if (prop.PropertyType.IsValueType)
+            {
+                if (prop.PropertyType.IsPrimitive)
+                {
+                    if (prop.PropertyType == typeof(bool))
+                    {
+                        if (!(bool)v2)
+                            Assert.Fail($"Expected property {prop.Name} to be true");
+                    }
+                    else
+                    {
+                        int intVal = (int)v2;
+                        if (intVal == 0)
+                            Assert.Fail($"Expected property {prop.Name} to be non-zero");
+                    }
+                }
+                else if(prop.PropertyType.IsEnum)
+                {
+                    int intVal = (int)v2;
+                    if (intVal == 0)
+                        Assert.Fail($"Expected property {prop.Name} to be non-zero");
+                }
+                else
+                    Assert.Fail($"Property {prop.Name} not handled");
+            }
+            else
+            {
+                if (v2 == null)
+                    Assert.Fail($"Property {prop.Name} value is null");
+            }
+
+            if (!object.Equals(v1, v2))
+                Assert.Fail($"Value missmatch for property {prop.Name}: '{v1}' vs '{v2}'");
+        }
     }
 
     [Test]


### PR DESCRIPTION
https://jira.unity3d.com/browse/MNB-27
Adds two new properties to iOSNotification: InterruptionLevel and RelevanceScore.

Both of these have been introduced in iOS 15, on lower versions they should be ignored.
InterruptionLevel determines if/when notification causes alert (see Apple docs).
RelevanceScore works when sending multiple notifications and collapsing them shows the one with highest score. Apple docs are very non-descriptive for this, I've tried using the same thread id, there's also category that I haven't tried.

Testing required:
- no problems on iOS <15
- all interruption levels work (test project has added button for  low importance)
- check the relevance too, note that when sending multiple notifications with duplicate score it did show unexpectedly for me, but with one notification standing out in score it looked as expected.