### PR TITLE
Change repeating notification setup in test project

### DIFF
--- a/TestProjects/Main/Assets/Resources/iOSNotifications/TimeIntervalTrigger/Exception with interval set to 10 + Repeats.asset
+++ b/TestProjects/Main/Assets/Resources/iOSNotifications/TimeIntervalTrigger/Exception with interval set to 10 + Repeats.asset
@@ -16,12 +16,16 @@ MonoBehaviour:
   Identifier: 
   CategoryIdentifier: 
   ThreadIdentifier: 
-  Title: 
+  Title: Repeats
   Subtitle: 
   Body: 
   ShowInForeground: 1
-  PresentationOptions: 6
+  PresentationOptions: 18
   Badge: -1
   Data: 
   TimeTriggerInterval: 60
   Repeats: 1
+  SoundType: 0
+  InterruptionLevel: 0
+  UserInfo: []
+  Attachments: []


### PR DESCRIPTION
https://jira.unity3d.com/browse/MNB-72
"Repeatable notification" has very few fields setup and had weird bahavior. On iPhone X with iOS 16.7.4 it would not arrive when app is in background, for example.
Did two changes to it: added title and changed presentation from Alert (now deprecated by Apple) to Banner. Now it works.
No changes in package code, no other changes in test project.

QA: test if this fixes the issue on device where the issue was reproduced.