### PR TITLE
iOS remote notification presentation fixes

### DIFF
--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -6,9 +6,12 @@ All notable changes to this package will be documented in this file.
 
 ### Changes & Improvements:
 - [Android] - Reschedule after reboot will send all notifications that expired less than 10 minutes ago.
+- [iOS] - Remote notifications now support showInForeground key (allows to show notification while app is the foreground).
 
 ### Fixes:
 - [Android] - [issue 271](https://github.com/Unity-Technologies/com.unity.mobile.notifications/issues/271) Fix possible ANR when sending/rescheduling after reboot.
+- [iOS] - Remote notification presentation options work regardless of when authorization is performed.
+- [iOS] - Remote notifications have presentation independent of whether callback is registered or not.
 
 ## [2.2.1] - 2023-07-17
 

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityAppController+Notifications.mm
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityAppController+Notifications.mm
@@ -57,8 +57,6 @@
              BOOL registerRemoteOnLaunch = supportsPushNotification == YES ?
                  [[[NSBundle mainBundle] objectForInfoDictionaryKey: @"UnityNotificationRequestAuthorizationForRemoteNotificationsOnAppLaunch"] boolValue] : NO;
 
-             NSInteger remoteForegroundPresentationOptions = [[[NSBundle mainBundle] objectForInfoDictionaryKey: @"UnityRemoteNotificationForegroundPresentationOptions"] integerValue];
-
              NSInteger defaultAuthorizationOptions = [[[NSBundle mainBundle] objectForInfoDictionaryKey: @"UnityNotificationDefaultAuthorizationOptions"] integerValue];
 
              if (defaultAuthorizationOptions <= 0)
@@ -68,7 +66,6 @@
              {
                  UnityNotificationManager* manager = [UnityNotificationManager sharedInstance];
                  [manager requestAuthorization: defaultAuthorizationOptions withRegisterRemote: registerRemoteOnLaunch forRequest: NULL];
-                 manager.remoteNotificationForegroundPresentationOptions = remoteForegroundPresentationOptions;
              }
          }];
 

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
@@ -27,8 +27,6 @@
 @property NSString* lastRespondedNotificationAction;
 @property NSString* lastRespondedNotificationUserText;
 
-@property UNNotificationPresentationOptions remoteNotificationForegroundPresentationOptions;
-
 + (instancetype)sharedInstance;
 
 - (id)init;

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -15,6 +15,7 @@
 {
     NSLock* _lock;
     UNAuthorizationStatus _remoteNotificationsRegistered;
+    NSInteger _remoteNotificationForegroundPresentationOptions;
     NSString* _deviceToken;
     NSPointerArray* _pendingRemoteAuthRequests;
 }
@@ -39,6 +40,7 @@
     _remoteNotificationsRegistered = UNAuthorizationStatusNotDetermined;
     _deviceToken = nil;
     _pendingRemoteAuthRequests = nil;
+    _remoteNotificationForegroundPresentationOptions = [[[NSBundle mainBundle] objectForInfoDictionaryKey: @"UnityRemoteNotificationForegroundPresentationOptions"] integerValue];
     return self;
 }
 

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -162,8 +162,10 @@
     BOOL showInForeground;
     NSInteger presentationOptions;
 
+    showInForeground = [[notification.request.content.userInfo objectForKey: @"showInForeground"] boolValue];
     if ([notification.request.trigger isKindOfClass: [UNPushNotificationTrigger class]])
     {
+        presentationOptions = _remoteNotificationForegroundPresentationOptions;
         if (self.onRemoteNotificationReceivedCallback != NULL)
         {
             if (!haveNotificationData)
@@ -172,19 +174,16 @@
                 haveNotificationData = YES;
             }
 
-            showInForeground = NO;
             self.onRemoteNotificationReceivedCallback(notificationData);
         }
         else
         {
             showInForeground = YES;
-            presentationOptions = self.remoteNotificationForegroundPresentationOptions;
         }
     }
     else
     {
         presentationOptions = [[notification.request.content.userInfo objectForKey: @"showInForegroundPresentationOptions"] intValue];
-        showInForeground = [[notification.request.content.userInfo objectForKey: @"showInForeground"] boolValue];
     }
 
     if (haveNotificationData)


### PR DESCRIPTION
https://jira.unity3d.com/browse/MNB-60
https://jira.unity3d.com/browse/MNB-61

Fix two bugs related to iOS remote notification presentation:
- Remote presentation options set in settings are only used if permission is requested on app startup, not if manually requested by user at later point, notification does not show up as a result when delivered to foreground app
- If callback for remote notification receive is registered, notification is not shown when app is in the foreground

One small feature added while fixing this: adding showInForeground key to remote notification now allows to show it when received with app in foreground (just like for local notifications).

Both fixes verified by developer:
- requesting permission at later point in the app still shows remote notification sent to foreground app
- registering callback for remote notification does not alter the behavior except that now notification is shown based on showInForeground flag on it (without callback it is always shown).