### PR TITLE
Documentation fixes

### DIFF
--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotification.cs
@@ -50,8 +50,8 @@ namespace Unity.Notifications.Android
     /// <summary>
     /// Data for setting up the big picture style notification.
     /// Properties that are not available in devices API level are ignored. See Android documentation for availibility.
+    /// <see href="https://developer.android.com/reference/android/app/Notification.BigPictureStyle"/>
     /// </summary>
-    /// <see cref="https://developer.android.com/reference/android/app/Notification.BigPictureStyle"/>
     public struct BigPictureStyle
     {
         /// <summary>

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -600,8 +600,8 @@ namespace Unity.Notifications.Android
 
         /// <summary>
         /// A PlayerPrefs key used to save users reply to POST_NOTIFICATIONS request (integer value of the PermissionStatus).
+        /// Value is one of <see cref="PermissionStatus"/>
         /// </summary>
-        /// <see cref="PermissionStatus"/>
         public static string SETTING_POST_NOTIFICATIONS_PERMISSION = "com.unity.androidnotifications.PostNotificationsPermission";
 
         /// <summary>

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
@@ -35,8 +35,8 @@ namespace Unity.Notifications.iOS
     /// <summary>
     /// The type of sound to use for the notification.
     /// See Apple documentation for details.
-    /// </summary>
     /// <see href="https://developer.apple.com/documentation/usernotifications/unnotificationsound?language=objc"/>
+    /// </summary>
     public enum NotificationSoundType
     {
         /// <summary>
@@ -63,8 +63,8 @@ namespace Unity.Notifications.iOS
     /// <summary>
     /// Importance and delivery timing of a notification.
     /// See Apple documentation for details. Available since iOS 15, always Active on lower versions.
+    /// <see href="https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel?language=objc"/>
     /// </summary>
-    /// <see cref="https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel?language=objc"/>
     public enum NotificationInterruptionLevel
     {
         /// <summary>
@@ -218,8 +218,8 @@ namespace Unity.Notifications.iOS
         /// <summary>
         /// The message displayed in the notification alert.
         /// See Apple's documentation for details.
-        /// </summary>
         /// <see href="https://developer.apple.com/documentation/usernotifications/unnotificationcontent/1649863-body"/>
+        /// </summary>
         public string Body
         {
             get { return data.body; }
@@ -299,8 +299,8 @@ namespace Unity.Notifications.iOS
         /// <summary>
         /// The volume for the sound. Use null to use the default volume.
         /// See Apple documentation for supported values.
-        /// </summary>
         /// <see href="https://developer.apple.com/documentation/usernotifications/unnotificationsound/2963118-defaultcriticalsoundwithaudiovol?language=objc"/>
+        /// </summary>
         public float? SoundVolume { get; set; }
 
         /// <summary>
@@ -314,8 +314,8 @@ namespace Unity.Notifications.iOS
 
         /// <summary>
         /// The score the system uses to determine if the notification is the summary’s featured notification.
+        /// <see href="https://developer.apple.com/documentation/usernotifications/unnotificationcontent/3821031-relevancescore?language=objc"/>
         /// </summary>
-        /// <see cref="https://developer.apple.com/documentation/usernotifications/unnotificationcontent/3821031-relevancescore?language=objc"/>
         public double RelevanceScore
         {
             get { return data.relevanceScore; }
@@ -348,8 +348,8 @@ namespace Unity.Notifications.iOS
         /// <summary>
         /// A list of notification attachments.
         /// Notification attachments can be images, audio or video files. Refer to Apple documentation on supported formats.
+        /// <see href="https://developer.apple.com/documentation/usernotifications/unmutablenotificationcontent/1649857-attachments?language=objc"/>
         /// </summary>
-        /// <see cref="https://developer.apple.com/documentation/usernotifications/unmutablenotificationcontent/1649857-attachments?language=objc"/>
         public List<iOSNotificationAttachment> Attachments { get; set; }
 
         /// <summary>

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationAction.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationAction.cs
@@ -5,8 +5,8 @@ namespace Unity.Notifications.iOS
     /// <summary>
     /// Options for notification actions.
     /// These represent values from UNNotificationActionOptions.
+    /// <see href="https://developer.apple.com/documentation/usernotifications/unnotificationactionoptions"/>
     /// </summary>
-    /// <see cref="https://developer.apple.com/documentation/usernotifications/unnotificationactionoptions"/>
     [Flags]
     public enum iOSNotificationActionOptions
     {
@@ -51,14 +51,14 @@ namespace Unity.Notifications.iOS
         /// <summary>
         /// Options for the action. Can be a combination of given flags.
         /// Refer to Apple documentation for UNNotificationActionOptions for exact meanings.
+        /// <see href="https://developer.apple.com/documentation/usernotifications/unnotificationactionoptions"/>
         /// </summary>
-        /// <see cref="https://developer.apple.com/documentation/usernotifications/unnotificationactionoptions"/>
         public iOSNotificationActionOptions Options { get; set; }
 
         /// <summary>
         /// Set the icon for action using system symbol image name.
+        /// <see href="https://developer.apple.com/documentation/usernotifications/unnotificationactionicon/3747241-iconwithsystemimagename?language=objc"/>
         /// </summary>
-        /// <see cref="https://developer.apple.com/documentation/usernotifications/unnotificationactionicon/3747241-iconwithsystemimagename?language=objc"/>
         public string SystemImageName
         {
             get { return _imageType == iOSNotificationActionIconType.SystemImageName ? _image : null; }
@@ -71,8 +71,8 @@ namespace Unity.Notifications.iOS
 
         /// <summary>
         /// Set the icon for action using image from app's bundle.
+        /// <see href="https://developer.apple.com/documentation/usernotifications/unnotificationactionicon/3747242-iconwithtemplateimagename?language=objc"/>
         /// </summary>
-        /// <see cref="https://developer.apple.com/documentation/usernotifications/unnotificationactionicon/3747242-iconwithtemplateimagename?language=objc"/>
         public string TemplateImageName
         {
             get { return _imageType == iOSNotificationActionIconType.TemplateImageName ? _image : null; }

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationAttachment.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationAttachment.cs
@@ -3,8 +3,8 @@ namespace Unity.Notifications.iOS
     /// <summary>
     /// Notification attachment.
     /// Refer to Apple documentation for details.
+    /// <see href="https://developer.apple.com/documentation/usernotifications/unnotificationattachment?language=objc"/>
     /// </summary>
-    /// <see cref="https://developer.apple.com/documentation/usernotifications/unnotificationattachment?language=objc"/>
     public struct iOSNotificationAttachment
     {
         /// <summary>

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCategory.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCategory.cs
@@ -6,8 +6,8 @@ namespace Unity.Notifications.iOS
     /// <summary>
     /// Options for notification category. Multiple options can be combined.
     /// These represent values from UNNotificationCategoryOptions.
+    /// <see href="https://developer.apple.com/documentation/usernotifications/unnotificationcategoryoptions"/>
     /// </summary>
-    /// <see cref="https://developer.apple.com/documentation/usernotifications/unnotificationcategoryoptions"/>
     [Flags]
     public enum iOSNotificationCategoryOptions
     {
@@ -23,7 +23,7 @@ namespace Unity.Notifications.iOS
     /// Notification categories need to be registered on application start to be useful.
     /// By adding actions to category, you make all notification sent with this category identifier actionable.
     /// </summary>
-    /// <see cref="iOSNotification.CategoryIdentifier"/>
+    /// <seealso cref="iOSNotification.CategoryIdentifier"/>
     /// <seealso cref="https://developer.apple.com/documentation/usernotifications/unnotificationcategory"/>
     public class iOSNotificationCategory
     {
@@ -37,26 +37,26 @@ namespace Unity.Notifications.iOS
 
         /// <summary>
         /// Get actions set for this category.
+        /// For more info see <see cref="iOSNotificationAction"/>.
         /// </summary>
-        /// <see cref="iOSNotificationAction"/>
         public iOSNotificationAction[] Actions { get { return m_Actions.ToArray(); } }
 
         /// <summary>
         /// Intent identifiers set for this category.
+        /// <see href="https://developer.apple.com/documentation/usernotifications/unnotificationcategory/1649282-intentidentifiers"/>
         /// </summary>
-        /// <see cref="https://developer.apple.com/documentation/usernotifications/unnotificationcategory/1649282-intentidentifiers"/>
         public string[] IntentIdentifiers { get { return m_IntentIdentifiers.ToArray(); } }
 
         /// <summary>
         /// The placeholder text to display when the system disables notification previews for the app.
+        /// <see href="https://developer.apple.com/documentation/usernotifications/unnotificationcategory/2873736-hiddenpreviewsbodyplaceholder"/>
         /// </summary>
-        /// <see cref="https://developer.apple.com/documentation/usernotifications/unnotificationcategory/2873736-hiddenpreviewsbodyplaceholder"/>
         public string HiddenPreviewsBodyPlaceholder { get; set; }
 
         /// <summary>
         /// A format string for the summary description used when the system groups the category’s notifications.
+        /// <see href="https://developer.apple.com/documentation/usernotifications/unnotificationcategory/2963112-categorysummaryformat"/>
         /// </summary>
-        /// <see cref="https://developer.apple.com/documentation/usernotifications/unnotificationcategory/2963112-categorysummaryformat"/>
         public string SummaryFormat { get; set; }
 
         /// <summary>


### PR DESCRIPTION
A bunch of <see> tags are missplaced in API docs and have incorrect attribute for external links.