### PR TITLE
Unregister push support

### DIFF
--- a/TestProjects/Main/Assets/Scripts/iOSTest.cs
+++ b/TestProjects/Main/Assets/Scripts/iOSTest.cs
@@ -195,6 +195,11 @@ namespace Unity.Notifications.Tests.Sample
             {
                 StartCoroutine(GetCurrentLocation());
             });
+            m_groups["General"]["Check push registration"] = new Action(() =>
+            {
+                RegisteredForRemoteNotifications();
+            });
+            m_groups["General"]["Unregister push notifications"] = new Action(UnregisterForRemoteNotifications);
             m_groups["General"]["Request Authorization Sound + Badge + Alert"] = new Action(() =>
             {
                 StartCoroutine(RequestAuthorization(AuthorizationOption.Alert | AuthorizationOption.Badge | AuthorizationOption.Sound));
@@ -426,6 +431,20 @@ namespace Unity.Notifications.Tests.Sample
                 // Access granted and location value could be retrieved
                 m_LOGGER.Green("Location: " + Input.location.lastData.latitude + " " + Input.location.lastData.longitude + " " + Input.location.lastData.altitude + " " + Input.location.lastData.horizontalAccuracy + " " + Input.location.lastData.timestamp);
             }
+        }
+
+        void RegisteredForRemoteNotifications()
+        {
+            if (AuthorizationRequest.RegisteredForRemoteNotifications)
+                m_LOGGER.Green("App is registered with push notifications");
+            else
+                m_LOGGER.Red("App is not registered with push notifications");
+        }
+
+        void UnregisterForRemoteNotifications()
+        {
+            AuthorizationRequest.UnregisterForRemoteNotifications();
+            m_LOGGER.Gray("Unregisterred for push notifications");
         }
 
         //Request authorization if it is not enabled in Editor UI

--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this package will be documented in this file.
 ### Changes & Improvements:
 
 - Added unified APIs for basic notifications that work on both platforms in the `Unity.Notifications` namespace.
+- [iOS] - Added APIs for checking and unregistering for push notifications.
 
 ## [2.2.2] - 2023-09-07
 

--- a/com.unity.mobile.notifications/Runtime/iOS/AuthorizationRequest.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/AuthorizationRequest.cs
@@ -169,11 +169,20 @@ namespace Unity.Notifications.iOS
             }
         }
 
+        /// <summary>
+        /// Whether the app is currently registered for remote notifications.
+        /// </summary>
+        /// <seealso cref="https://developer.apple.com/documentation/uikit/uiapplication/1623069-registeredforremotenotifications?language=objc"/>
         public static bool RegisteredForRemoteNotifications
         {
             get => iOSNotificationsWrapper.RegisteredForRemoteNotifications();
         }
 
+        /// <summary>
+        /// Unregister for remote notifications.
+        /// This is rarely needed, typically when user logs out. The app can always re-register.
+        /// </summary>
+        /// <seealso cref="https://developer.apple.com/documentation/uikit/uiapplication/1623093-unregisterforremotenotifications?language=objc"/>
         public static void UnregisterForRemoteNotifications()
         {
             iOSNotificationsWrapper.UnregisterForRemoteNotifications();

--- a/com.unity.mobile.notifications/Runtime/iOS/AuthorizationRequest.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/AuthorizationRequest.cs
@@ -169,6 +169,16 @@ namespace Unity.Notifications.iOS
             }
         }
 
+        public static bool RegisteredForRemoteNotifications
+        {
+            get => iOSNotificationsWrapper.RegisteredForRemoteNotifications();
+        }
+
+        public static void UnregisterForRemoteNotifications()
+        {
+            iOSNotificationsWrapper.UnregisterForRemoteNotifications();
+        }
+
         /// <summary>
         /// Dispose to unregister the OnAuthorizationRequestCompleted callback.
         /// </summary>

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
@@ -10,8 +10,6 @@
 #import <UserNotifications/UserNotifications.h>
 #import "UnityNotificationData.h"
 
