### PR TITLE
Fix test project showinforeground

### DIFF
--- a/TestProjects/Main/Assets/Scripts/AndroidTest.cs
+++ b/TestProjects/Main/Assets/Scripts/AndroidTest.cs
@@ -163,7 +163,7 @@ namespace Unity.Notifications.Tests.Sample
                 IntentData = template.IntentData,
                 ShowTimestamp = template.ShowTimestamp,
                 RepeatInterval = TimeSpan.FromSeconds(template.RepeatInterval),
-                //ShowInForeground = template.ShowInForeground
+                ShowInForeground = template.ShowInForeground
             };
             return newNotification;
         }

--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this package will be documented in this file.
 
+## [Unreleased]
+
+### Changes & Improvements:
+
+### Fixes:
+
 ## [2.2.0] - 2023-04-06
 
 ### Changes & Improvements:


### PR DESCRIPTION
A mistake in past change left one line in test project commented out breaking the not shown in foreground notification.
No real changes to the packages, just to the test project.