### PR TITLE
Fix large icon from file

### DIFF
--- a/TestProjects/AndroidBigPicture/Assets/Plugins/Android/FileAccess.androidlib/build.gradle
+++ b/TestProjects/AndroidBigPicture/Assets/Plugins/Android/FileAccess.androidlib/build.gradle
@@ -6,4 +6,5 @@ dependencies {
 
 android {
     compileSdkVersion 33
+    buildToolsVersion project(':unityLibrary').extensions.getByName('android').buildToolsVersion
 }

--- a/TestProjects/AndroidBigPicture/Assets/Scripts/NotificationStuff.cs
+++ b/TestProjects/AndroidBigPicture/Assets/Scripts/NotificationStuff.cs
@@ -39,6 +39,8 @@ public class NotificationStuff : MonoBehaviour
             SmallIconUri();
         if (GUI.Button(new Rect(400, 300, 300, 200), "Large icon URI"))
             LargeIconUri();
+        if (GUI.Button(new Rect(400, 550, 300, 200), "Large Icon file"))
+            LargeIconFile();
 
         GUI.Label(new Rect(50, Screen.height - 50, 100, 50), "Delay (0-50s):");
         notificationDelay = GUI.HorizontalSlider(new Rect(150, Screen.height - 50, Screen.width - 200, 50), notificationDelay, 0, 50);
@@ -112,6 +114,14 @@ public class NotificationStuff : MonoBehaviour
         var uri = GetSmallIconUri();
         var notification = new AndroidNotification("Large icon", uri, GetNotificationDelay());
         notification.LargeIcon = uri;
+        AndroidNotificationCenter.SendNotification(notification, channel);
+    }
+
+    void LargeIconFile()
+    {
+        var path = Path.Combine(sharedImages, "small_icon.png");
+        var notification = new AndroidNotification("Large icon", path, GetNotificationDelay());
+        notification.LargeIcon = path;
         AndroidNotificationCenter.SendNotification(notification, channel);
     }
 

--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this package will be documented in this file.
 - Added unified APIs for basic notifications that work on both platforms in the `Unity.Notifications` namespace.
 - [iOS] - Added APIs for checking and unregistering for push notifications.
 
+### Fixes:
+- [Android] - [issue 290](https://github.com/Unity-Technologies/com.unity.mobile.notifications/issues/290) Fix large icon not displayed when privided as file path.
+
 ## [2.2.2] - 2023-09-07
 
 ### Changes & Improvements:

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
@@ -830,7 +830,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         if (icon == null || icon.length() == 0)
             return null;
         if (icon.charAt(0) == '/') {
-            BitmapFactory.decodeFile(icon);
+            return BitmapFactory.decodeFile(icon);
         }
 
         Object ico = getIconForUri(icon);


### PR DESCRIPTION
https://github.com/Unity-Technologies/com.unity.mobile.notifications/issues/290
Large icon does not show up on notification when provided as file path. A fix is trivial and is very unlikely to cause any side effects.
A test project for big picture style update to add a case for this + project update with regard to build tools version.

Tested using mentioned project for big picture support. Issue is not specific to neither Unity nor Android version/device.
In my opinion no additional testing is required.