### PR TITLE
Prepare 2.3.1

### DIFF
--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 All notable changes to this package will be documented in this file.
 
-## [Unreleased]
-
-## [2.3.0] - 2023-10-09
+## [2.3.1] - 2023-12-11
 
 ### Fixes:
-- [iOS] - Do not copy Android plugins to Xcode project.
+- [Android] - Mark Android library to be compatible only with Android.
 - [iOS] - Calendar trigger will use local or UTC time depending on which one is set on trigger.
+- Various documentation fixes.
+
+## [2.3.0] - 2023-10-09
 
 ### Changes & Improvements:
 

--- a/com.unity.mobile.notifications/package.json
+++ b/com.unity.mobile.notifications/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.mobile.notifications",
   "displayName": "Mobile Notifications",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "unity": "2021.3",
   "description": "Mobile Notifications package adds support for scheduling local repeatable or one-time notifications on iOS and Android.\n\nOn iOS receiving of push notifications is also supported.",
   "keywords": [


### PR DESCRIPTION
By mistake release notes for fixes were added to previous release, fixing that.
No significant changes in this release, leaving up for QA to decide, how much to test.