### PR TITLE
Version control friendly settings

### DIFF
--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this package will be documented in this file.
 
 ### Fixes:
 
+- Changing settings will make settings file editable if read-only by version control.
+
 ## [2.2.0] - 2023-04-06
 
 ### Changes & Improvements:

--- a/com.unity.mobile.notifications/Documentation~/index.md
+++ b/com.unity.mobile.notifications/Documentation~/index.md
@@ -6,7 +6,7 @@ The Unity Mobile Notifications package adds support for scheduling local one-tim
 
 - Compatible with Unity 2020.3 or above.
 - Compatible with Android 5 (API 21) and iOS 10.0+.
-- Requires Android SDK with API level 31 or higher.
+- Requires Android SDK with API level 33 or higher.
 - Requires Xcode with SDK for iOS 15.2 or newer.
 
 ### Supported features

--- a/com.unity.mobile.notifications/Editor/NotificationSettingsManager.cs
+++ b/com.unity.mobile.notifications/Editor/NotificationSettingsManager.cs
@@ -251,7 +251,10 @@ namespace Unity.Notifications
             if (!forceSave && File.Exists(k_SettingsPath))
                 return;
 
-            File.WriteAllText(k_SettingsPath, EditorJsonUtility.ToJson(this, true));
+            if (AssetDatabase.MakeEditable(k_SettingsPath))
+                File.WriteAllText(k_SettingsPath, EditorJsonUtility.ToJson(this, true));
+            else
+                Debug.LogError($"Failed to make file {k_SettingsPath} editable");
         }
 
         public void AddDrawableResource(string id, Texture2D image, NotificationIconType type)


### PR DESCRIPTION
https://jira.unity3d.com/browse/MNB-52
Some version control systems (f.e. Perforce) keep files read-only and you have to check them out before editing. Currently mobile notifications don't handle this and modifying settings will fail.
This PR makes it use Editor API to make file editable in a VCS friendly way.
A small unrelated change is Android SDK requirement to compile the code.