### PR TITLE
Prepare 2.3.0

### DIFF
--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 All notable changes to this package will be documented in this file.
 
-## [2.3.0] - 2023-10-05
+## [2.3.0] - 2023-10-09
 
 ### Changes & Improvements:
 
 - Added unified APIs for basic notifications that work on both platforms in the `Unity.Notifications` namespace.
+- Sample project modified to use unified APIs.
+- [Android] - Package now placed to Gradle project as a separate module (.androidlib).
 - [iOS] - Added APIs for checking and unregistering for push notifications.
 - [iOS] - Added new presentation options, supported since iOS 14 (list and banner).
 

--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this package will be documented in this file.
 
-## [Unreleased]
+## [2.3.0] - 2023-10-05
 
 ### Changes & Improvements:
 


### PR DESCRIPTION
Nothing new here.
See [changelog](https://github.com/Unity-Technologies/com.unity.mobile.notifications/blob/master/com.unity.mobile.notifications/CHANGELOG.md) for focus areas for this release.
Up to QA to decide what tests to run to determine release readiness.