### PR TITLE
Deserialize on background thread

### DIFF
--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -5,8 +5,10 @@ All notable changes to this package will be documented in this file.
 ## [Unreleased]
 
 ### Changes & Improvements:
+- [Android] - Reschedule after reboot will send all notifications that expired less than 10 minutes ago.
 
 ### Fixes:
+- [Android] - [issue 271](https://github.com/Unity-Technologies/com.unity.mobile.notifications/issues/271) Fix possible ANR when sending/rescheduling after reboot.
 
 ## [2.2.1] - 2023-07-17
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -719,36 +719,39 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
         Notification notif = null;
         int id = -1;
-        boolean sendable = notification instanceof Notification;
-        if (sendable) {
+        if (notification instanceof Notification) {
             notif = (Notification) notification;
             id = notif.extras.getInt(KEY_ID, -1);
-        } else {
-            Notification.Builder builder = (Notification.Builder)notification;
-            // this is different instance and does not have mOpenActivity
-            if (builder == null) {
-                Log.e(TAG_UNITY, "Failed to recover builder, can't send notification");
-                return;
-            }
-
-            Class openActivity;
-            if (mOpenActivity == null) {
-                openActivity = UnityNotificationUtilities.getOpenAppActivity(mContext);
-                if (openActivity == null) {
-                    Log.e(TAG_UNITY, "Activity not found, cannot show notification");
-                    return;
-                }
-            }
-            else {
-                openActivity = mOpenActivity;
-            }
-
-            id = builder.getExtras().getInt(KEY_ID, -1);
-            notif = buildNotificationForSending(openActivity, builder);
+            notify(id, notif);
+            return;
         }
 
-        if (notif != null) {
-            notify(id, notif);
+        Notification.Builder builder = (Notification.Builder)notification;
+        if (builder == null) {
+            Log.e(TAG_UNITY, "Failed to recover builder, can't send notification");
+            return;
+        }
+
+        notify(builder);
+    }
+
+    private void notify(Notification.Builder builder) {
+        Class openActivity;
+        if (mOpenActivity == null) {
+            openActivity = UnityNotificationUtilities.getOpenAppActivity(mContext);
+            if (openActivity == null) {
+                Log.e(TAG_UNITY, "Activity not found, cannot show notification");
+                return;
+            }
+        }
+        else {
+            openActivity = mOpenActivity;
+        }
+
+        int id = builder.getExtras().getInt(KEY_ID, -1);
+        Notification notification = buildNotificationForSending(openActivity, builder);
+        if (notification != null) {
+            notify(id, notification);
         }
     }
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -717,11 +717,9 @@ public class UnityNotificationManager extends BroadcastReceiver {
             return;
         }
 
-        Notification notif = null;
-        int id = -1;
         if (notification instanceof Notification) {
-            notif = (Notification) notification;
-            id = notif.extras.getInt(KEY_ID, -1);
+            Notification notif = (Notification) notification;
+            int id = notif.extras.getInt(KEY_ID, -1);
             notify(id, notif);
             return;
         }
@@ -729,7 +727,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         Integer notificationId = (Integer)notification;
         Notification.Builder builder = mScheduledNotifications.get(notificationId);
         if (builder != null) {
-            notify(builder);
+            notify(notificationId, builder);
             return;
         }
 
@@ -739,10 +737,10 @@ public class UnityNotificationManager extends BroadcastReceiver {
             return;
         }
 
-        notify(builder);
+        notify(notificationId, builder);
     }
 
-    private void notify(Notification.Builder builder) {
+    private void notify(int id, Notification.Builder builder) {
         Class openActivity;
         if (mOpenActivity == null) {
             openActivity = UnityNotificationUtilities.getOpenAppActivity(mContext);
@@ -755,7 +753,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
             openActivity = mOpenActivity;
         }
 
-        int id = builder.getExtras().getInt(KEY_ID, -1);
         Notification notification = buildNotificationForSending(openActivity, builder);
         if (notification != null) {
             notify(id, notification);

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -1038,32 +1038,26 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
     private Object getNotificationOrBuilderForIntent(Intent intent) {
         Object notification = getNotificationOrIdForIntent(intent);
-        boolean sendable = false;
         if (notification instanceof Integer) {
             Integer notificationId = (Integer)notification;
-            if ((notification = mScheduledNotifications.get(notificationId)) != null) {
-                sendable = true;
-            } else {
+            if ((notification = mScheduledNotifications.get(notificationId)) == null) {
                 // in case we don't have cached notification, deserialize from storage
                 SharedPreferences prefs = mContext.getSharedPreferences(getSharedPrefsNameByNotificationId(notificationId.toString()), Context.MODE_PRIVATE);
                 notification = UnityNotificationUtilities.deserializeNotification(mContext, prefs);
+
+                Notification.Builder builder;
+                if (notification instanceof Notification) {
+                    builder = UnityNotificationUtilities.recoverBuilder(mContext, (Notification)notification);
+                }
+                else {
+                    builder = (Notification.Builder)notification;
+                }
+
+                return builder;
             }
-        } else if (notification != null) {
-            sendable = true;
         }
 
-        if (notification == null || sendable)
-            return notification;
-
-        Notification.Builder builder;
-        if (notification instanceof Notification) {
-            builder = UnityNotificationUtilities.recoverBuilder(mContext, (Notification)notification);
-        }
-        else {
-            builder = (Notification.Builder)notification;
-        }
-
-        return builder;
+        return notification;
     }
 
     public void showNotificationSettings(String channelId) {

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -708,41 +708,47 @@ public class UnityNotificationManager extends BroadcastReceiver {
                 return;
             }
         }
+        showNotification(intent);
+    }
+
+    private void showNotification(Intent intent) {
         Object notification = getNotificationOrBuilderForIntent(intent);
-        if (notification != null) {
-            Notification notif = null;
-            int id = -1;
-            boolean sendable = notification instanceof Notification;
-            if (sendable) {
-                notif = (Notification) notification;
-                id = notif.extras.getInt(KEY_ID, -1);
-            } else {
-                Notification.Builder builder = (Notification.Builder)notification;
-                // this is different instance and does not have mOpenActivity
-                if (builder == null) {
-                    Log.e(TAG_UNITY, "Failed to recover builder, can't send notification");
+        if (notification == null) {
+            return;
+        }
+
+        Notification notif = null;
+        int id = -1;
+        boolean sendable = notification instanceof Notification;
+        if (sendable) {
+            notif = (Notification) notification;
+            id = notif.extras.getInt(KEY_ID, -1);
+        } else {
+            Notification.Builder builder = (Notification.Builder)notification;
+            // this is different instance and does not have mOpenActivity
+            if (builder == null) {
+                Log.e(TAG_UNITY, "Failed to recover builder, can't send notification");
+                return;
+            }
+
+            Class openActivity;
+            if (mOpenActivity == null) {
+                openActivity = UnityNotificationUtilities.getOpenAppActivity(mContext);
+                if (openActivity == null) {
+                    Log.e(TAG_UNITY, "Activity not found, cannot show notification");
                     return;
                 }
-
-                Class openActivity;
-                if (mOpenActivity == null) {
-                    openActivity = UnityNotificationUtilities.getOpenAppActivity(mContext);
-                    if (openActivity == null) {
-                        Log.e(TAG_UNITY, "Activity not found, cannot show notification");
-                        return;
-                    }
-                }
-                else {
-                    openActivity = mOpenActivity;
-                }
-
-                id = builder.getExtras().getInt(KEY_ID, -1);
-                notif = buildNotificationForSending(openActivity, builder);
+            }
+            else {
+                openActivity = mOpenActivity;
             }
 
-            if (notif != null) {
-                notify(id, notif);
-            }
+            id = builder.getExtras().getInt(KEY_ID, -1);
+            notif = buildNotificationForSending(openActivity, builder);
+        }
+
+        if (notif != null) {
+            notify(id, notif);
         }
     }
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -1042,22 +1042,25 @@ public class UnityNotificationManager extends BroadcastReceiver {
             Integer notificationId = (Integer)notification;
             if ((notification = mScheduledNotifications.get(notificationId)) == null) {
                 // in case we don't have cached notification, deserialize from storage
-                SharedPreferences prefs = mContext.getSharedPreferences(getSharedPrefsNameByNotificationId(notificationId.toString()), Context.MODE_PRIVATE);
-                notification = UnityNotificationUtilities.deserializeNotification(mContext, prefs);
-
-                Notification.Builder builder;
-                if (notification instanceof Notification) {
-                    builder = UnityNotificationUtilities.recoverBuilder(mContext, (Notification)notification);
-                }
-                else {
-                    builder = (Notification.Builder)notification;
-                }
-
-                return builder;
+                return deserializeNotificationBuilder(notificationId);
             }
         }
 
         return notification;
+    }
+
+    private Notification.Builder deserializeNotificationBuilder(Integer notificationId) {
+        SharedPreferences prefs = mContext.getSharedPreferences(getSharedPrefsNameByNotificationId(notificationId.toString()), Context.MODE_PRIVATE);
+        Object notification = UnityNotificationUtilities.deserializeNotification(mContext, prefs);
+        if (notification == null) {
+            return null;
+        }
+
+        if (notification instanceof Notification) {
+            return UnityNotificationUtilities.recoverBuilder(mContext, (Notification)notification);
+        }
+
+        return (Notification.Builder)notification;
     }
 
     public void showNotificationSettings(String channelId) {

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -743,7 +743,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         });
     }
 
-    private void notify(int id, Notification.Builder builder) {
+    void notify(int id, Notification.Builder builder) {
         Class openActivity;
         if (mOpenActivity == null) {
             openActivity = UnityNotificationUtilities.getOpenAppActivity(mContext);

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -20,6 +20,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.drawable.Icon;
 import android.net.Uri;
+import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
 import android.provider.Settings;
@@ -731,13 +732,15 @@ public class UnityNotificationManager extends BroadcastReceiver {
             return;
         }
 
-        builder = deserializeNotificationBuilder(notificationId);
-        if (builder == null) {
-            Log.e(TAG_UNITY, "Failed to recover builder, can't send notification");
-            return;
-        }
+        AsyncTask.execute(() -> {
+            Notification.Builder nb = deserializeNotificationBuilder(notificationId);
+            if (nb == null) {
+                Log.e(TAG_UNITY, "Failed to recover builder, can't send notification");
+                return;
+            }
 
-        notify(notificationId, builder);
+            notify(notificationId, nb);
+        });
     }
 
     private void notify(int id, Notification.Builder builder) {

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -712,7 +712,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
     }
 
     private void showNotification(Intent intent) {
-        Object notification = getNotificationOrBuilderForIntent(intent);
+        Object notification = getNotificationOrIdForIntent(intent);
         if (notification == null) {
             return;
         }
@@ -726,7 +726,14 @@ public class UnityNotificationManager extends BroadcastReceiver {
             return;
         }
 
-        Notification.Builder builder = (Notification.Builder)notification;
+        Integer notificationId = (Integer)notification;
+        Notification.Builder builder = mScheduledNotifications.get(notificationId);
+        if (builder != null) {
+            notify(builder);
+            return;
+        }
+
+        builder = deserializeNotificationBuilder(notificationId);
         if (builder == null) {
             Log.e(TAG_UNITY, "Failed to recover builder, can't send notification");
             return;

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
@@ -4,6 +4,7 @@ import android.app.Notification;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.util.Log;
 
@@ -22,7 +23,7 @@ public class UnityNotificationRestartOnBootReceiver extends BroadcastReceiver {
     public void onReceive(Context context, Intent received_intent) {
         Log.d(TAG_UNITY, "Rescheduling notifications after restart");
         if (Intent.ACTION_BOOT_COMPLETED.equals(received_intent.getAction())) {
-            rescheduleSavedNotifications(context);
+            AsyncTask.execute(() -> { rescheduleSavedNotifications(context); });
         }
     }
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
@@ -30,12 +30,12 @@ public class UnityNotificationRestartOnBootReceiver extends BroadcastReceiver {
     private static void rescheduleSavedNotifications(Context context) {
         UnityNotificationManager manager = UnityNotificationManager.getNotificationManagerImpl(context);
         List<Notification.Builder> saved_notifications = manager.loadSavedNotifications();
+        Date currentDate = Calendar.getInstance().getTime();
 
         for (Notification.Builder notificationBuilder : saved_notifications) {
             Bundle extras = notificationBuilder.getExtras();
             long repeatInterval = extras.getLong(KEY_REPEAT_INTERVAL, 0L);
             long fireTime = extras.getLong(KEY_FIRE_TIME, 0L);
-            Date currentDate = Calendar.getInstance().getTime();
             Date fireTimeDate = new Date(fireTime);
 
             boolean isRepeatable = repeatInterval > 0;

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
@@ -5,18 +5,22 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
 import static com.unity.androidnotifications.UnityNotificationManager.KEY_FIRE_TIME;
+import static com.unity.androidnotifications.UnityNotificationManager.KEY_ID;
 import static com.unity.androidnotifications.UnityNotificationManager.KEY_REPEAT_INTERVAL;
+import static com.unity.androidnotifications.UnityNotificationManager.TAG_UNITY;
 
 public class UnityNotificationRestartOnBootReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent received_intent) {
+        Log.d(TAG_UNITY, "Rescheduling notifications after restart");
         if (Intent.ACTION_BOOT_COMPLETED.equals(received_intent.getAction())) {
             rescheduleSavedNotifications(context);
         }
@@ -37,6 +41,8 @@ public class UnityNotificationRestartOnBootReceiver extends BroadcastReceiver {
 
             if (fireTimeDate.after(currentDate) || isRepeatable) {
                 manager.scheduleAlarmWithNotification(notificationBuilder);
+            } else {
+                Log.d(TAG_UNITY, "Notification expired, not rescheduling, ID: " + extras.getInt(KEY_ID, -1));
             }
         }
     }

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
@@ -18,6 +18,7 @@ import static com.unity.androidnotifications.UnityNotificationManager.KEY_REPEAT
 import static com.unity.androidnotifications.UnityNotificationManager.TAG_UNITY;
 
 public class UnityNotificationRestartOnBootReceiver extends BroadcastReceiver {
+    private static final long EXPIRATION_TRESHOLD = 600000;  // 10 minutes
 
     @Override
     public void onReceive(Context context, Intent received_intent) {
@@ -42,6 +43,10 @@ public class UnityNotificationRestartOnBootReceiver extends BroadcastReceiver {
 
             if (fireTimeDate.after(currentDate) || isRepeatable) {
                 manager.scheduleAlarmWithNotification(notificationBuilder);
+            } else if (currentDate.getTime() - fireTime < EXPIRATION_TRESHOLD) {
+                // notification is in the past, but not by much, send now
+                int id = extras.getInt(KEY_ID);
+                manager.notify(id, notificationBuilder);
             } else {
                 Log.d(TAG_UNITY, "Notification expired, not rescheduling, ID: " + extras.getInt(KEY_ID, -1));
             }

--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
@@ -378,8 +378,10 @@ class AndroidNotificationSendingTests
             manager = managerClass.GetStatic<AndroidJavaObject>("mUnityNotificationManager");
         var rebootClass = new AndroidJavaClass("com.unity.androidnotifications.UnityNotificationRestartOnBootReceiver");
         using (var calendarClass = new AndroidJavaClass("java.util.Calendar"))
+        {
             using (var calendar = calendarClass.CallStatic<AndroidJavaObject>("getInstance"))
                 currentTime = calendar.Call<AndroidJavaObject>("getTime");
+        }
 
         using var builder = AndroidNotificationCenter.CreateNotificationBuilder(789, notification, kDefaultTestChannel);
         var result = rebootClass.CallStatic<bool>("rescheduleNotification", manager, currentTime, builder);

--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
@@ -371,6 +371,55 @@ class AndroidNotificationSendingTests
         Assert.AreEqual(1, currentHandler.receivedNotificationCount);
     }
 
+    bool RescheduleNotification(AndroidNotification notification)
+    {
+        AndroidJavaObject manager, currentTime;
+        using (var managerClass = new AndroidJavaClass("com.unity.androidnotifications.UnityNotificationManager"))
+            manager = managerClass.GetStatic<AndroidJavaObject>("mUnityNotificationManager");
+        var rebootClass = new AndroidJavaClass("com.unity.androidnotifications.UnityNotificationRestartOnBootReceiver");
+        using (var calendarClass = new AndroidJavaClass("java.util.Calendar"))
+            using (var calendar = calendarClass.CallStatic<AndroidJavaObject>("getInstance"))
+                currentTime = calendar.Call<AndroidJavaObject>("getTime");
+
+        using var builder = AndroidNotificationCenter.CreateNotificationBuilder(789, notification, kDefaultTestChannel);
+        var result = rebootClass.CallStatic<bool>("rescheduleNotification", manager, currentTime, builder);
+        manager.Dispose();
+        currentTime.Dispose();
+        return result;
+    }
+
+    [UnityTest]
+    [UnityPlatform(RuntimePlatform.Android)]
+    public IEnumerator RescheduleNotification_ExpiredMomentAgo_SendsNotification()
+    {
+        var n = new AndroidNotification();
+        n.Title = "JustExpired";
+        n.Text = "Should be sent";
+        n.FireTime = System.DateTime.Now.AddMinutes(-1);
+
+        var result = RescheduleNotification(n);
+        Assert.IsTrue(result);
+
+        yield return WaitForNotification(5.0f);
+
+        Assert.AreEqual(1, currentHandler.receivedNotificationCount);
+        var received = currentHandler.lastNotification.Notification;
+        Assert.AreEqual("JustExpired", received.Title);
+    }
+
+    [Test]
+    [UnityPlatform(RuntimePlatform.Android)]
+    public void RescheduleNotification_ExpiredNotification_DoesNotReschedule()
+    {
+        var n = new AndroidNotification();
+        n.Title = "LongExpired";
+        n.Text = "Should NOT be sent";
+        n.FireTime = System.DateTime.Now.AddHours(-1);
+
+        var result = RescheduleNotification(n);
+        Assert.IsFalse(result);
+    }
+
     [UnityTest]
     [UnityPlatform(RuntimePlatform.Android)]
     public IEnumerator SendNotificationNotShownInForeground_IsDeliveredButNotShown()


### PR DESCRIPTION
https://github.com/Unity-Technologies/com.unity.mobile.notifications/issues/271
It is not advised to do IO on Android UI thread, as that may take time and lead to ANRs. Solution is to offload the work onto a background thread.
There are two places where the issue is present:
- receiving a broadcast that notification needs to be shown
- receiving broadcast that device has been rebooted and notifications have to be rescheduled
Two changes not related to the bug:
- Logging when reboot message is received, so it can be debugged whether it's app issue, or Android did not send app the message (which does happen on some devices)
- Give a 10 minute slack when rescheduling after boot. With Android pushing towards inexact alarms, notifications showing a couple minutes late is becoming a norm, so rescheduling should to some degree match. 10min is chosen arbitrary, we don't want to show notifications that expired a long time ago.

Developer testing:
- Unity trunk only (should not matter aside that trunk only supports Android 6, while older versions support 5.1)
- Main test project from the package repo
- Scenarios:
  - Notifications scheduled to arrive after some time do arrive with app in foreground, background or completely killed
  - Scheduled after reboot notification (dedicated button in project) arrives after device reboot
- Devices tested with no issues:
  - Nokia 7 Plus (10.0)
  - Pixel 5 (13)
  - Galaxy S22 (12)
  - OnePlus6T (9.0)
  - Asus ROG Phone (8.1)

Testing request:
- Android only
- Try same scenarios on more devices, especially lower Android versions
- When testing reboot, capture logcat for all processes and search for "resched", if the app doesn't print anything, it's a device issue (launching app quickly may be a solution); it is known that some devices don't work well in this scenario.
- Some devices have auto-start feature. App may be have auto-start disabled for it by default and experience issues because of that. Assu ROG had this and I would not get notifications after reboot of if app is killed. Enabling auto-start for app resolved the problem.