### PR TITLE
Add support for Unity with Gradle 8+

### DIFF
--- a/TestProjects/AndroidBigPicture/Assets/Plugins/Android/FileAccess.androidlib/build.gradle
+++ b/TestProjects/AndroidBigPicture/Assets/Plugins/Android/FileAccess.androidlib/build.gradle
@@ -5,6 +5,12 @@ dependencies {
 }
 
 android {
+    // Checking if namespace exists is needed for 2021.3 (AGP 4.0.1)
+    // When 2021.3 is dropped, remove this check and package="com.unity.fileaccess" from AndroidManifest
+    if (project.android.hasProperty("namespace")) {
+        namespace "com.unity.fileaccess"
+    }
+
     compileSdkVersion 33
     buildToolsVersion project(':unityLibrary').extensions.getByName('android').buildToolsVersion
 }

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/build.gradle
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/build.gradle
@@ -12,6 +12,12 @@ def getCompileSdk(unityLib) {
 }
 
 android {
+    // Checking if namespace exists is needed for 2021.3 (AGP 4.0.1)
+    // When 2021.3 is dropped, remove this check and package="com.unity.androidnotifications" from AndroidManifest
+    if (project.android.hasProperty("namespace")) {
+        namespace "com.unity.androidnotifications"
+    }
+
     def unityLib = project(':unityLibrary').extensions.getByName('android')
     compileSdkVersion getCompileSdk(unityLib)
     buildToolsVersion unityLib.buildToolsVersion


### PR DESCRIPTION
Starting with AGP 8+, module's `build.gradle` files are **required** to have the `namespace` property. This is supposed to replace the package attribute on the `AndroidManifest.xml` file.

Error before:
``` 
A problem occurred configuring project ':unityLibrary:mobilenotifications.androidlib'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.
```

**Manual testing:**
- ✅  Tested using the three TestProjects included in the package. 
- ✅  All the AutomatedTests are passing locally as well. 
- ✅  Tested 2021.3, 2022.3 and 2023.3 (trunk). No issues found.

**Automated tests:**
 - ✅ [Automated tests](https://unity-ci.cds.internal.unity3d.com/job/31830149/dependency-graph) passing for all supported Unity versions. 