### PR TITLE
Android notification status after app restart

### DIFF
--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this package will be documented in this file.
 
 ### Fixes:
 - [Android] - Remove excessive permissions and metadata from default manifest (auto-add them based on settings).
+- [Android] - Fixed notification status reporting after dismissing notification and re-launching the app.
 - [iOS] - Fixed a possible crash when sending push notifications with attachment (like image).
 
 ## [2.3.1] - 2023-12-11

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -35,7 +35,7 @@ namespace Unity.Notifications.Android
         Scheduled = 1,
 
         /// <summary>
-        /// A notification with a specified id was already delivered.
+        /// A notification with a specified id was already delivered (showing in status bar).
         /// </summary>
         Delivered = 2,
     }

--- a/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/Android/AndroidNotificationSendingTests.cs
@@ -225,6 +225,17 @@ class AndroidNotificationSendingTests
         yield return new WaitForSeconds(2.0f); // cancel is async
         var status = AndroidNotificationCenter.CheckScheduledNotificationStatus(originalId);
         Assert.AreEqual(NotificationStatus.Unknown, status);
+
+        // now simulate app kill and restart, where notifications are loaded from persistent storage
+        using var managerClass = new AndroidJavaClass("com.unity.androidnotifications.UnityNotificationManager");
+        using var manager = managerClass.GetStatic<AndroidJavaObject>("mUnityNotificationManager");
+        using var backgroundThread = manager.Get<AndroidJavaObject>("mBackgroundThread");
+        using var scheduledNotifications = manager.Get<AndroidJavaObject>("mScheduledNotifications");
+        scheduledNotifications.Call("clear");
+        backgroundThread.Call("loadNotifications");
+
+        status = AndroidNotificationCenter.CheckScheduledNotificationStatus(originalId);
+        Assert.AreEqual(NotificationStatus.Unknown, status);
     }
 
     [Test]


### PR DESCRIPTION
https://jira.unity3d.com/browse/MNB-78
Fix incorrect notification status being reported on app restart. When app starts, we load all scheduled notifications to a cached list, but there was no check for expiration, so if notification arrived and was dismissed with app killed and restarted afterwards, we would report notification as scheduled afterwards.

Existing test was updated to cover this case. Most basic scenarios also covered by existing tests. Also tried the repro project from the original users report that the issue no longer reproduces.
QA:
- Test reschedule after reboot
- Try various notification status reporting scenarios you can think of (like app killed at various points in time with regard to notification arrival)
- Not device or OS version specific, don't overstretch  there