### PR TITLE
Fix plugin settings for .androidlib

### DIFF
--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 All notable changes to this package will be documented in this file.
 
+## [Unreleased]
+
 ## [2.3.0] - 2023-10-09
+
+### Fixes:
+- [iOS] - Do not copy Android plugins to Xcode project.
 
 ### Changes & Improvements:
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib.meta
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib.meta
@@ -1,2 +1,80 @@
 fileFormatVersion: 2
 guid: 5a06b648d726ee0479a00bac712c49f1
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 0
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude iOS: 1
+  - first:
+      Android: Android
+    second:
+      enabled: 1
+      settings:
+        CPU: ARMv7
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 0
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: AnyCPU
+        CompileFlags: 
+        FrameworkDependencies: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The .androidlib is marked for all platforms now, so as a result it is copied into Xcode project when built. No harm, as it's ignored, but incorrect too.
Tested manually that the library project is not copied to iOS any more. Automation tests that it is correctly copied into Android build.
Opened a bug in Unity, as .androidlib should only be compatible with Android by default .