### PR TITLE
Use slough artifactory for choco installs in yamato jobs

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -66,7 +66,7 @@ test_Android_{{ editor.version }}:
     flavor: b1.medium
   commands:
     - curl -s {{ utr.url_win }} --output utr.bat
-    - gsudo choco install unity-downloader-cli -y -s https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/unity-choco-local
+    - gsudo choco install unity-downloader-cli -y -s https://artifactory-slo.bf.unity3d.com/artifactory/api/nuget/choco
     - unity-downloader-cli -c Editor -c Android -u {{ editor.version }} --wait --fast
     - utr.bat --testproject=TestProjects\AutomatedTests --editor-location=.Editor --suite=playmode --platform=android --scripting-backend=il2cpp --architecture=arm64 --artifacts_path=upm-ci~/test-results/android --timeout=900  --extra-editor-arg="-upmNoDefaultPackages" --player-save-path=build/players --build-only
     - |


### PR DESCRIPTION
There's an ongoing incident in [#incident-2024-03-25-1](https://unity.enterprise.slack.com/archives/C06R0T5V18E) that is causing timeouts for IT Artifactory. This PR updates the yamato jobs to use the slough artifactory instead to help alleviate this.

This PR is auto generated so the results is probably pretty dumb. 

If something looks strange then please help it along by correcting anything that is incorrect or missing.

[_Created by Sourcegraph batch change `henrikp/unity-config-slough`._](https://sourcegraph.ds.unity3d.com/users/henrikp/batch-changes/unity-config-slough)