### PR TITLE
Fix crash with image attached to notification

### DIFF
--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
@@ -298,7 +298,7 @@ void _ReadNSDictionary(void* csDict, void* nsDict, void (*callback)(void* csDcit
 
 void _ReadAttachmentsNSArray(void* csList, void* nsArray, void (*callback)(void*, const char*, const char*))
 {
-    NSArray<UNNotificationAttachment*>* attachments = (__bridge_transfer NSArray<UNNotificationAttachment*>*)nsArray;
+    NSArray<UNNotificationAttachment*>* attachments = (__bridge NSArray<UNNotificationAttachment*>*)nsArray;
     [attachments enumerateObjectsUsingBlock:^(UNNotificationAttachment * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
         NSString* idr = obj.identifier;
         NSString* url = obj.URL.absoluteString;

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
@@ -235,6 +235,12 @@ void freeiOSNotificationData(iOSNotificationData* notificationData)
         NSDictionary* userInfo = (__bridge_transfer NSDictionary*)notificationData->userInfo;
         userInfo = nil;
     }
+
+    if (notificationData->attachments != NULL)
+    {
+        NSArray* attachments = (__bridge_transfer NSArray*)notificationData->attachments;
+        attachments = nil;
+    }
 }
 
 void* _AddItemToNSDictionary(void* dict, const char* key, const char* value)


### PR DESCRIPTION
Using a notification service extension as per: https://firebase.google.com/docs/cloud-messaging/ios/send-image we observed crashes when receiving a notification with the app opened
This change resolves the crash issue for us