### PR TITLE
GameActivity support

### DIFF
--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -109,7 +109,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
                 PackageManager.DONT_KILL_APP);
         }
 
-        mOpenActivity = UnityNotificationUtilities.getOpenAppActivity(mContext, false);
+        mOpenActivity = UnityNotificationUtilities.getOpenAppActivity(mContext);
         if (mOpenActivity == null)
             throw new RuntimeException("Failed to determine Activity to be opened when tapping notification");
         if (!mBackgroundThread.isAlive())
@@ -705,7 +705,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
                 Class openActivity;
                 if (mOpenActivity == null) {
-                    openActivity = UnityNotificationUtilities.getOpenAppActivity(mContext, true);
+                    openActivity = UnityNotificationUtilities.getOpenAppActivity(mContext);
                     if (openActivity == null) {
                         Log.e(TAG_UNITY, "Activity not found, cannot show notification");
                         return;

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -707,6 +707,10 @@ public class UnityNotificationManager extends BroadcastReceiver {
                 Class openActivity;
                 if (mOpenActivity == null) {
                     openActivity = UnityNotificationUtilities.getOpenAppActivity(mContext, true);
+                    if (openActivity == null) {
+                        Log.e(TAG_UNITY, "Activity not found, cannot show notification");
+                        return;
+                    }
                 }
                 else {
                     openActivity = mOpenActivity;

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -111,8 +111,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
         mOpenActivity = UnityNotificationUtilities.getOpenAppActivity(mContext, false);
         if (mOpenActivity == null)
-            mOpenActivity = activity.getClass();
-
+            throw new RuntimeException("Failed to determine Activity to be opened when tapping notification");
         if (!mBackgroundThread.isAlive())
             mBackgroundThread.start();
     }

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationUtilities.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationUtilities.java
@@ -510,7 +510,7 @@ class UnityNotificationUtilities {
         return null;
     }
 
-    protected static Class<?> getOpenAppActivity(Context context, boolean fallbackToDefault) {
+    protected static Class<?> getOpenAppActivity(Context context) {
         ApplicationInfo ai = null;
         try {
             ai = context.getPackageManager().getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
@@ -532,7 +532,7 @@ class UnityNotificationUtilities {
             }
         }
 
-        if (activityClass == null && fallbackToDefault) {
+        if (activityClass == null) {
             Log.w(TAG_UNITY, "No custom_notification_android_activity found, attempting to find app activity class");
 
             String classToFind = "com.unity3d.player.UnityPlayerActivity";

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationUtilities.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationUtilities.java
@@ -519,14 +519,11 @@ class UnityNotificationUtilities {
         }
         Bundle bundle = ai.metaData;
 
-        String customActivityClassName = null;
         Class activityClass = null;
 
         if (bundle.containsKey("custom_notification_android_activity")) {
-            customActivityClassName = bundle.getString("custom_notification_android_activity");
-
             try {
-                activityClass = Class.forName(customActivityClassName);
+                return Class.forName(bundle.getString("custom_notification_android_activity"));
             } catch (ClassNotFoundException ignored) {
                 ;
             }

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationUtilities.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationUtilities.java
@@ -11,6 +11,7 @@ import android.app.Notification;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.ActivityInfo;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
@@ -510,43 +511,72 @@ class UnityNotificationUtilities {
         return null;
     }
 
+    // Returns Activity class to be opened when notification is tapped
+    // Search is done in this order:
+    //   * class specified in meta-data key custom_notification_android_activity
+    //   * the only enabled activity with name ending in either .UnityPlayerActivity or .UnityPlayerGameActivity
+    //   * the only enabled activity in the package
     protected static Class<?> getOpenAppActivity(Context context) {
-        ApplicationInfo ai = null;
         try {
-            ai = context.getPackageManager().getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
-        } catch (PackageManager.NameNotFoundException e) {
-            e.printStackTrace();
-        }
-        Bundle bundle = ai.metaData;
+            PackageManager pm = context.getPackageManager();
+            ApplicationInfo ai = pm.getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
+            Bundle bundle = ai.metaData;
 
-        Class activityClass = null;
-
-        if (bundle.containsKey("custom_notification_android_activity")) {
-            try {
-                return Class.forName(bundle.getString("custom_notification_android_activity"));
-            } catch (ClassNotFoundException ignored) {
-                ;
-            }
-        }
-
-        if (activityClass == null) {
-            Log.w(TAG_UNITY, "No custom_notification_android_activity found, attempting to find app activity class");
-
-            String classToFind = "com.unity3d.player.UnityPlayerActivity";
-            try {
-                return Class.forName(classToFind);
-            } catch (ClassNotFoundException ignored) {
-                Log.w(TAG_UNITY, String.format("Attempting to find : %s, failed!", classToFind));
-                classToFind = String.format("%s.UnityPlayerActivity", context.getPackageName());
+            if (bundle.containsKey("custom_notification_android_activity")) {
                 try {
-                    return Class.forName(classToFind);
-                } catch (ClassNotFoundException ignored1) {
-                    Log.w(TAG_UNITY, String.format("Attempting to find class based on package name: %s, failed!", classToFind));
+                    return Class.forName(bundle.getString("custom_notification_android_activity"));
+                } catch (ClassNotFoundException e) {
+                    Log.e(TAG_UNITY, "Specified activity class for notifications not found: " + e.getMessage());
                 }
             }
+
+            Log.w(TAG_UNITY, "No custom_notification_android_activity found, attempting to find app activity class");
+
+            ActivityInfo[] aInfo = pm.getPackageInfo(context.getPackageName(), PackageManager.GET_ACTIVITIES).activities;
+            if (aInfo != null) {
+                String activityClassName = null;
+                String conflictingActivity = null;
+                boolean activityConflict = false;
+                for (ActivityInfo info : aInfo) {
+                    // activity alias not supported
+                    if (info.enabled && info.targetActivity == null) {
+                        if (activityClassName == null) {
+                            activityClassName = info.name;
+                        } else if (info.name.endsWith(".UnityPlayerActivity") || info.name.endsWith(".UnityPlayerGameActivity")) {
+                            if (activityClassName.endsWith(".UnityPlayerActivity") || activityClassName.endsWith(".UnityPlayerGameActivity")) {
+                                conflictingActivity = info.name;
+                                activityConflict = true;
+                                break;
+                            }
+
+                            activityClassName = info.name;
+                            activityConflict = false;
+                        } else {
+                            conflictingActivity = info.name;
+                            activityConflict = true;
+                        }
+                    }
+                }
+
+                if (activityConflict) {
+                    Log.e(TAG_UNITY, String.format("Multiple choices for activity for notifications: %s and %s", activityClassName, conflictingActivity));
+                    return null;
+                }
+
+                if (activityClassName == null) {
+                    Log.e(TAG_UNITY, "Activity class for notifications not found");
+                    return null;
+                }
+
+                return Class.forName(activityClassName);
+            }
+        } catch (PackageManager.NameNotFoundException e) {
+            e.printStackTrace();
+        } catch (ClassNotFoundException e) {
+            Log.e(TAG_UNITY, "Failed to find activity class: " + e.getMessage());
         }
 
-        return activityClass;
+        return null;
     }
 
     protected static Notification.Builder recoverBuilder(Context context, Notification notification) {


### PR DESCRIPTION
Support GameActivity. Our notifications open an activity when tapped.
Changes:
- Do not use current activity as an option anymore; this is wrong - it only works as long as you don't kill the app, while for notifications the most essential part is precisely to work well after the app was killed.
- Fail initialization if we cannot determine the activity to open, so user knows in advance that something is wrong.
- If activity to be opened is not explicitly specified by the user, loop over activities in the application and select either the Unity one or the only one, fail if there are multiple choices.

Tested by developer/automation:
- Having either Activity or GameActivity chosen works as expected
- Having both enabled in Player Settings fails initialization logging the exact reason

Testing required:
- Explicitly specify the activity class in notification settings, that one should be used no matter how many other activities you have
- Having extra activities in project should pick the Unity activity, if only one such is present
- When project has only one enabled activity, that one should be used
- Try reschedule after boot
- Hints:
  - Not specific to Android device or version, Unity version only matters for GameActivity part
  - The easiest way to test is to enable both activity types and specifying custom activity for notifications, then export the Android Studio project and play there by modifying manifest in the unityLibrary project and adding activities via IDE (custom activity is in the manifest as meta data)
  - You can enable/disable activities in the manifest, we only care about enabled ones
  - To have no Unity activity, make a class that extends one of Unity activities and use this new class in the manifest instead of Unity one