### PR TITLE
Backport bugfixes to 2.2.x

### DIFF
--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this package will be documented in this file.
 
+## [Unreleased]
+
+### Changes & Improvements:
+- [Android] - Reschedule after reboot will send all notifications that expired less than 10 minutes ago.
+
+### Fixes:
+- [Android] - [issue 271](https://github.com/Unity-Technologies/com.unity.mobile.notifications/issues/271) Fix possible ANR when sending/rescheduling after reboot.
+
 ## [2.2.1] - 2023-07-17
 
 ### Fixes:

--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -6,9 +6,12 @@ All notable changes to this package will be documented in this file.
 
 ### Changes & Improvements:
 - [Android] - Reschedule after reboot will send all notifications that expired less than 10 minutes ago.
+- [iOS] - Remote notifications now support showInForeground key (allows to show notification while app is the foreground).
 
 ### Fixes:
 - [Android] - [issue 271](https://github.com/Unity-Technologies/com.unity.mobile.notifications/issues/271) Fix possible ANR when sending/rescheduling after reboot.
+- [iOS] - Remote notification presentation options work regardless of when authorization is performed.
+- [iOS] - Remote notifications have presentation independent of whether callback is registered or not.
 
 ## [2.2.1] - 2023-07-17
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -719,36 +719,39 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
         Notification notif = null;
         int id = -1;
-        boolean sendable = notification instanceof Notification;
-        if (sendable) {
+        if (notification instanceof Notification) {
             notif = (Notification) notification;
             id = notif.extras.getInt(KEY_ID, -1);
-        } else {
-            Notification.Builder builder = (Notification.Builder)notification;
-            // this is different instance and does not have mOpenActivity
-            if (builder == null) {
-                Log.e(TAG_UNITY, "Failed to recover builder, can't send notification");
-                return;
-            }
-
-            Class openActivity;
-            if (mOpenActivity == null) {
-                openActivity = UnityNotificationUtilities.getOpenAppActivity(mContext);
-                if (openActivity == null) {
-                    Log.e(TAG_UNITY, "Activity not found, cannot show notification");
-                    return;
-                }
-            }
-            else {
-                openActivity = mOpenActivity;
-            }
-
-            id = builder.getExtras().getInt(KEY_ID, -1);
-            notif = buildNotificationForSending(openActivity, builder);
+            notify(id, notif);
+            return;
         }
 
-        if (notif != null) {
-            notify(id, notif);
+        Notification.Builder builder = (Notification.Builder)notification;
+        if (builder == null) {
+            Log.e(TAG_UNITY, "Failed to recover builder, can't send notification");
+            return;
+        }
+
+        notify(builder);
+    }
+
+    private void notify(Notification.Builder builder) {
+        Class openActivity;
+        if (mOpenActivity == null) {
+            openActivity = UnityNotificationUtilities.getOpenAppActivity(mContext);
+            if (openActivity == null) {
+                Log.e(TAG_UNITY, "Activity not found, cannot show notification");
+                return;
+            }
+        }
+        else {
+            openActivity = mOpenActivity;
+        }
+
+        int id = builder.getExtras().getInt(KEY_ID, -1);
+        Notification notification = buildNotificationForSending(openActivity, builder);
+        if (notification != null) {
+            notify(id, notification);
         }
     }
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -1045,32 +1045,26 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
     private Object getNotificationOrBuilderForIntent(Intent intent) {
         Object notification = getNotificationOrIdForIntent(intent);
-        boolean sendable = false;
         if (notification instanceof Integer) {
             Integer notificationId = (Integer)notification;
-            if ((notification = mScheduledNotifications.get(notificationId)) != null) {
-                sendable = true;
-            } else {
+            if ((notification = mScheduledNotifications.get(notificationId)) == null) {
                 // in case we don't have cached notification, deserialize from storage
                 SharedPreferences prefs = mContext.getSharedPreferences(getSharedPrefsNameByNotificationId(notificationId.toString()), Context.MODE_PRIVATE);
                 notification = UnityNotificationUtilities.deserializeNotification(mContext, prefs);
+
+                Notification.Builder builder;
+                if (notification instanceof Notification) {
+                    builder = UnityNotificationUtilities.recoverBuilder(mContext, (Notification)notification);
+                }
+                else {
+                    builder = (Notification.Builder)notification;
+                }
+
+                return builder;
             }
-        } else if (notification != null) {
-            sendable = true;
         }
 
-        if (notification == null || sendable)
-            return notification;
-
-        Notification.Builder builder;
-        if (notification instanceof Notification) {
-            builder = UnityNotificationUtilities.recoverBuilder(mContext, (Notification)notification);
-        }
-        else {
-            builder = (Notification.Builder)notification;
-        }
-
-        return builder;
+        return notification;
     }
 
     public void showNotificationSettings(String channelId) {

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -717,11 +717,9 @@ public class UnityNotificationManager extends BroadcastReceiver {
             return;
         }
 
-        Notification notif = null;
-        int id = -1;
         if (notification instanceof Notification) {
-            notif = (Notification) notification;
-            id = notif.extras.getInt(KEY_ID, -1);
+            Notification notif = (Notification) notification;
+            int id = notif.extras.getInt(KEY_ID, -1);
             notify(id, notif);
             return;
         }
@@ -729,7 +727,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         Integer notificationId = (Integer)notification;
         Notification.Builder builder = mScheduledNotifications.get(notificationId);
         if (builder != null) {
-            notify(builder);
+            notify(notificationId, builder);
             return;
         }
 
@@ -739,10 +737,10 @@ public class UnityNotificationManager extends BroadcastReceiver {
             return;
         }
 
-        notify(builder);
+        notify(notificationId, builder);
     }
 
-    private void notify(Notification.Builder builder) {
+    private void notify(int id, Notification.Builder builder) {
         Class openActivity;
         if (mOpenActivity == null) {
             openActivity = UnityNotificationUtilities.getOpenAppActivity(mContext);
@@ -755,7 +753,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
             openActivity = mOpenActivity;
         }
 
-        int id = builder.getExtras().getInt(KEY_ID, -1);
         Notification notification = buildNotificationForSending(openActivity, builder);
         if (notification != null) {
             notify(id, notification);

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -1049,22 +1049,25 @@ public class UnityNotificationManager extends BroadcastReceiver {
             Integer notificationId = (Integer)notification;
             if ((notification = mScheduledNotifications.get(notificationId)) == null) {
                 // in case we don't have cached notification, deserialize from storage
-                SharedPreferences prefs = mContext.getSharedPreferences(getSharedPrefsNameByNotificationId(notificationId.toString()), Context.MODE_PRIVATE);
-                notification = UnityNotificationUtilities.deserializeNotification(mContext, prefs);
-
-                Notification.Builder builder;
-                if (notification instanceof Notification) {
-                    builder = UnityNotificationUtilities.recoverBuilder(mContext, (Notification)notification);
-                }
-                else {
-                    builder = (Notification.Builder)notification;
-                }
-
-                return builder;
+                return deserializeNotificationBuilder(notificationId);
             }
         }
 
         return notification;
+    }
+
+    private Notification.Builder deserializeNotificationBuilder(Integer notificationId) {
+        SharedPreferences prefs = mContext.getSharedPreferences(getSharedPrefsNameByNotificationId(notificationId.toString()), Context.MODE_PRIVATE);
+        Object notification = UnityNotificationUtilities.deserializeNotification(mContext, prefs);
+        if (notification == null) {
+            return null;
+        }
+
+        if (notification instanceof Notification) {
+            return UnityNotificationUtilities.recoverBuilder(mContext, (Notification)notification);
+        }
+
+        return (Notification.Builder)notification;
     }
 
     public void showNotificationSettings(String channelId) {

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -708,41 +708,47 @@ public class UnityNotificationManager extends BroadcastReceiver {
                 return;
             }
         }
+        showNotification(intent);
+    }
+
+    private void showNotification(Intent intent) {
         Object notification = getNotificationOrBuilderForIntent(intent);
-        if (notification != null) {
-            Notification notif = null;
-            int id = -1;
-            boolean sendable = notification instanceof Notification;
-            if (sendable) {
-                notif = (Notification) notification;
-                id = notif.extras.getInt(KEY_ID, -1);
-            } else {
-                Notification.Builder builder = (Notification.Builder)notification;
-                // this is different instance and does not have mOpenActivity
-                if (builder == null) {
-                    Log.e(TAG_UNITY, "Failed to recover builder, can't send notification");
+        if (notification == null) {
+            return;
+        }
+
+        Notification notif = null;
+        int id = -1;
+        boolean sendable = notification instanceof Notification;
+        if (sendable) {
+            notif = (Notification) notification;
+            id = notif.extras.getInt(KEY_ID, -1);
+        } else {
+            Notification.Builder builder = (Notification.Builder)notification;
+            // this is different instance and does not have mOpenActivity
+            if (builder == null) {
+                Log.e(TAG_UNITY, "Failed to recover builder, can't send notification");
+                return;
+            }
+
+            Class openActivity;
+            if (mOpenActivity == null) {
+                openActivity = UnityNotificationUtilities.getOpenAppActivity(mContext);
+                if (openActivity == null) {
+                    Log.e(TAG_UNITY, "Activity not found, cannot show notification");
                     return;
                 }
-
-                Class openActivity;
-                if (mOpenActivity == null) {
-                    openActivity = UnityNotificationUtilities.getOpenAppActivity(mContext);
-                    if (openActivity == null) {
-                        Log.e(TAG_UNITY, "Activity not found, cannot show notification");
-                        return;
-                    }
-                }
-                else {
-                    openActivity = mOpenActivity;
-                }
-
-                id = builder.getExtras().getInt(KEY_ID, -1);
-                notif = buildNotificationForSending(openActivity, builder);
+            }
+            else {
+                openActivity = mOpenActivity;
             }
 
-            if (notif != null) {
-                notify(id, notif);
-            }
+            id = builder.getExtras().getInt(KEY_ID, -1);
+            notif = buildNotificationForSending(openActivity, builder);
+        }
+
+        if (notif != null) {
+            notify(id, notif);
         }
     }
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -1025,23 +1025,31 @@ public class UnityNotificationManager extends BroadcastReceiver {
         return builder.build();
     }
 
-    private Object getNotificationOrBuilderForIntent(Intent intent) {
-        Object notification = null;
-        boolean sendable = false;
+    private Object getNotificationOrIdForIntent(Intent intent) {
         if (intent.hasExtra(KEY_NOTIFICATION_ID)) {
-            int id = intent.getExtras().getInt(KEY_NOTIFICATION_ID);
-            Integer notificationId = Integer.valueOf(id);
+            return intent.getExtras().getInt(KEY_NOTIFICATION_ID);
+        } else if (intent.hasExtra(KEY_NOTIFICATION)) {
+            // old code path where Notification object is in intent
+            // in case the app was replaced and there still are pending alarms with notification
+            return intent.getParcelableExtra(KEY_NOTIFICATION);
+        }
+
+        return null;
+    }
+
+    private Object getNotificationOrBuilderForIntent(Intent intent) {
+        Object notification = getNotificationOrIdForIntent(intent);
+        boolean sendable = false;
+        if (notification instanceof Integer) {
+            Integer notificationId = (Integer)notification;
             if ((notification = mScheduledNotifications.get(notificationId)) != null) {
                 sendable = true;
             } else {
                 // in case we don't have cached notification, deserialize from storage
-                SharedPreferences prefs = mContext.getSharedPreferences(getSharedPrefsNameByNotificationId(String.valueOf(id)), Context.MODE_PRIVATE);
+                SharedPreferences prefs = mContext.getSharedPreferences(getSharedPrefsNameByNotificationId(notificationId.toString()), Context.MODE_PRIVATE);
                 notification = UnityNotificationUtilities.deserializeNotification(mContext, prefs);
             }
-        } else if (intent.hasExtra(KEY_NOTIFICATION)) {
-            // old code path where Notification object is in intent
-            // in case the app was replaced and there still are pending alarms with notification
-            notification = intent.getParcelableExtra(KEY_NOTIFICATION);
+        } else if (notification != null) {
             sendable = true;
         }
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -743,7 +743,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         });
     }
 
-    private void notify(int id, Notification.Builder builder) {
+    void notify(int id, Notification.Builder builder) {
         Class openActivity;
         if (mOpenActivity == null) {
             openActivity = UnityNotificationUtilities.getOpenAppActivity(mContext);

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -20,6 +20,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.drawable.Icon;
 import android.net.Uri;
+import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
 import android.provider.Settings;
@@ -731,13 +732,15 @@ public class UnityNotificationManager extends BroadcastReceiver {
             return;
         }
 
-        builder = deserializeNotificationBuilder(notificationId);
-        if (builder == null) {
-            Log.e(TAG_UNITY, "Failed to recover builder, can't send notification");
-            return;
-        }
+        AsyncTask.execute(() -> {
+            Notification.Builder nb = deserializeNotificationBuilder(notificationId);
+            if (nb == null) {
+                Log.e(TAG_UNITY, "Failed to recover builder, can't send notification");
+                return;
+            }
 
-        notify(notificationId, builder);
+            notify(notificationId, nb);
+        });
     }
 
     private void notify(int id, Notification.Builder builder) {

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationManager.java
@@ -712,7 +712,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
     }
 
     private void showNotification(Intent intent) {
-        Object notification = getNotificationOrBuilderForIntent(intent);
+        Object notification = getNotificationOrIdForIntent(intent);
         if (notification == null) {
             return;
         }
@@ -726,7 +726,14 @@ public class UnityNotificationManager extends BroadcastReceiver {
             return;
         }
 
-        Notification.Builder builder = (Notification.Builder)notification;
+        Integer notificationId = (Integer)notification;
+        Notification.Builder builder = mScheduledNotifications.get(notificationId);
+        if (builder != null) {
+            notify(builder);
+            return;
+        }
+
+        builder = deserializeNotificationBuilder(notificationId);
         if (builder == null) {
             Log.e(TAG_UNITY, "Failed to recover builder, can't send notification");
             return;

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
@@ -4,6 +4,7 @@ import android.app.Notification;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.util.Log;
 
@@ -22,7 +23,7 @@ public class UnityNotificationRestartOnBootReceiver extends BroadcastReceiver {
     public void onReceive(Context context, Intent received_intent) {
         Log.d(TAG_UNITY, "Rescheduling notifications after restart");
         if (Intent.ACTION_BOOT_COMPLETED.equals(received_intent.getAction())) {
-            rescheduleSavedNotifications(context);
+            AsyncTask.execute(() -> { rescheduleSavedNotifications(context); });
         }
     }
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
@@ -30,12 +30,12 @@ public class UnityNotificationRestartOnBootReceiver extends BroadcastReceiver {
     private static void rescheduleSavedNotifications(Context context) {
         UnityNotificationManager manager = UnityNotificationManager.getNotificationManagerImpl(context);
         List<Notification.Builder> saved_notifications = manager.loadSavedNotifications();
+        Date currentDate = Calendar.getInstance().getTime();
 
         for (Notification.Builder notificationBuilder : saved_notifications) {
             Bundle extras = notificationBuilder.getExtras();
             long repeatInterval = extras.getLong(KEY_REPEAT_INTERVAL, 0L);
             long fireTime = extras.getLong(KEY_FIRE_TIME, 0L);
-            Date currentDate = Calendar.getInstance().getTime();
             Date fireTimeDate = new Date(fireTime);
 
             boolean isRepeatable = repeatInterval > 0;

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
@@ -5,18 +5,22 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
 import static com.unity.androidnotifications.UnityNotificationManager.KEY_FIRE_TIME;
+import static com.unity.androidnotifications.UnityNotificationManager.KEY_ID;
 import static com.unity.androidnotifications.UnityNotificationManager.KEY_REPEAT_INTERVAL;
+import static com.unity.androidnotifications.UnityNotificationManager.TAG_UNITY;
 
 public class UnityNotificationRestartOnBootReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent received_intent) {
+        Log.d(TAG_UNITY, "Rescheduling notifications after restart");
         if (Intent.ACTION_BOOT_COMPLETED.equals(received_intent.getAction())) {
             rescheduleSavedNotifications(context);
         }
@@ -37,6 +41,8 @@ public class UnityNotificationRestartOnBootReceiver extends BroadcastReceiver {
 
             if (fireTimeDate.after(currentDate) || isRepeatable) {
                 manager.scheduleAlarmWithNotification(notificationBuilder);
+            } else {
+                Log.d(TAG_UNITY, "Notification expired, not rescheduling, ID: " + extras.getInt(KEY_ID, -1));
             }
         }
     }

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/com/unity/androidnotifications/UnityNotificationRestartOnBootReceiver.java
@@ -18,6 +18,7 @@ import static com.unity.androidnotifications.UnityNotificationManager.KEY_REPEAT
 import static com.unity.androidnotifications.UnityNotificationManager.TAG_UNITY;
 
 public class UnityNotificationRestartOnBootReceiver extends BroadcastReceiver {
+    private static final long EXPIRATION_TRESHOLD = 600000;  // 10 minutes
 
     @Override
     public void onReceive(Context context, Intent received_intent) {
@@ -42,6 +43,10 @@ public class UnityNotificationRestartOnBootReceiver extends BroadcastReceiver {
 
             if (fireTimeDate.after(currentDate) || isRepeatable) {
                 manager.scheduleAlarmWithNotification(notificationBuilder);
+            } else if (currentDate.getTime() - fireTime < EXPIRATION_TRESHOLD) {
+                // notification is in the past, but not by much, send now
+                int id = extras.getInt(KEY_ID);
+                manager.notify(id, notificationBuilder);
             } else {
                 Log.d(TAG_UNITY, "Notification expired, not rescheduling, ID: " + extras.getInt(KEY_ID, -1));
             }

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityAppController+Notifications.mm
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityAppController+Notifications.mm
@@ -57,8 +57,6 @@
              BOOL registerRemoteOnLaunch = supportsPushNotification == YES ?
                  [[[NSBundle mainBundle] objectForInfoDictionaryKey: @"UnityNotificationRequestAuthorizationForRemoteNotificationsOnAppLaunch"] boolValue] : NO;
 
-             NSInteger remoteForegroundPresentationOptions = [[[NSBundle mainBundle] objectForInfoDictionaryKey: @"UnityRemoteNotificationForegroundPresentationOptions"] integerValue];
-
              NSInteger defaultAuthorizationOptions = [[[NSBundle mainBundle] objectForInfoDictionaryKey: @"UnityNotificationDefaultAuthorizationOptions"] integerValue];
 
              if (defaultAuthorizationOptions <= 0)
@@ -68,7 +66,6 @@
              {
                  UnityNotificationManager* manager = [UnityNotificationManager sharedInstance];
                  [manager requestAuthorization: defaultAuthorizationOptions withRegisterRemote: registerRemoteOnLaunch forRequest: NULL];
-                 manager.remoteNotificationForegroundPresentationOptions = remoteForegroundPresentationOptions;
              }
          }];
 

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
@@ -27,8 +27,6 @@
 @property NSString* lastRespondedNotificationAction;
 @property NSString* lastRespondedNotificationUserText;
 
-@property UNNotificationPresentationOptions remoteNotificationForegroundPresentationOptions;
-
 + (instancetype)sharedInstance;
 
 - (id)init;

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -15,6 +15,7 @@
 {
     NSLock* _lock;
     UNAuthorizationStatus _remoteNotificationsRegistered;
+    NSInteger _remoteNotificationForegroundPresentationOptions;
     NSString* _deviceToken;
     NSPointerArray* _pendingRemoteAuthRequests;
 }
@@ -39,6 +40,7 @@
     _remoteNotificationsRegistered = UNAuthorizationStatusNotDetermined;
     _deviceToken = nil;
     _pendingRemoteAuthRequests = nil;
+    _remoteNotificationForegroundPresentationOptions = [[[NSBundle mainBundle] objectForInfoDictionaryKey: @"UnityRemoteNotificationForegroundPresentationOptions"] integerValue];
     return self;
 }
 

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -162,8 +162,10 @@
     BOOL showInForeground;
     NSInteger presentationOptions;
 
+    showInForeground = [[notification.request.content.userInfo objectForKey: @"showInForeground"] boolValue];
     if ([notification.request.trigger isKindOfClass: [UNPushNotificationTrigger class]])
     {
+        presentationOptions = _remoteNotificationForegroundPresentationOptions;
         if (self.onRemoteNotificationReceivedCallback != NULL)
         {
             if (!haveNotificationData)
@@ -172,19 +174,16 @@
                 haveNotificationData = YES;
             }
 
-            showInForeground = NO;
             self.onRemoteNotificationReceivedCallback(notificationData);
         }
         else
         {
             showInForeground = YES;
-            presentationOptions = self.remoteNotificationForegroundPresentationOptions;
         }
     }
     else
     {
         presentationOptions = [[notification.request.content.userInfo objectForKey: @"showInForegroundPresentationOptions"] intValue];
-        showInForeground = [[notification.request.content.userInfo objectForKey: @"showInForeground"] boolValue];
     }
 
     if (haveNotificationData)

--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
@@ -378,8 +378,10 @@ class AndroidNotificationSendingTests
             manager = managerClass.GetStatic<AndroidJavaObject>("mUnityNotificationManager");
         var rebootClass = new AndroidJavaClass("com.unity.androidnotifications.UnityNotificationRestartOnBootReceiver");
         using (var calendarClass = new AndroidJavaClass("java.util.Calendar"))
+        {
             using (var calendar = calendarClass.CallStatic<AndroidJavaObject>("getInstance"))
                 currentTime = calendar.Call<AndroidJavaObject>("getTime");
+        }
 
         using var builder = AndroidNotificationCenter.CreateNotificationBuilder(789, notification, kDefaultTestChannel);
         var result = rebootClass.CallStatic<bool>("rescheduleNotification", manager, currentTime, builder);

--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
@@ -371,6 +371,55 @@ class AndroidNotificationSendingTests
         Assert.AreEqual(1, currentHandler.receivedNotificationCount);
     }
 
+    bool RescheduleNotification(AndroidNotification notification)
+    {
+        AndroidJavaObject manager, currentTime;
+        using (var managerClass = new AndroidJavaClass("com.unity.androidnotifications.UnityNotificationManager"))
+            manager = managerClass.GetStatic<AndroidJavaObject>("mUnityNotificationManager");
+        var rebootClass = new AndroidJavaClass("com.unity.androidnotifications.UnityNotificationRestartOnBootReceiver");
+        using (var calendarClass = new AndroidJavaClass("java.util.Calendar"))
+            using (var calendar = calendarClass.CallStatic<AndroidJavaObject>("getInstance"))
+                currentTime = calendar.Call<AndroidJavaObject>("getTime");
+
+        using var builder = AndroidNotificationCenter.CreateNotificationBuilder(789, notification, kDefaultTestChannel);
+        var result = rebootClass.CallStatic<bool>("rescheduleNotification", manager, currentTime, builder);
+        manager.Dispose();
+        currentTime.Dispose();
+        return result;
+    }
+
+    [UnityTest]
+    [UnityPlatform(RuntimePlatform.Android)]
+    public IEnumerator RescheduleNotification_ExpiredMomentAgo_SendsNotification()
+    {
+        var n = new AndroidNotification();
+        n.Title = "JustExpired";
+        n.Text = "Should be sent";
+        n.FireTime = System.DateTime.Now.AddMinutes(-1);
+
+        var result = RescheduleNotification(n);
+        Assert.IsTrue(result);
+
+        yield return WaitForNotification(5.0f);
+
+        Assert.AreEqual(1, currentHandler.receivedNotificationCount);
+        var received = currentHandler.lastNotification.Notification;
+        Assert.AreEqual("JustExpired", received.Title);
+    }
+
+    [Test]
+    [UnityPlatform(RuntimePlatform.Android)]
+    public void RescheduleNotification_ExpiredNotification_DoesNotReschedule()
+    {
+        var n = new AndroidNotification();
+        n.Title = "LongExpired";
+        n.Text = "Should NOT be sent";
+        n.FireTime = System.DateTime.Now.AddHours(-1);
+
+        var result = RescheduleNotification(n);
+        Assert.IsFalse(result);
+    }
+
     [UnityTest]
     [UnityPlatform(RuntimePlatform.Android)]
     public IEnumerator SendNotificationNotShownInForeground_IsDeliveredButNotShown()


### PR DESCRIPTION
Backport bugfixes to 2.2-based branch.
Master has moved on, but one ES bug is urgent, hence need faster release. This PR packs 3 bugfixes (2 PRs) that already landed to master:
https://github.com/Unity-Technologies/com.unity.mobile.notifications/pull/278
https://github.com/Unity-Technologies/com.unity.mobile.notifications/pull/280

Tested by developer, see test cases in linked PRs. iOS testing done in simulator, Android on Nokia 7 Plus (10.0). IMO no need for wider range, given that all code changes backported cleanly and differences from master are still minimal.