### PR TITLE
Android api level cleanup

### DIFF
--- a/com.unity.mobile.notifications/Documentation~/index.md
+++ b/com.unity.mobile.notifications/Documentation~/index.md
@@ -6,6 +6,7 @@ The Unity Mobile Notifications package adds support for scheduling local one-tim
 
 - Compatible with Unity 2020.3 or above.
 - Compatible with Android 5 (API 21) and iOS 10.0+.
+- Requires Android SDK with API level 31 or higher.
 
 ### Supported features
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -31,7 +31,6 @@ import static android.app.Notification.VISIBILITY_PUBLIC;
 
 import java.io.InputStream;
 import java.lang.Integer;
-import java.lang.reflect.Method;
 import java.util.Calendar;
 import java.util.Random;
 import java.util.Set;
@@ -55,8 +54,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
     private ConcurrentHashMap<Integer, Notification.Builder> mScheduledNotifications;
     private NotificationCallback mNotificationCallback;
     private int mExactSchedulingSetting = -1;
-    private Method mSetContentDescription;
-    private Method mShowBigPictureWhenCollapsed;
 
     static final String TAG_UNITY = "UnityNotifications";
 
@@ -939,29 +936,11 @@ public class UnityNotificationManager extends BroadcastReceiver {
         style.setBigContentTitle(extras.getString(KEY_BIG_CONTENT_TITLE));
         style.setSummaryText(extras.getString(KEY_BIG_SUMMARY_TEXT));
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            setBigPictureProps31(style, extras.getString(KEY_BIG_CONTENT_DESCRIPTION), extras.getBoolean(KEY_BIG_SHOW_WHEN_COLLAPSED, false));
+            style.setContentDescription(extras.getString(KEY_BIG_CONTENT_DESCRIPTION));
+            style.showBigPictureWhenCollapsed(extras.getBoolean(KEY_BIG_SHOW_WHEN_COLLAPSED, false));
         }
 
         builder.setStyle(style);
-    }
-
-    private void setBigPictureProps31(Notification.BigPictureStyle style, String contentDesc, boolean showWhenCollapsed) {
-        if (mSetContentDescription == null || mShowBigPictureWhenCollapsed == null) {
-            try {
-                mSetContentDescription = Notification.BigPictureStyle.class.getMethod("setContentDescription", CharSequence.class);
-                mShowBigPictureWhenCollapsed = Notification.BigPictureStyle.class.getMethod("showBigPictureWhenCollapsed", boolean.class);
-            } catch (NoSuchMethodException e) {
-                Log.e(TAG_UNITY, "Failed to find method", e);
-                return;
-            }
-        }
-
-        try {
-            mSetContentDescription.invoke(style, contentDesc);
-            mShowBigPictureWhenCollapsed.invoke(style, showWhenCollapsed);
-        } catch (Exception e) {
-            Log.e(TAG_UNITY, "Failed to call method", e);
-        }
     }
 
     public static void setNotificationColor(Notification.Builder notificationBuilder, int color) {

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -504,14 +504,14 @@ public class UnityNotificationManager extends BroadcastReceiver {
     }
 
     private PendingIntent getActivityPendingIntent(int id, Intent intent, int flags) {
-        if (Build.VERSION.SDK_INT >= 23)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
             return PendingIntent.getActivity(mContext, id, intent, flags | PendingIntent.FLAG_IMMUTABLE);
         else
             return PendingIntent.getActivity(mContext, id, intent, flags);
     }
 
     private PendingIntent getBroadcastPendingIntent(int id, Intent intent, int flags) {
-        if (Build.VERSION.SDK_INT >= 23)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
             return PendingIntent.getBroadcast(mContext, id, intent, flags | PendingIntent.FLAG_IMMUTABLE);
         else
             return PendingIntent.getBroadcast(mContext, id, intent, flags);
@@ -931,7 +931,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         if (picture.charAt(0) == '/') {
             style.bigPicture(BitmapFactory.decodeFile(picture));
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && picture.indexOf("://") > 0) {
-            if (Build.VERSION.SDK_INT >= 31) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 Icon icon = Icon.createWithContentUri(picture);
                 setBigPictureIcon(style, icon);
             } else {
@@ -941,8 +941,8 @@ public class UnityNotificationManager extends BroadcastReceiver {
                 }
             }
         } else {
-            Object pic = getIconFromResources(picture, Build.VERSION.SDK_INT < 31);
-            if (Build.VERSION.SDK_INT >= 31 && pic instanceof Icon)
+            Object pic = getIconFromResources(picture, Build.VERSION.SDK_INT < Build.VERSION_CODES.S);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && pic instanceof Icon)
                 setBigPictureIcon(style, pic);
             else if (pic instanceof Bitmap)
                 style.bigPicture((Bitmap)pic);
@@ -950,7 +950,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
         style.setBigContentTitle(extras.getString(KEY_BIG_CONTENT_TITLE));
         style.setSummaryText(extras.getString(KEY_BIG_SUMMARY_TEXT));
-        if (Build.VERSION.SDK_INT >= 31) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             setBigPictureProps31(style, extras.getString(KEY_BIG_CONTENT_DESCRIPTION), extras.getBoolean(KEY_BIG_SHOW_WHEN_COLLAPSED, false));
         }
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -55,7 +55,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
     private ConcurrentHashMap<Integer, Notification.Builder> mScheduledNotifications;
     private NotificationCallback mNotificationCallback;
     private int mExactSchedulingSetting = -1;
