### PR TITLE
Remove auto-added stuff from the manifest

### DIFF
--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/AndroidManifest.xml
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
         <action android:name="android.intent.action.BOOT_COMPLETED" />
       </intent-filter>
     </receiver>
+    <meta-data android:name="com.unity.androidnotifications.exact_scheduling" android:value="0" />
   </application>
   <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 </manifest>

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/AndroidManifest.xml
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/AndroidManifest.xml
@@ -6,10 +6,6 @@
         <action android:name="android.intent.action.BOOT_COMPLETED" />
       </intent-filter>
     </receiver>
-    <meta-data android:name="reschedule_notifications_on_restart" android:value="true" />
-    <meta-data android:name="com.unity.androidnotifications.exact_scheduling" android:value="1" />
   </application>
   <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-  <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
-  <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 </manifest>


### PR DESCRIPTION
https://jira.unity3d.com/browse/MNB-76
The androidlib plugin has a manifest file that contains base stuff. Then post process script adds additional things to it based on settings. By accident after creating androidlib plugin manifest ended up having too many things, so even if you don't set rescheduling after boot or exact scheduling in the settings, these settings are still in the manifest.

Adding stuff to manifest is tested by automation. Only remove things that shouldn't be there in the first place. Exact scheduling metadata item needs to be in the manifest, as for legacy reasons code defaults to 1 otherwise.
Tested manually by playing with settings that the stuff removed in this PR gets auto-added if requested.