### PR TITLE
Formatting update

### DIFF
--- a/.yamato/format.yml
+++ b/.yamato/format.yml
@@ -5,7 +5,8 @@ check_format:
     image: package-ci/ubuntu:stable
     flavor: b1.small
   commands:
-    - git clone --branch stable git@github.cds.internal.unity3d.com:unity/unity-meta.git
+    - git clone --branch stable git@github.cds.internal.unity3d.com:unity/unity-meta.git --no-checkout
+    - git checkout -C unity-meta 6f6dd71b42f7fd3294032a6c89b1402ef3e46099
     - perl unity-meta/Tools/Format/format.pl --dry-run all
   triggers:
     branches:

--- a/.yamato/format.yml
+++ b/.yamato/format.yml
@@ -7,7 +7,7 @@ check_format:
   commands:
     - git clone --branch stable git@github.cds.internal.unity3d.com:unity/unity-meta.git --no-checkout
     - git -C unity-meta checkout 6f6dd71b42f7fd3294032a6c89b1402ef3e46099
-    - perl unity-meta/Tools/Format/format.pl --dry-run all
+    - perl unity-meta/Tools/Format/format.pl --dry-run .
   triggers:
     branches:
       only:

--- a/.yamato/format.yml
+++ b/.yamato/format.yml
@@ -7,7 +7,7 @@ check_format:
   commands:
     - git clone --branch stable git@github.cds.internal.unity3d.com:unity/unity-meta.git --no-checkout
     - git -C unity-meta checkout 6f6dd71b42f7fd3294032a6c89b1402ef3e46099
-    - perl unity-meta/Tools/Format/format.pl --dry-run .
+    - perl unity-meta/Tools/Format/format.pl --dry-run ./com.unity.mobile.notifications
   triggers:
     branches:
       only:

--- a/.yamato/format.yml
+++ b/.yamato/format.yml
@@ -6,7 +6,7 @@ check_format:
     flavor: b1.small
   commands:
     - git clone --branch stable git@github.cds.internal.unity3d.com:unity/unity-meta.git --no-checkout
-    - git checkout -C unity-meta 6f6dd71b42f7fd3294032a6c89b1402ef3e46099
+    - git -C unity-meta checkout 6f6dd71b42f7fd3294032a6c89b1402ef3e46099
     - perl unity-meta/Tools/Format/format.pl --dry-run all
   triggers:
     branches:

--- a/.yamato/format.yml
+++ b/.yamato/format.yml
@@ -6,7 +6,7 @@ check_format:
     flavor: b1.small
   commands:
     - git clone --branch stable git@github.cds.internal.unity3d.com:unity/unity-meta.git
-    - perl unity-meta/Tools/Format/format.pl --dry-run --hgarg metahash=badf00d --hgarg metabranch=stable ./com.unity.mobile.notifications/Editor ./com.unity.mobile.notifications/Runtime ./com.unity.mobile.notifications/Tests ./TestProjects/Main
+    - perl unity-meta/Tools/Format/format.pl --dry-run all
   triggers:
     branches:
       only:


### PR DESCRIPTION
Two changes here:
- Check format for the whole package
- Use specific version of formatter

Main change is the later. It happened more than once when formatter update actually did minor changes to format and perfectly formatted code became incorrectly formatted. This shouldn't happen, repository should use a specific fixed formatter and consciously update it.