-    private Method mCanScheduleExactAlarms;
     private Method mBigIcon;
     private Method mSetContentDescription;
     private Method mShowBigPictureWhenCollapsed;
@@ -579,17 +578,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         if (Build.VERSION.SDK_INT < 31)
             return true;
 
-        try {
-            if (mCanScheduleExactAlarms == null)
-                mCanScheduleExactAlarms = AlarmManager.class.getMethod("canScheduleExactAlarms");
-            return (boolean)mCanScheduleExactAlarms.invoke(alarmManager);
-        } catch (NoSuchMethodException ex) {
-            Log.e(TAG_UNITY, "No AlarmManager.canScheduleExactAlarms() on Android 31+ device, should not happen", ex);
-            return false;
-        } catch (Exception ex) {
-            Log.e(TAG_UNITY, "AlarmManager.canScheduleExactAlarms() threw", ex);
-            return false;
-        }
+        return alarmManager.canScheduleExactAlarms();
     }
 
     // Call AlarmManager to set the broadcast intent with fire time and interval.

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -55,7 +55,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
     private ConcurrentHashMap<Integer, Notification.Builder> mScheduledNotifications;
     private NotificationCallback mNotificationCallback;
     private int mExactSchedulingSetting = -1;
-    private Method mBigIcon;
     private Method mSetContentDescription;
     private Method mShowBigPictureWhenCollapsed;
 
@@ -922,7 +921,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && picture.indexOf("://") > 0) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 Icon icon = Icon.createWithContentUri(picture);
-                setBigPictureIcon(style, icon);
+                style.bigPicture(icon);
             } else {
                 Bitmap pic = loadBitmap(picture);
                 if (pic != null) {
@@ -932,7 +931,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         } else {
             Object pic = getIconFromResources(picture, Build.VERSION.SDK_INT < Build.VERSION_CODES.S);
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && pic instanceof Icon)
-                setBigPictureIcon(style, pic);
+                style.bigPicture((Icon)pic);
             else if (pic instanceof Bitmap)
                 style.bigPicture((Bitmap)pic);
         }
@@ -944,24 +943,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
         }
 
         builder.setStyle(style);
-    }
-
-    @TargetApi(Build.VERSION_CODES.M)
-    private void setBigPictureIcon(Notification.BigPictureStyle style, Object icon) {
-        if (mBigIcon == null) {
-            try {
-                mBigIcon = Notification.BigPictureStyle.class.getMethod("bigPicture", Icon.class);
-            } catch (NoSuchMethodException e) {
-                Log.e(TAG_UNITY, "Failed to find method bigPicture", e);
-                return;
-            }
-        }
-
-        try {
-            mBigIcon.invoke(style, icon);
-        } catch (Exception e) {
-            Log.e(TAG_UNITY, "Failed to call method bigPicture", e);
-        }
     }
 
     private void setBigPictureProps31(Notification.BigPictureStyle style, String contentDesc, boolean showWhenCollapsed) {


### PR DESCRIPTION
Removes hardcoded numbers and use of reflection from Java code. Also specifies the required API level is documentation.
Unity infrastructure has been updated and API level 31 is now available for all versions. It is also the level new apps must target to be accepted to Google Play, so it looks reasonable to require such SDK when building.

No user visible changes other than API level requirement in this PR. I don't think there is a reason to test anything here (of course it won't hurt to do it).