### PR TITLE
Android: report if notifications are enabled

### DIFF
--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this package will be documented in this file.
 - [Android] - Added API to check if UI with permission rationale for notifications should be shown before requesting permission.
 - [Android] - Added APIs to request exact scheduling and bupasssing battery optimizations.
 - [Android] - Minification seetings now managed automatically by package.
+- [Android] - AndroidNotificationCenter.UserPermissionToPost now will also report if notifications are blocked in Settings (Android 7+).
 - [iOS] - Added support for notification action icons (requires iOS 15).
 - [iOS] - Added property to set interruption level (requires iOS 15).
 - [iOS] - Added property to set relevance score (requires iOS 15).

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -289,6 +289,11 @@ namespace Unity.Notifications.Android
         {
             return self.Call<bool>("canScheduleExactAlarms");
         }
+
+        public PermissionStatus AreNotificationsEnabled()
+        {
+            return (PermissionStatus)self.Call<int>("areNotificationsEnabled");
+        }
     }
 
     struct NotificationJni
@@ -674,8 +679,8 @@ namespace Unity.Notifications.Android
                     return PermissionStatus.Allowed;
 
                 var permissionStatus = (PermissionStatus)PlayerPrefs.GetInt(SETTING_POST_NOTIFICATIONS_PERMISSION, (int)PermissionStatus.NotRequested);
-                var allowed = Permission.HasUserAuthorizedPermission(PERMISSION_POST_NOTIFICATIONS);
-                if (allowed)
+                var enableStatus = s_Jni.NotificationManager.AreNotificationsEnabled();
+                if (enableStatus == PermissionStatus.Allowed)
                 {
                     if (permissionStatus != PermissionStatus.Allowed)
                         SetPostPermissionSetting(PermissionStatus.Allowed);

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -600,6 +600,7 @@ namespace Unity.Notifications.Android
     /// </summary>
     public class AndroidNotificationCenter
     {
+        private static int API_NOTIFICATIONS_CAN_BE_BLOCKED = 24;
         private static int API_POST_NOTIFICATIONS_PERMISSION_REQUIRED = 33;
         internal static string PERMISSION_POST_NOTIFICATIONS = "android.permission.POST_NOTIFICATIONS";
 
@@ -667,7 +668,7 @@ namespace Unity.Notifications.Android
 
         /// <summary>
         /// Has user given permission to post notifications.
-        /// Before Android 13 (API 33) no permission is required.
+        /// Before Android 13 (API 33) no permission is required, but user can disable notifications in the Settings since Android 7 (API 24).
         /// </summary>
         public static PermissionStatus UserPermissionToPost
         {
@@ -675,17 +676,20 @@ namespace Unity.Notifications.Android
             {
                 if (!Initialize())
                     return PermissionStatus.Denied;
-                if (s_DeviceApiLevel < API_POST_NOTIFICATIONS_PERMISSION_REQUIRED)
+                if (s_DeviceApiLevel < API_NOTIFICATIONS_CAN_BE_BLOCKED)
                     return PermissionStatus.Allowed;
 
                 var permissionStatus = (PermissionStatus)PlayerPrefs.GetInt(SETTING_POST_NOTIFICATIONS_PERMISSION, (int)PermissionStatus.NotRequested);
                 var enableStatus = s_Jni.NotificationManager.AreNotificationsEnabled();
                 if (enableStatus == PermissionStatus.Allowed)
                 {
-                    if (permissionStatus != PermissionStatus.Allowed)
+                    // only save to settings on devices where runtime permission exists
+                    if (s_DeviceApiLevel >= API_POST_NOTIFICATIONS_PERMISSION_REQUIRED && permissionStatus != PermissionStatus.Allowed)
                         SetPostPermissionSetting(PermissionStatus.Allowed);
                     return PermissionStatus.Allowed;
                 }
+                else if (enableStatus == PermissionStatus.NotificationsBlockedForApp)
+                    return enableStatus;
 
                 switch (permissionStatus)
                 {

--- a/com.unity.mobile.notifications/Runtime/Android/NotificationPermission.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/NotificationPermission.cs
@@ -31,6 +31,12 @@ namespace Unity.Notifications.Android
         /// A request for permission was made and user hasn't responded yet.
         /// </summary>
         RequestPending = 4,
+
+        /// <summary>
+        /// Notifications are blocked for this app. Before API level 33 this means they were disabled in Settings.
+        /// <see cref="https://developer.android.com/reference/android/app/NotificationManager#areNotificationsEnabled()"/>
+        /// </summary>
+        NotificationsBlockedForApp = 5,
     }
 
     /// <summary>

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -1,5 +1,6 @@
 package com.unity.androidnotifications;
 
+import android.Manifest;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.ActivityManager;
@@ -55,6 +56,8 @@ public class UnityNotificationManager extends BroadcastReceiver {
     private NotificationCallback mNotificationCallback;
     private int mExactSchedulingSetting = -1;
 
+    private static final int PERMISSION_STATUS_ALLOWED = 1;
+    private static final int PERMISSION_STATUS_DENIED = 2;
     static final String TAG_UNITY = "UnityNotifications";
 
     public static final String KEY_FIRE_TIME = "fireTime";
@@ -152,6 +155,15 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
     public int getTargetSdk() {
         return mContext.getApplicationInfo().targetSdkVersion;
+    }
+
+    public int areNotificationsEnabled() {
+        boolean permissionGranted = true;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+            permissionGranted = mContext.checkCallingOrSelfPermission(Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED;
+        if (!permissionGranted)
+            return PERMISSION_STATUS_DENIED;
+        return PERMISSION_STATUS_ALLOWED;
     }
 
     public void registerNotificationChannelGroup(String id, String name, String description) {

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -58,6 +58,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
     private static final int PERMISSION_STATUS_ALLOWED = 1;
     private static final int PERMISSION_STATUS_DENIED = 2;
+    private static final int PERMISSION_STATUS_NOTIFICATIONS_BLOCKED_FOR_APP = 5;
     static final String TAG_UNITY = "UnityNotifications";
 
     public static final String KEY_FIRE_TIME = "fireTime";
@@ -157,13 +158,15 @@ public class UnityNotificationManager extends BroadcastReceiver {
         return mContext.getApplicationInfo().targetSdkVersion;
     }
 
+    @TargetApi(Build.VERSION_CODES.N)
     public int areNotificationsEnabled() {
         boolean permissionGranted = true;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
             permissionGranted = mContext.checkCallingOrSelfPermission(Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED;
-        if (!permissionGranted)
-            return PERMISSION_STATUS_DENIED;
-        return PERMISSION_STATUS_ALLOWED;
+        boolean notificationsEnabled = getNotificationManager().areNotificationsEnabled();
+        if (permissionGranted)
+            return notificationsEnabled ? PERMISSION_STATUS_ALLOWED : PERMISSION_STATUS_NOTIFICATIONS_BLOCKED_FOR_APP;
+        return PERMISSION_STATUS_DENIED;
     }
 
     public void registerNotificationChannelGroup(String id, String name, String description) {


### PR DESCRIPTION
https://jira.unity3d.com/browse/MNB-43
On Android 7+ notifications can be disabled per app. Right now we have AndroidNotificationCenter.UserPermissionToPost, but it only report if permission is enabled, which is Android 13+.
This PR adds one more enum value for disabled notifications and reports that on Android 7+. On even older Android versions it should be always enabled.
Note: looks like there is no such thing as disabled notifications in Android 13, it simply revokes the permission.

The Main test project prints permission status each time when gaining focus and there is a button to open settings. Please do try Android version <7 if nothing bad happens!