### PR TITLE
Android proguard seetings

### DIFF
--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this package will be documented in this file.
 - [Android] - Icons now support local files and URIs.
 - [Android] - Added API to check if UI with permission rationale for notifications should be shown before requesting permission.
 - [Android] - Added APIs to request exact scheduling and bupasssing battery optimizations.
+- [Android] - Minification seetings now managed automatically by package.
 - [iOS] - Added support for notification action icons (requires iOS 15).
 - [iOS] - Added property to set interruption level (requires iOS 15).
 - [iOS] - Added property to set relevance score (requires iOS 15).

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -57,23 +57,23 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
     static final String TAG_UNITY = "UnityNotifications";
 
-    static final String KEY_FIRE_TIME = "fireTime";
-    static final String KEY_ID = "id";
-    static final String KEY_INTENT_DATA = "data";
-    static final String KEY_LARGE_ICON = "largeIcon";
-    static final String KEY_REPEAT_INTERVAL = "repeatInterval";
-    static final String KEY_NOTIFICATION = "unityNotification";
-    static final String KEY_NOTIFICATION_ID = "com.unity.NotificationID";
-    static final String KEY_SMALL_ICON = "smallIcon";
-    static final String KEY_CHANNEL_ID = "channelID";
-    static final String KEY_SHOW_IN_FOREGROUND = "com.unity.showInForeground";
-    static final String KEY_NOTIFICATION_DISMISSED = "com.unity.NotificationDismissed";
-    static final String KEY_BIG_LARGE_ICON = "com.unity.BigLargeIcon";
-    static final String KEY_BIG_PICTURE = "com.unity.BigPicture";
-    static final String KEY_BIG_CONTENT_TITLE = "com.unity.BigContentTytle";
-    static final String KEY_BIG_SUMMARY_TEXT = "com.unity.BigSummaryText";
-    static final String KEY_BIG_CONTENT_DESCRIPTION = "com.unity.BigContentDescription";
-    static final String KEY_BIG_SHOW_WHEN_COLLAPSED = "com.unity.BigShowWhenCollapsed";
+    public static final String KEY_FIRE_TIME = "fireTime";
+    public static final String KEY_ID = "id";
+    public static final String KEY_INTENT_DATA = "data";
+    public static final String KEY_LARGE_ICON = "largeIcon";
+    public static final String KEY_REPEAT_INTERVAL = "repeatInterval";
+    public static final String KEY_NOTIFICATION = "unityNotification";
+    public static final String KEY_NOTIFICATION_ID = "com.unity.NotificationID";
+    public static final String KEY_SMALL_ICON = "smallIcon";
+    public static final String KEY_CHANNEL_ID = "channelID";
+    public static final String KEY_SHOW_IN_FOREGROUND = "com.unity.showInForeground";
+    public static final String KEY_NOTIFICATION_DISMISSED = "com.unity.NotificationDismissed";
+    public static final String KEY_BIG_LARGE_ICON = "com.unity.BigLargeIcon";
+    public static final String KEY_BIG_PICTURE = "com.unity.BigPicture";
+    public static final String KEY_BIG_CONTENT_TITLE = "com.unity.BigContentTytle";
+    public static final String KEY_BIG_SUMMARY_TEXT = "com.unity.BigSummaryText";
+    public static final String KEY_BIG_CONTENT_DESCRIPTION = "com.unity.BigContentDescription";
+    public static final String KEY_BIG_SHOW_WHEN_COLLAPSED = "com.unity.BigShowWhenCollapsed";
 
     static final String NOTIFICATION_CHANNELS_SHARED_PREFS = "UNITY_NOTIFICATIONS";
     static final String NOTIFICATION_CHANNELS_SHARED_PREFS_KEY = "ChannelIDs";

--- a/com.unity.mobile.notifications/Tests/Editor/PostprocessorTests.cs
+++ b/com.unity.mobile.notifications/Tests/Editor/PostprocessorTests.cs
@@ -204,6 +204,30 @@ namespace Unity.Notifications.Tests
             Assert.IsFalse(xmlDoc.InnerXml.Contains(permission));
         }
 
+        static readonly string[] kProguardContents = new[]
+        {
+            "-keep class bitter.jnibridge.* { *; }",
+            "-keep class com.unity3d.player.* { *; }",
+            "-keep class org.fmod.* { *; }",
+        };
+
+        [Test]
+        public void InjectProguard_WhenMissing_AddsNotifications()
+        {
+            string[] result;
+            bool ret = AndroidNotificationPostProcessor.InjectProguard(kProguardContents, out result);
+
+            Assert.IsTrue(ret);
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result[result.Length - 1].Contains("com.unity.androidnotifications.UnityNotificationManager"));
+
+            // try again, now should not modify
+            string[] res2;
+            ret = AndroidNotificationPostProcessor.InjectProguard(result, out res2);
+            Assert.IsFalse(ret);
+            Assert.IsNull(res2);
+        }
+
 #endif
     }
 }

--- a/com.unity.mobile.notifications/Tests/Editor/PostprocessorTests.cs
+++ b/com.unity.mobile.notifications/Tests/Editor/PostprocessorTests.cs
@@ -214,18 +214,17 @@ namespace Unity.Notifications.Tests
         [Test]
         public void InjectProguard_WhenMissing_AddsNotifications()
         {
-            string[] result;
-            bool ret = AndroidNotificationPostProcessor.InjectProguard(kProguardContents, out result);
+            string[] result = kProguardContents;
+            bool ret = AndroidNotificationPostProcessor.InjectProguard(ref result);
 
             Assert.IsTrue(ret);
             Assert.IsNotNull(result);
-            Assert.IsTrue(result[result.Length - 1].Contains("com.unity.androidnotifications.UnityNotificationManager"));
+            Assert.IsTrue(result[result.Length - 2].Contains("com.unity.androidnotifications.UnityNotificationManager"));
+            Assert.IsTrue(result[result.Length - 1].Contains("com.unity.androidnotifications.NotificationCallback"));
 
             // try again, now should not modify
-            string[] res2;
-            ret = AndroidNotificationPostProcessor.InjectProguard(result, out res2);
+            ret = AndroidNotificationPostProcessor.InjectProguard(ref result);
             Assert.IsFalse(ret);
-            Assert.IsNull(res2);
         }
 
 #endif


### PR DESCRIPTION
https://jira.unity3d.com/browse/MNB-38
Add proguard settings for notifications during post process. Otherwise if you enabled minification in player settings, notifications will not work because Java code will be obfuscated. The convention currently is to make stuff used from C# public, some constants are made such as a result.

To test: enable minification in Player Settings publishing section and try both release and development builds. Take a random sample of actions in Main test project. All should work as expected. Not specific to Unity version nor device nor Android version, but as two runs are required, probably good idea to do them on different Unity versions.