### PR TITLE
CI update

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -7,7 +7,7 @@ test_editors:
 test_platforms:
   - name: mac
     type: Unity::VM::osx
-    image: package-ci/mac:stable
+    image: package-ci/macos-13:v4
     flavor: m1.mac
 
 artifactory:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,7 +1,6 @@
 test_editors:
   - version: trunk
   - version: 2023.2
-  - version: 2023.1
   - version: 2022.3
   - version: 2021.3
 


### PR DESCRIPTION
Change Mac image, old one not compatible with trunk.
Also remove 2023.1 which is End-of-Life.