### PR TITLE
Fix doc comment for icon placement

### DIFF
--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotification.cs
@@ -107,7 +107,8 @@ namespace Unity.Notifications.Android
         /// <summary>
         /// Notification small icon.
         /// It will be used to represent the notification in the status bar and content view (unless overridden there by a large icon)
-        /// The icon PNG file has to be placed in the `/Assets/Plugins/Android/res/drawable` folder and it's name has to be specified without the extension.
+        /// The icon has to be registered in Notification Settings or a PNG file has to be placed in the `res/drawable` folder of the Android library plugin
+        /// and it's name has to be specified without the extension.
         /// Alternatively it can also be URI supported by the OS.
         /// </summary>
         public string SmallIcon { get; set; }
@@ -130,7 +131,8 @@ namespace Unity.Notifications.Android
         /// <summary>
         /// Notification large icon.
         /// Add a large icon to the notification content view. This image will be shown on the left of the notification view in place of the small icon (which will be placed in a small badge atop the large icon).
-        /// The icon PNG file has to be placed in the `/Assets/Plugins/Android/res/drawable folder` and it's name has to be specified without the extension.
+        /// The icon has to be registered in Notification Settings or a PNG file has to be placed in the `res/drawable` folder of the Android library plugin
+        /// and it's name has to be specified without the extension.
         /// Alternatively it can be a file path or system supported URI.
         /// </summary>
         public string LargeIcon { get; set; }


### PR DESCRIPTION
The support for res folder in Plugins/Android has been removed for quite some time. Update the API docs to point to Notification Settings (still mentioning res folder in Android library for more advanced users).