### PR TITLE
iOS: schedule using local/UTC time natively

### DIFF
--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this package will be documented in this file.
 
 ### Fixes:
 - [iOS] - Do not copy Android plugins to Xcode project.
+- [iOS] - Calendar trigger will use local or UTC time depending on which one is set on trigger.
 
 ### Changes & Improvements:
 

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -324,7 +324,7 @@ bool validateAuthorizationStatus(UnityNotificationManager* manager)
             date.second = data->trigger.calendar.second;
 
         date.calendar = [NSCalendar calendarWithIdentifier: NSCalendarIdentifierGregorian];
-        if ([@"1" isEqualToString: [userInfo objectForKey:@"OriginalUtc"]])
+        if ([@"1" isEqualToString: [userInfo objectForKey: @"OriginalUtc"]])
             date.timeZone = [NSTimeZone timeZoneWithAbbreviation: @"UTC"];
 
         trigger = [UNCalendarNotificationTrigger triggerWithDateMatchingComponents: date repeats: data->trigger.calendar.repeats];

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -322,9 +322,10 @@ bool validateAuthorizationStatus(UnityNotificationManager* manager)
             date.minute = data->trigger.calendar.minute;
         if (data->trigger.calendar.second >= 0)
             date.second = data->trigger.calendar.second;
-        // From C# we get UTC time
+
         date.calendar = [NSCalendar calendarWithIdentifier: NSCalendarIdentifierGregorian];
-        date.timeZone = [NSTimeZone timeZoneWithAbbreviation: @"UTC"];
+        if ([@"1" isEqualToString: [userInfo objectForKey:@"OriginalUtc"]])
+            date.timeZone = [NSTimeZone timeZoneWithAbbreviation: @"UTC"];
 
         trigger = [UNCalendarNotificationTrigger triggerWithDateMatchingComponents: date repeats: data->trigger.calendar.repeats];
         NSLog(@"Notification will show after %f s.", ((UNCalendarNotificationTrigger*)trigger).nextTriggerDate.timeIntervalSinceNow);

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
@@ -399,8 +399,6 @@ namespace Unity.Notifications.iOS
                             if (userInfo == null)
                                 userInfo = new Dictionary<string, string>();
                             userInfo["OriginalUtc"] = trigger.UtcTime ? "1" : "0";
-                            if (!trigger.UtcTime)
-                                trigger = trigger.ToUtc();
                             data.trigger.calendar.year = trigger.Year != null ? trigger.Year.Value : -1;
                             data.trigger.calendar.month = trigger.Month != null ? trigger.Month.Value : -1;
                             data.trigger.calendar.day = trigger.Day != null ? trigger.Day.Value : -1;
@@ -450,7 +448,7 @@ namespace Unity.Notifications.iOS
                                 Hour = (data.trigger.calendar.hour >= 0) ? (int?)data.trigger.calendar.hour : null,
                                 Minute = (data.trigger.calendar.minute >= 0) ? (int?)data.trigger.calendar.minute : null,
                                 Second = (data.trigger.calendar.second >= 0) ? (int?)data.trigger.calendar.second : null,
-                                UtcTime = true,
+                                UtcTime = false,
                                 Repeats = data.trigger.calendar.repeats != 0
                             };
                             if (userInfo != null)
@@ -458,14 +456,10 @@ namespace Unity.Notifications.iOS
                                 string utc;
                                 if (userInfo.TryGetValue("OriginalUtc", out utc))
                                 {
-                                    if (utc == "0")
-                                        trigger = trigger.ToLocal();
+                                    if (utc == "1")
+                                        trigger.UtcTime = true;
                                 }
-                                else
-                                    trigger.UtcTime = false;
                             }
-                            else
-                                trigger.UtcTime = false;
                             return trigger;
                         }
                     case iOSNotificationTriggerType.Location:


### PR DESCRIPTION
https://jira.unity3d.com/browse/MNB-66
We used to schedule notifications using UTC time when  using calendar trigger. This causes problems with daylight saving time. This PR changes to use either UTC or local time natively in Objective-C depending on how calendar trigger is setup.
Note, that users report has an incorrect expectation in switching timezones. iOS does schedule notification using current timezone, so switching it does not alter the time notification will arrive.

Tested on iPhone X, iOS 15.3 (though, the issue is not device or OS specific).
Used users project, but modified it. It is better to test that notification arrives, rather than the opposite. The main test scenario is: schedule notification to happen 1 hour and 2 minutes in the future, then change the phone time. This gives 6 test cases:
1) change phone time to one hour forward, notification arrives within two minutes
2) have phone time one hour behind and after scheduling notification switch back to automatic time, notification arrives withing couple minutes
3, 4) same as the two above except scheduling using UTC time and switching timezone after switching, then changing time; timezone change should have no impact, changing phone time one hour forward makes notification arrive within couple minutes
5, 6) same as first two except timezone on phone is changed after scheduling, then phone time is changed to one hour forward and notification should arrive within couple minutes

Note, that when notification is scheduled, it is printed in the log after how many seconds ti should arrive (telling you how much you should change the clock time).

Manually tested all scenarios with changing phone time manually. With switching back to automatic only tried local time, assuming other two will work as well.
Calendar trigger can be setup to fire when particular components match, one could use for example day, hour and minute only with repeating, then notification should happen each month when the day, hour and minute matches. Did not try this scenario.