### PR TITLE
Prevent null exception

### DIFF
--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -739,7 +739,8 @@ public class UnityNotificationManager extends BroadcastReceiver {
         }
 
         try {
-            mNotificationCallback.onSentNotification(notification);
+            if (mNotificationCallback != null)
+                mNotificationCallback.onSentNotification(notification);
         } catch (RuntimeException ex) {
             Log.w(TAG_UNITY, "Can not invoke OnNotificationReceived event when the app is not running!");
         }


### PR DESCRIPTION
Happens when notification happens when app is entirely killed or notification stuff not yet initialized by app, so no callback registered from C#.
try-catch handles it, but better to prevent it from happening at all.