### PR TITLE
Android UTC/Local time

### DIFF
--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this package will be documented in this file.
 ### Changes & Improvements:
 
 - Added unified APIs for basic notifications that work on both platforms in the `Unity.Notifications` namespace.
+- [Android] - FireTime will be local or UTC uppon receiving, depending on what it was when sending.
 - [iOS] - Added APIs for checking and unregistering for push notifications.
 
 ## [2.2.2] - 2023-09-07

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotification.cs
@@ -283,7 +283,7 @@ namespace Unity.Notifications.Android
 
             m_RepeatInterval = (-1L).ToTimeSpan();
             m_Color = new Color(0, 0, 0, 0);
-            m_CustomTimestamp = (-1L).ToDatetime();
+            m_CustomTimestamp = (-1L).ToLocalDatetime();
             m_SilentInForeground = false;
         }
 

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationExtensions.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationExtensions.cs
@@ -64,10 +64,15 @@ namespace Unity.Notifications.Android
             return (long)Math.Floor(diff.TotalMilliseconds);
         }
 
-        public static DateTime ToDatetime(this long dateTime)
+        public static DateTime ToUtcDatetime(this long dateTime)
         {
             DateTime origin = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
-            return origin.AddMilliseconds(dateTime).ToLocalTime();
+            return origin.AddMilliseconds(dateTime);
+        }
+
+        public static DateTime ToLocalDatetime(this long dateTime)
+        {
+            return ToUtcDatetime(dateTime).ToLocalTime();
         }
 
         public static long ToLong(this TimeSpan? timeSpan)

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
@@ -221,7 +221,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         } else {
             SharedPreferences prefs = mContext.getSharedPreferences(NOTIFICATION_CHANNELS_SHARED_PREFS, Context.MODE_PRIVATE);
             Set<String> channelIds = new HashSet<String>(prefs.getStringSet(NOTIFICATION_CHANNELS_SHARED_PREFS_KEY, new HashSet<String>()));
-            channelIds.add(id); // TODO: what if users create the channel again with the same id?
+            channelIds.add(id);
 
             // Add to notification channel ids SharedPreferences.
             SharedPreferences.Editor editor = prefs.edit().clear();

--- a/com.unity.mobile.notifications/Runtime/Unified/NotificationScheduling.cs
+++ b/com.unity.mobile.notifications/Runtime/Unified/NotificationScheduling.cs
@@ -110,7 +110,6 @@ namespace Unity.Notifications
         void NotificationSchedule.Schedule(ref PlatformNotification notification)
         {
 #if UNITY_ANDROID
-            // TODO handle UTC
             switch (RepeatInterval)
             {
                 case NotificationRepeatInterval.OneTime:

--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
@@ -500,4 +500,18 @@ class AndroidNotificationSendingTests
         Assert.AreEqual(replacement.Title, received.Title);
         Assert.AreEqual(replacement.Text, received.Text);
     }
+
+    [UnityTest]
+    [UnityPlatform(RuntimePlatform.Android)]
+    public IEnumerator ScheduleUsingUtc()
+    {
+        var original = new AndroidNotification("UTC time", "Using UTC", DateTime.UtcNow.AddSeconds(2));
+        int id = AndroidNotificationCenter.SendNotification(original, kDefaultTestChannel);
+
+        yield return WaitForNotification(8.0f);
+
+        Assert.AreEqual(1, currentHandler.receivedNotificationCount);
+        var received = currentHandler.lastNotification.Notification;
+        Assert.AreEqual(DateTimeKind.Utc, received.FireTime.Kind);
+    }
 }

--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
@@ -98,6 +98,8 @@ class AndroidNotificationSendingTests
         Assert.AreEqual(1, currentHandler.receivedNotificationCount);
         Assert.AreEqual(originalId, currentHandler.lastNotification.Id);
         Assert.AreEqual(n.Group, currentHandler.lastNotification.Notification.Group);
+        // scheduled using local time, should receive in local too
+        Assert.AreEqual(DateTimeKind.Local, currentHandler.lastNotification.Notification.FireTime.Kind);
     }
 
     [UnityTest]


### PR DESCRIPTION
Currently we schedule notifications use UTC, but when receiving we on iOS we convert it to local time if it was originally scheduled using local time, on Android we always convert to local.
This PR changes it to match iOS - now scheduling using UTC will also return UTC when receiving.