-#define SYSTEM_VERSION_10_OR_ABOVE  ([[[UIDevice currentDevice] systemVersion] compare:@"10.0" options:NSNumericSearch] != NSOrderedAscending)
-
 @interface UnityNotificationManager : NSObject<UNUserNotificationCenterDelegate>
 
 @property UNNotificationSettings* cachedNotificationSettings;

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
@@ -34,6 +34,7 @@
 - (void)updateDeliveredNotificationList;
 - (void)updateNotificationSettings;
 - (void)requestAuthorization:(NSInteger)authorizationOptions withRegisterRemote:(BOOL)registerRemote forRequest:(void*)request;
+- (void)unregisterForRemoteNotifications;
 - (void)scheduleLocalNotification:(iOSNotificationData*)data;
 
 @end

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -123,6 +123,12 @@
     }];
 }
 
+- (void)unregisterForRemoteNotifications
+{
+    [[UIApplication sharedApplication] unregisterForRemoteNotifications];
+    _remoteNotificationsRegistered = UNAuthorizationStatusNotDetermined;
+}
+
 + (NSString*)deviceTokenFromNotification:(NSNotification*)notification
 {
     NSData* deviceTokenData;

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -81,9 +81,6 @@
 
 - (void)requestAuthorization:(NSInteger)authorizationOptions withRegisterRemote:(BOOL)registerRemote forRequest:(void*)request
 {
-    if (!SYSTEM_VERSION_10_OR_ABOVE)
-        return;
-
     UNUserNotificationCenter* center = [UNUserNotificationCenter currentNotificationCenter];
 
     BOOL supportsPushNotification = [[[NSBundle mainBundle] objectForInfoDictionaryKey: @"UnityAddRemoteNotificationCapability"] boolValue];

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationWrapper.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationWrapper.m
@@ -57,6 +57,17 @@ void _RequestAuthorization(void* request, int options, BOOL registerRemote)
     center.delegate = manager;
 }
 
+int _RegisteredForRemoteNotifications()
+{
+    return [UIApplication sharedApplication].registeredForRemoteNotifications;
+}
+
+void _UnregisterForRemoteNotifications()
+{
+    UnityNotificationManager* manager = [UnityNotificationManager sharedInstance];
+    [manager unregisterForRemoteNotifications];
+}
+
 void _ScheduleLocalNotification(iOSNotificationData data)
 {
     UnityNotificationManager* manager = [UnityNotificationManager sharedInstance];

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationsWrapper.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationsWrapper.cs
@@ -32,6 +32,12 @@ namespace Unity.Notifications.iOS
         private static extern void _RequestAuthorization(IntPtr request, Int32 options, bool registerForRemote);
 
         [DllImport("__Internal")]
+        private static extern int _RegisteredForRemoteNotifications();
+
+        [DllImport("__Internal")]
+        private static extern void _UnregisterForRemoteNotifications();
+
+        [DllImport("__Internal")]
         private static extern void _ScheduleLocalNotification(iOSNotificationData data);
 
         [DllImport("__Internal")]
@@ -232,6 +238,22 @@ namespace Unity.Notifications.iOS
         {
 #if UNITY_IOS && !UNITY_EDITOR
             _RequestAuthorization(request, options, registerRemote);
+#endif
+        }
+
+        public static bool RegisteredForRemoteNotifications()
+        {
+#if UNITY_IOS && !UNITY_EDITOR
+            return _RegisteredForRemoteNotifications() != 0;
+#else
+            return false;
+#endif
+        }
+
+        public static void UnregisterForRemoteNotifications()
+        {
+#if UNITY_IOS && !UNITY_EDITOR
+            _UnregisterForRemoteNotifications();
 #endif
         }
 


### PR DESCRIPTION
https://github.com/Unity-Technologies/com.unity.mobile.notifications/issues/277
iOS has APIs not only to register for push notifications, but also to unregister. While rarely used, it has use cases, such us user logging out of app.
This PR adds two new methods: to check if registered and to unregister.

Added two buttons to the Maintest project for each of new APIs:
- "Check push registration"
- "Unregister push notifications"
Tested both:
- the app registers for push on launch, so checking returns true
- after pressing unregister check reports push is not registered
- Pressing button to request authorization register for push again (check button returns true)
Tested on iPhone X iOS 15.3.1
Trying few more iOS versions would be nice, otherwise it's quite straight-forward.