### PR TITLE
Android notification update fix

### DIFF
--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this package will be documented in this file.
 - [iOS] - Added property to set interruption level (requires iOS 15).
 - [iOS] - Added property to set relevance score (requires iOS 15).
 
+### Fixes:
+- [Android] - Fix updating scheduled notification not updating if app is not killed.
+
 ## [2.1.1] - 2023-01-04
 
 ### Fixes:

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -995,7 +995,7 @@ namespace Unity.Notifications.Android
             {
                 using (var builder = CreateNotificationBuilder(id, notification, channelId))
                 {
-                    SendNotification(builder);
+                    ScheduleNotification(builder, false);
                 }
             }
         }

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -403,7 +403,8 @@ public class UnityNotificationManager extends BroadcastReceiver {
         // fireTime not taken from notification, because we may have adjusted it
 
         // when rescheduling after boot notification may be absent
-        mScheduledNotifications.putIfAbsent(Integer.valueOf(id), notificationBuilder);
+        // also, we may be replacing an existing notification
+        mScheduledNotifications.put(Integer.valueOf(id), notificationBuilder);
         intent.putExtra(KEY_NOTIFICATION_ID, id);
 
         PendingIntent broadcast = getBroadcastPendingIntent(id, intent, PendingIntent.FLAG_UPDATE_CURRENT);

--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
@@ -429,4 +429,22 @@ class AndroidNotificationSendingTests
         Assert.AreEqual("summary", bigPictureData.SummaryText);
         Assert.IsTrue(bigPictureData.ShowWhenCollapsed);
     }
+
+    [UnityTest]
+    [UnityPlatform(RuntimePlatform.Android)]
+    public IEnumerator SendAndReplaceNotification()
+    {
+        var original = new AndroidNotification("NotificationToBeReplaced", "This should be replaced", DateTime.Now.AddSeconds(5));
+        int id = AndroidNotificationCenter.SendNotification(original, kDefaultTestChannel);
+        yield return new WaitForSeconds(1);
+
+        var replacement = new AndroidNotification("ReplacementNotification", "Replacement text", DateTime.Now.AddSeconds(3));
+        AndroidNotificationCenter.UpdateScheduledNotification(id, replacement, kDefaultTestChannel);
+        yield return WaitForNotification(8.0f);
+
+        Assert.AreEqual(1, currentHandler.receivedNotificationCount);
+        var received = currentHandler.lastNotification.Notification;
+        Assert.AreEqual(replacement.Title, received.Title);
+        Assert.AreEqual(replacement.Text, received.Text);
+    }
 }


### PR DESCRIPTION
https://jira.unity3d.com/browse/MNB-41
Fix notification update for the case where app is not killed completely.
Also a minor fix where notification update was regarded as user customized, when it actually wasn't and was using more expensive serialization as a result.

There are two manual tests for this feature in Main test project:
- schedule notification with explicit id and press update button before it arrives -> you should get a notification with text telling that it was updated (without clicking the update button notification should show it's id)
- When updated notification is present in taskbar, scheduling the explicit id one again should replace the existing notification in taskbar.
The changes are not specific to Android version nor Unity version nor device.