### PR TITLE
Fix activity conflict when first activity is Unity

### DIFF
--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationUtilities.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationUtilities.java
@@ -539,24 +539,32 @@ class UnityNotificationUtilities {
             }
 
             String activityClassName = null;
-            boolean activityConflict = false;
+            boolean activityIsUnity = false, activityConflict = false;
             for (ActivityInfo info : aInfo) {
                 // activity alias not supported
                 if (!info.enabled || info.targetActivity != null)
                     continue;
 
+                boolean candidateIsUnity = isUnityActivity(info.name);
                 if (activityClassName == null) {
                     activityClassName = info.name;
-                } else if (isUnityActivity(info.name)) {
-                    if (isUnityActivity(activityClassName)) {
-                        activityConflict = true;
-                        break;
-                    }
+                    activityIsUnity = candidateIsUnity;
+                    continue;
+                }
 
-                    activityClassName = info.name;
-                    activityConflict = false;
-                } else {
+                // two Unity activities is a hard conflict
+                // two non-Unity activities is a conflict unless we find a Unity activity later on
+                if (activityIsUnity == candidateIsUnity) {
                     activityConflict = true;
+                    if (activityIsUnity && candidateIsUnity)
+                        break;
+                    continue;
+                }
+
+                if (candidateIsUnity) {
+                    activityClassName = info.name;
+                    activityIsUnity = candidateIsUnity;
+                    activityConflict = false;
                 }
             }
 


### PR DESCRIPTION
A corner case was missed when determining activity for notifications: if you have multiple activities and Unity activity is not the last of them, our code treats this as conflict, when it shouldn't be.
AndroidBixPicture project has this problem out of the box.

Test cases:
- If activity is specified in Notification Settings, it should be used and not of the following cases should happen; when activity is not specified in settings the following cases do apply.
- Both Activity and GameActivity enabled - activity conflict
- No Unity activity, multiple activities - activity conflict
- Either Activity or GameActivity enabled, multiple activities - Unity activity is used
- Single activity - it is used regardless if it's Unity or not.
Changes are not specific to Android nor Unity version nor device.
The easiest way to test is to export Android Studio project and add activities there and manipulate the manifest manually. For the case of "no unity activities" write your own class that extends any of two Unity activities and modify manifest to use it instead of Unity activity.