### PR TITLE
[Yamato] Update test versions

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,6 +1,6 @@
 test_editors:
   - version: trunk
-  - version: 2023.2
+  - version: 6000.0
   - version: 2022.3
   - version: 2021.3
 


### PR DESCRIPTION
- Add 6000.0 (this will test latest publicly available 6000.0 version, which might be different than trunk)
- Remove unsupported 2023.2