### PR TITLE
Update android execution image and use choco for unity-downloader-cli

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -63,7 +63,7 @@ test_Android_{{ editor.version }}:
   name: Test {{ editor.version }} on Android
   agent:
     type: Unity::mobile::shield
-    image: mobile/android-execution-base:v0.6.1
+    image: mobile/android-execution-base:v0.7
     flavor: b1.medium
   commands:
     - curl -s {{ utr.url_win }} --output utr.bat

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -63,7 +63,7 @@ test_Android_{{ editor.version }}:
   name: Test {{ editor.version }} on Android
   agent:
     type: Unity::mobile::shield
-    image: mobile/android-execution-base:v0.7
+    image: mobile/android-execution-base:v0.7.0
     flavor: b1.medium
   commands:
     - curl -s {{ utr.url_win }} --output utr.bat

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -67,7 +67,7 @@ test_Android_{{ editor.version }}:
     flavor: b1.medium
   commands:
     - curl -s {{ utr.url_win }} --output utr.bat
-    - pip install unity-downloader-cli --index-url {{ artifactory.production }}pypi/pypi/simple --upgrade
+    - pip install unity-downloader-cli --index-url {{ artifactory.production }}pypi/pypi/simple --upgrade --use-pep517
     - unity-downloader-cli -c Editor -c Android -u {{ editor.version }} --wait --fast
     - utr.bat --testproject=TestProjects\Main --editor-location=.Editor --suite=playmode --platform=android --scripting-backend=il2cpp --architecture=arm64 --artifacts_path=upm-ci~/test-results/android --timeout=900  --extra-editor-arg="-upmNoDefaultPackages" --player-save-path=build/players --build-only
     - |

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -67,8 +67,8 @@ test_Android_{{ editor.version }}:
     flavor: b1.medium
   commands:
     - curl -s {{ utr.url_win }} --output utr.bat
-    - pip install unity-downloader-cli --index-url {{ artifactory.production }}pypi/pypi/simple --upgrade --use-pep517
-    - pipenv run unity-downloader-cli -c Editor -c Android -u {{ editor.version }} --wait --fast
+    - gsudo choco install unity-downloader-cli -y -s https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/unity-choco-local
+    - unity-downloader-cli -c Editor -c Android -u {{ editor.version }} --wait --fast
     - utr.bat --testproject=TestProjects\Main --editor-location=.Editor --suite=playmode --platform=android --scripting-backend=il2cpp --architecture=arm64 --artifacts_path=upm-ci~/test-results/android --timeout=900  --extra-editor-arg="-upmNoDefaultPackages" --player-save-path=build/players --build-only
     - |
        set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -68,7 +68,7 @@ test_Android_{{ editor.version }}:
   commands:
     - curl -s {{ utr.url_win }} --output utr.bat
     - pip install unity-downloader-cli --index-url {{ artifactory.production }}pypi/pypi/simple --upgrade --use-pep517
-    - unity-downloader-cli -c Editor -c Android -u {{ editor.version }} --wait --fast
+    - pipenv run unity-downloader-cli -c Editor -c Android -u {{ editor.version }} --wait --fast
     - utr.bat --testproject=TestProjects\Main --editor-location=.Editor --suite=playmode --platform=android --scripting-backend=il2cpp --architecture=arm64 --artifacts_path=upm-ci~/test-results/android --timeout=900  --extra-editor-arg="-upmNoDefaultPackages" --player-save-path=build/players --build-only
     - |
        set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%


### PR DESCRIPTION
Use updated android-execution-base image that uses windows 21h1 version instead of 20h1. This unblocks the download of unity-downloader-cli via pip, but using choco is more reliable, as it sets PATH correctly.