### PR TITLE
Docs xray fixes

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -22,7 +22,7 @@ pack:
   name: Pack
   agent:
     type: Unity::VM
-    image: package-ci/ubuntu:stable
+    image: package-ci/ubuntu-22.04:v4
     flavor: b1.small
 
   commands:

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotification.cs
@@ -49,13 +49,13 @@ namespace Unity.Notifications.Android
 
     /// <summary>
     /// Data for setting up the big picture style notification.
-    /// Properties that are not available in devices API level are ignored. See <a href="https://developer.android.com/reference/android/app/Notification.BigPictureStyle">Android documentation</a> for availibility.
+    /// Properties that aren't available in the device's API level are ignored. Refer to <a href="https://developer.android.com/reference/android/app/Notification.BigPictureStyle">Android documentation</a> to check availability of properties based on each API level.
     /// </summary>
     public struct BigPictureStyle
     {
         /// <summary>
         /// The override for large icon (requirements are the same).
-        /// For more information see <a href="Unity.Notifications.Android.AndroidNotification.html#Unity_Notifications_Android_AndroidNotification_LargeIcon">AndroidNotification.LargeIcon</a>.
+        /// For more information, refer to <a href="Unity.Notifications.Android.AndroidNotification.html#Unity_Notifications_Android_AndroidNotification_LargeIcon">AndroidNotification.LargeIcon</a>.
         /// </summary>
         public string LargeIcon { get; set; }
 

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotification.cs
@@ -49,15 +49,14 @@ namespace Unity.Notifications.Android
 
     /// <summary>
     /// Data for setting up the big picture style notification.
-    /// Properties that are not available in devices API level are ignored. See Android documentation for availibility.
-    /// <see href="https://developer.android.com/reference/android/app/Notification.BigPictureStyle"/>
+    /// Properties that are not available in devices API level are ignored. See <a href="https://developer.android.com/reference/android/app/Notification.BigPictureStyle">Android documentation</a> for availibility.
     /// </summary>
     public struct BigPictureStyle
     {
         /// <summary>
         /// The override for large icon (requirements are the same).
+        /// For more information see <a href="Unity.Notifications.Android.AndroidNotification.html#Unity_Notifications_Android_AndroidNotification_LargeIcon"/>.
         /// </summary>
-        /// <see cref="AndroidNotification.LargeIcon"/>
         public string LargeIcon { get; set; }
 
         /// <summary>

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotification.cs
@@ -55,7 +55,7 @@ namespace Unity.Notifications.Android
     {
         /// <summary>
         /// The override for large icon (requirements are the same).
-        /// For more information see <a href="Unity.Notifications.Android.AndroidNotification.html#Unity_Notifications_Android_AndroidNotification_LargeIcon"/>.
+        /// For more information see <a href="Unity.Notifications.Android.AndroidNotification.html#Unity_Notifications_Android_AndroidNotification_LargeIcon">AndroidNotification.LargeIcon</a>.
         /// </summary>
         public string LargeIcon { get; set; }
 

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationCenter.cs
@@ -614,6 +614,7 @@ namespace Unity.Notifications.Android
         /// The delegate type for the notification received callbacks.
         /// It is used in <see cref="AndroidNotificationCenter.OnNotificationReceived"/> event.
         /// </summary>
+        /// <param name="data">The data from notification intent.</param>
         public delegate void NotificationReceivedCallback(AndroidNotificationIntentData data);
 
         /// <summary>
@@ -822,6 +823,7 @@ namespace Unity.Notifications.Android
         /// <summary>
         /// Register notification channel group.
         /// </summary>
+        /// <param name="group">The channel group to register.</param>
         public static void RegisterNotificationChannelGroup(AndroidNotificationChannelGroup group)
         {
             if (!Initialize())
@@ -966,6 +968,7 @@ namespace Unity.Notifications.Android
         /// Schedule a notification created using the provided Notification.Builder object.
         /// Notification builder should be created by calling CreateNotificationBuilder.
         /// </summary>
+        /// <param name="notificationBuilder">Notification builder from which to construct the notification.</param>
         public static void SendNotification(AndroidJavaObject notificationBuilder)
         {
             if (Initialize())
@@ -977,6 +980,8 @@ namespace Unity.Notifications.Android
         /// Notification builder should be created by calling CreateNotificationBuilder.
         /// Stores the notification id to the second argument
         /// </summary>
+        /// <param name="notificationBuilder">Notification builder from which to construct the notification.</param>
+        /// <param name="id">Receives the generated notification ID.</param>
         public static void SendNotification(AndroidJavaObject notificationBuilder, out int id)
         {
             id = -1;
@@ -1131,6 +1136,9 @@ namespace Unity.Notifications.Android
         /// Will automatically generate the ID for notification.
         /// <see cref="CreateNotificationBuilder(int, AndroidNotification, string)"/>
         /// </summary>
+        /// <param name="notification">Notification from which to create the builder.</param>
+        /// <param name="channelId">Notification channel to which notification should be sent to.</param>
+        /// <returns>A proxy object for created Notification.Builder</returns>
         public static AndroidJavaObject CreateNotificationBuilder(AndroidNotification notification, string channelId)
         {
             AndroidJavaObject builder, extras;

--- a/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationChannel.cs
+++ b/com.unity.mobile.notifications/Runtime/Android/AndroidNotificationChannel.cs
@@ -106,7 +106,7 @@ namespace Unity.Notifications.Android
         /// <summary>
         /// Sets whether notifications posted to this channel should display notification lights, on devices that support that feature.
         /// This can be changed by users in the settings app.
-        /// </summary>/
+        /// </summary>
         public bool EnableLights { get; set; }
 
         /// <summary>

--- a/com.unity.mobile.notifications/Runtime/Unified/Notification.cs
+++ b/com.unity.mobile.notifications/Runtime/Unified/Notification.cs
@@ -21,6 +21,10 @@ namespace Unity.Notifications
     {
         PlatformNotification notification;
 
+        /// <summary>
+        /// Notification can be converted to it's platform specific counterpart using explicit cast.
+        /// </summary>
+        /// <param name="n">Notification to convert</param>
         public static explicit operator PlatformNotification(Notification n)
         {
 #if UNITY_ANDROID

--- a/com.unity.mobile.notifications/Runtime/Unified/Notification.cs
+++ b/com.unity.mobile.notifications/Runtime/Unified/Notification.cs
@@ -11,12 +11,16 @@ namespace Unity.Notifications
 {
     /// <summary>
     /// Represents a notification to be sent or a received one.
+    /// </summary>
+    /// <remarks>
     /// Can be converted to platform specific notification via explicit cast.
+    /// <para>
     /// <code>
     /// var n1 = (AndroidNotification)notification; // convert to Android
     /// var n1 = (iOSNotification)notification; // convert to iOS
     /// </code>
-    /// </summary>
+    /// </para>
+    /// </remarks>
     public struct Notification
     {
         PlatformNotification notification;
@@ -25,6 +29,7 @@ namespace Unity.Notifications
         /// Notification can be converted to it's platform specific counterpart using explicit cast.
         /// </summary>
         /// <param name="n">Notification to convert</param>
+        /// <returns>Resulting platform specific notification</returns>
         public static explicit operator PlatformNotification(Notification n)
         {
 #if UNITY_ANDROID

--- a/com.unity.mobile.notifications/Runtime/Unified/Notification.cs
+++ b/com.unity.mobile.notifications/Runtime/Unified/Notification.cs
@@ -14,13 +14,13 @@ namespace Unity.Notifications
     /// </summary>
     /// <remarks>
     /// Can be converted to platform specific notification via explicit cast.
-    /// <para>
+    /// </remarks>
+    /// <example>
     /// <code>
     /// var n1 = (AndroidNotification)notification; // convert to Android
     /// var n1 = (iOSNotification)notification; // convert to iOS
     /// </code>
-    /// </para>
-    /// </remarks>
+    /// </example>
     public struct Notification
     {
         PlatformNotification notification;

--- a/com.unity.mobile.notifications/Runtime/Unified/Notification.cs
+++ b/com.unity.mobile.notifications/Runtime/Unified/Notification.cs
@@ -26,10 +26,10 @@ namespace Unity.Notifications
         PlatformNotification notification;
 
         /// <summary>
-        /// Notification can be converted to it's platform specific counterpart using explicit cast.
+        /// Notification can be converted to its platform-specific counterpart using explicit cast.
         /// </summary>
         /// <param name="n">Notification to convert</param>
-        /// <returns>Resulting platform specific notification</returns>
+        /// <returns>Resulting platform-specific notification</returns>
         public static explicit operator PlatformNotification(Notification n)
         {
 #if UNITY_ANDROID

--- a/com.unity.mobile.notifications/Runtime/Unified/NotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Unified/NotificationCenter.cs
@@ -326,7 +326,9 @@ namespace Unity.Notifications
         // <summary>
         /// Queries for the last notification used to open the app.
         /// </summary>
-        /// <returns>An asynchronous operation that can be used in a coroutine to retrieve the notification</returns>
+        /// <returns>
+        /// An asynchronous operation that can be used in a coroutine to retrieve the notification.
+        /// </returns>
         public static QueryLastRespondedNotificationOp QueryLastRespondedNotification()
         {
             CheckInitialized();

--- a/com.unity.mobile.notifications/Runtime/Unified/NotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Unified/NotificationCenter.cs
@@ -326,7 +326,7 @@ namespace Unity.Notifications
         // <summary>
         /// Queries for the last notification used to open the app.
         /// </summary>
-        /// <returns>An asynchronous operation that can be used in a coroutine to retrieve the notification.</returns>
+        /// <returns>An asynchronous operation that can be used in a coroutine to retrieve the notification</returns>
         public static QueryLastRespondedNotificationOp QueryLastRespondedNotification()
         {
             CheckInitialized();

--- a/com.unity.mobile.notifications/Runtime/Unified/NotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Unified/NotificationCenter.cs
@@ -323,7 +323,7 @@ namespace Unity.Notifications
             }
         }
 
-        // <summary>
+        /// <summary>
         /// Queries for the last notification used to open the app.
         /// </summary>
         /// <returns>

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
@@ -9,7 +9,7 @@ namespace Unity.Notifications.iOS
     /// Constants indicating how to present a notification in a foreground app.
     /// </summary>
     /// <remarks>
-    /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationpresentationoptions">Apple documentation</a> for more information.
+    /// For more information, refer to <a href="https://developer.apple.com/documentation/usernotifications/unnotificationpresentationoptions">Apple documentation</a>.
     /// </remarks>
     [Flags]
     public enum PresentationOption
@@ -47,7 +47,7 @@ namespace Unity.Notifications.iOS
 
     /// <summary>
     /// The type of sound to use for the notification.
-    /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationsound">Apple documentation</a> for details.
+    /// For more information, refer to <a href="https://developer.apple.com/documentation/usernotifications/unnotificationsound">Apple documentation</a>.
     /// </summary>
     public enum NotificationSoundType
     {
@@ -74,7 +74,7 @@ namespace Unity.Notifications.iOS
 
     /// <summary>
     /// Importance and delivery timing of a notification.
-    /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel">Apple documentation</a> for details. Available since iOS 15, always Active on lower versions.
+    /// For more information, refer to <a href="https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel">Apple documentation</a>. UNNotificationInterruptionLevel is available since iOS version 15. On versions earlier than iOS 15, the interruption level is always active.
     /// </summary>
     public enum NotificationInterruptionLevel
     {
@@ -165,7 +165,7 @@ namespace Unity.Notifications.iOS
     }
 
     /// <summary>
-    /// The iOSNotification class is used schedule local notifications. It includes the content of the notification and the trigger conditions for delivery.
+    /// The iOSNotification class is used to schedule local notifications. It includes the content of the notification and the trigger conditions for delivery.
     /// An instance of this class is also returned when receiving remote notifications.
     /// </summary>
     /// <remarks>
@@ -228,7 +228,7 @@ namespace Unity.Notifications.iOS
 
         /// <summary>
         /// The message displayed in the notification alert.
-        /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationcontent/1649863-body">Apple documentation</a> for details.
+        /// For more information, refer to <a href="https://developer.apple.com/documentation/usernotifications/unnotificationcontent/1649863-body">Apple documentation</a>.
         /// </summary>
         public string Body
         {
@@ -256,8 +256,8 @@ namespace Unity.Notifications.iOS
 
 
         /// <summary>
-        /// Presentation options for displaying the local of notification when the app is running.
-        /// Only works if  <a href="Unity.Notifications.iOS.iOSNotification.html#Unity_Notifications_iOS_iOSNotification_ShowInForeground">iOSNotification.ShowInForeground</a> is enabled and user has allowed enabled the requested options for your app.
+        /// Presentation options for displaying the local notification when the app is running.
+        /// Only works if  <a href="Unity.Notifications.iOS.iOSNotification.html#Unity_Notifications_iOS_iOSNotification_ShowInForeground">iOSNotification.ShowInForeground</a> is enabled and the user has allowed the requested permissions for your app.
         /// </summary>
         public PresentationOption ForegroundPresentationOption
         {
@@ -309,7 +309,7 @@ namespace Unity.Notifications.iOS
 
         /// <summary>
         /// The volume for the sound. Use null to use the default volume.
-        /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationsound/2963118-defaultcriticalsoundwithaudiovol">Apple documentation</a> for supported values.
+        /// For information on the supported values, refer to  <a href="https://developer.apple.com/documentation/usernotifications/unnotificationsound/2963118-defaultcriticalsoundwithaudiovol">Apple documentation</a>.
         /// </summary>
         public float? SoundVolume { get; set; }
 
@@ -324,7 +324,7 @@ namespace Unity.Notifications.iOS
 
         /// <summary>
         /// The score the system uses to determine if the notification is the summary’s featured notification.
-        /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationcontent/3821031-relevancescore">Apple documentation</a> for more details.
+        /// For more information, refer to <a href="https://developer.apple.com/documentation/usernotifications/unnotificationcontent/3821031-relevancescore">Apple documentation</a>.
         /// </summary>
         public double RelevanceScore
         {
@@ -359,7 +359,7 @@ namespace Unity.Notifications.iOS
 
         /// <summary>
         /// A list of notification attachments.
-        /// Notification attachments can be images, audio or video files. Refer to <a href="https://developer.apple.com/documentation/usernotifications/unmutablenotificationcontent/1649857-attachments?language=objc">Apple documentation</a> on supported formats.
+        /// Notification attachments can be images, audio, or video files. Refer to <a href="https://developer.apple.com/documentation/usernotifications/unmutablenotificationcontent/1649857-attachments?language=objc">Apple documentation</a> on supported formats.
         /// </summary>
         public List<iOSNotificationAttachment> Attachments { get; set; }
 
@@ -484,7 +484,7 @@ namespace Unity.Notifications.iOS
         }
 
         /// <summary>
-        /// Create a new instance of <a href="Unity.Notifications.iOS.iOSNotification.html">iOSNotification</a> and automatically generate an unique string for <a href="Unity.Notifications.iOS.iOSNotification.html#Unity_Notifications_iOS_iOSNotification_Identifier">iOSNotification.Identifier</a>  with all optional fields set to default values.
+        /// Create a new instance of <a href="Unity.Notifications.iOS.iOSNotification.html">iOSNotification</a> and automatically generate a unique string for <a href="Unity.Notifications.iOS.iOSNotification.html#Unity_Notifications_iOS_iOSNotification_Identifier">iOSNotification.Identifier</a>  with all optional fields set to default values.
         /// </summary>
         public iOSNotification() : this(GenerateUniqueID())
         {

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
@@ -7,7 +7,7 @@ namespace Unity.Notifications.iOS
 {
     /// <summary>
     /// Constants indicating how to present a notification in a foreground app
-    /// <see href="https://developer.apple.com/documentation/usernotifications/unnotificationpresentationoptions?language=objc"/>
+    /// For more information see <a href="https://developer.apple.com/documentation/usernotifications/unnotificationpresentationoptions?language=objc"/>Apple documentation</a>
     /// </summary>
     [Flags]
     public enum PresentationOption
@@ -45,8 +45,7 @@ namespace Unity.Notifications.iOS
 
     /// <summary>
     /// The type of sound to use for the notification.
-    /// See Apple documentation for details.
-    /// <see href="https://developer.apple.com/documentation/usernotifications/unnotificationsound?language=objc"/>
+    /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationsound?language=objc">Apple documentation</a> for details.
     /// </summary>
     public enum NotificationSoundType
     {
@@ -73,8 +72,7 @@ namespace Unity.Notifications.iOS
 
     /// <summary>
     /// Importance and delivery timing of a notification.
-    /// See Apple documentation for details. Available since iOS 15, always Active on lower versions.
-    /// <see href="https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel?language=objc"/>
+    /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel?language=objc">Apple documentation</a> for details. Available since iOS 15, always Active on lower versions.
     /// </summary>
     public enum NotificationInterruptionLevel
     {
@@ -171,7 +169,7 @@ namespace Unity.Notifications.iOS
     /// <remarks>
     /// Create an instance of this class when you want to schedule the delivery of a local notification. It contains the entire notification  payload to be delivered
     /// (which corresponds to UNNotificationContent) and  also the NotificationTrigger object with the conditions that trigger the delivery of the notification.
-    /// To schedule the delivery of your notification, pass an instance of this class to the <see cref="iOSNotificationCenter.ScheduleNotification"/>  method.
+    /// To schedule the delivery of your notification, pass an instance of this class to the <a href="Unity.Notifications.iOS.iOSNotificationCenter.html#Unity_Notifications_iOS_iOSNotificationCenter_ScheduleNotification_Unity_Notifications_iOS_iOSNotification_"/>iOSNotificationCenter.ScheduleNotification</a> method.
     /// </remarks>
     public class iOSNotification
     {
@@ -228,8 +226,7 @@ namespace Unity.Notifications.iOS
 
         /// <summary>
         /// The message displayed in the notification alert.
-        /// See Apple's documentation for details.
-        /// <see href="https://developer.apple.com/documentation/usernotifications/unnotificationcontent/1649863-body"/>
+        /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationcontent/1649863-body">Apple documentation</a> for details.
         /// </summary>
         public string Body
         {
@@ -241,7 +238,7 @@ namespace Unity.Notifications.iOS
         /// Indicates whether the notification alert should be shown when the app is open.
         /// </summary>
         /// <remarks>
-        /// Subscribe to the <see cref="iOSNotificationCenter.OnNotificationReceived"/> event to receive a callback when the notification is triggered.
+        /// Subscribe to the <a href="Unity.Notifications.iOS.iOSNotificationCenter.html#Unity_Notifications_iOS_iOSNotificationCenter_OnNotificationReceived">iOSNotificationCenter.OnNotificationReceived</a> event to receive a callback when the notification is triggered.
         /// </remarks>
         public bool ShowInForeground
         {
@@ -257,7 +254,8 @@ namespace Unity.Notifications.iOS
 
 
         /// <summary>
-        /// Presentation options for displaying the local of notification when the app is running. Only works if  <see cref="iOSNotification.ShowInForeground"/> is enabled and user has allowed enabled the requested options for your app.
+        /// Presentation options for displaying the local of notification when the app is running.
+        /// Only works if  <a href="Unity.Notifications.iOS.iOSNotification.html#Unity_Notifications_iOS_iOSNotification_ShowInForeground">iOSNotification.ShowInForeground</a> is enabled and user has allowed enabled the requested options for your app.
         /// </summary>
         public PresentationOption ForegroundPresentationOption
         {
@@ -309,8 +307,7 @@ namespace Unity.Notifications.iOS
 
         /// <summary>
         /// The volume for the sound. Use null to use the default volume.
-        /// See Apple documentation for supported values.
-        /// <see href="https://developer.apple.com/documentation/usernotifications/unnotificationsound/2963118-defaultcriticalsoundwithaudiovol?language=objc"/>
+        /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationsound/2963118-defaultcriticalsoundwithaudiovol?language=objc">Apple documentation</a> for supported values.
         /// </summary>
         public float? SoundVolume { get; set; }
 
@@ -325,7 +322,7 @@ namespace Unity.Notifications.iOS
 
         /// <summary>
         /// The score the system uses to determine if the notification is the summary’s featured notification.
-        /// <see href="https://developer.apple.com/documentation/usernotifications/unnotificationcontent/3821031-relevancescore?language=objc"/>
+        /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationcontent/3821031-relevancescore?language=objc">Apple documentation</a> for more details.
         /// </summary>
         public double RelevanceScore
         {
@@ -335,7 +332,7 @@ namespace Unity.Notifications.iOS
 
         /// <summary>
         /// Arbitrary string data which can be retrieved when the notification is used to open the app or is received while the app is running.
-        /// Push notification is sent to the device as <see href="https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification?language=objc">JSON</see>.
+        /// Push notification is sent to the device as <a href="https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification?language=objc">JSON</see>.
         /// The value for data key is set to the Data property on notification.
         /// </summary>
         public string Data
@@ -360,16 +357,15 @@ namespace Unity.Notifications.iOS
 
         /// <summary>
         /// A list of notification attachments.
-        /// Notification attachments can be images, audio or video files. Refer to Apple documentation on supported formats.
-        /// <see href="https://developer.apple.com/documentation/usernotifications/unmutablenotificationcontent/1649857-attachments?language=objc"/>
+        /// Notification attachments can be images, audio or video files. Refer to <a href="https://developer.apple.com/documentation/usernotifications/unmutablenotificationcontent/1649857-attachments?language=objc">Apple documentation</a> on supported formats.
         /// </summary>
         public List<iOSNotificationAttachment> Attachments { get; set; }
 
         /// <summary>
         /// The conditions that trigger the delivery of the notification.
-        /// For notification that were already delivered and whose instance was returned by <see cref="iOSNotificationCenter.OnRemoteNotificationReceived"/> or <see cref="iOSNotificationCenter.OnRemoteNotificationReceived"/>
-        /// use this property to determine what caused the delivery to occur. You can do this by comparing <see cref="iOSNotification.Trigger"/>  to any of the notification trigger types that implement it, such as
-        /// <see cref="iOSNotificationLocationTrigger"/>, <see cref="iOSNotificationPushTrigger"/>, <see cref="iOSNotificationTimeIntervalTrigger"/>, <see cref="iOSNotificationCalendarTrigger"/>.
+        /// For notification that were already delivered and whose instance was returned by <a href="Unity.Notifications.iOS.iOSNotificationCenter.html#Unity_Notifications_iOS_iOSNotificationCenter_OnNotificationReceived">iOSNotificationCenter.OnNotificationReceived</a> or <a href="Unity.Notifications.iOS.iOSNotificationCenter.html#Unity_Notifications_iOS_iOSNotificationCenter_OnRemoteNotificationReceived">iOSNotificationCenter.OnRemoteNotificationReceived</a>
+        /// use this property to determine what caused the delivery to occur. You can do this by comparing <a href="Unity.Notifications.iOS.iOSNotification.html#Unity_Notifications_iOS_iOSNotification_Trigger">iOSNotification.Trigger</a>  to any of the notification trigger types that implement it, such as
+        /// <a href="Unity.Notifications.iOS.iOSNotificationLocationTrigger.html">iOSNotificationLocationTrigger</a>, <a href="Unity.Notifications.iOS.iOSNotificationPushTrigger.html">iOSNotificationPushTrigger</a>, <a href="Unity.Notifications.iOS.iOSNotificationTimeIntervalTrigger.html">iOSNotificationTimeIntervalTrigger</a>, <a href="Unity.Notifications.iOS.iOSNotificationCalendarTrigger.html">iOSNotificationCalendarTrigger</a>.
         /// </summary>
         /// <example>
         /// <code>
@@ -486,14 +482,14 @@ namespace Unity.Notifications.iOS
         }
 
         /// <summary>
-        /// Create a new instance of <see cref="iOSNotification"/> and automatically generate an unique string for <see cref="iOSNotification.Identifier"/>  with all optional fields set to default values.
+        /// Create a new instance of <a href="Unity.Notifications.iOS.iOSNotification.html">iOSNotification</a> and automatically generate an unique string for <a href="Unity.Notifications.iOS.iOSNotification.html#Unity_Notifications_iOS_iOSNotification_Identifier">iOSNotification.Identifier</a>  with all optional fields set to default values.
         /// </summary>
         public iOSNotification() : this(GenerateUniqueID())
         {
         }
 
         /// <summary>
-        /// Specify a <see cref="iOSNotification.Identifier"/> and create a notification object with all optional fields set to default values.
+        /// Specify a <a href="Unity.Notifications.iOS.iOSNotification.html#Unity_Notifications_iOS_iOSNotification_Identifier">iOSNotification.Identifier</a> and create a notification object with all optional fields set to default values.
         /// </summary>
         /// <param name="identifier">  Unique identifier for the local notification tha can later be used to track or change it's status.</param>
         public iOSNotification(string identifier)

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
@@ -9,7 +9,7 @@ namespace Unity.Notifications.iOS
     /// Constants indicating how to present a notification in a foreground app.
     /// </summary>
     /// <remarks>
-    /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationpresentationoptions"/>Apple documentation</a> for more information.
+    /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationpresentationoptions">Apple documentation</a> for more information.
     /// </remarks>
     [Flags]
     public enum PresentationOption
@@ -171,7 +171,7 @@ namespace Unity.Notifications.iOS
     /// <remarks>
     /// Create an instance of this class when you want to schedule the delivery of a local notification. It contains the entire notification  payload to be delivered
     /// (which corresponds to UNNotificationContent) and  also the NotificationTrigger object with the conditions that trigger the delivery of the notification.
-    /// To schedule the delivery of your notification, pass an instance of this class to the <a href="Unity.Notifications.iOS.iOSNotificationCenter.html#Unity_Notifications_iOS_iOSNotificationCenter_ScheduleNotification_Unity_Notifications_iOS_iOSNotification_"/>iOSNotificationCenter.ScheduleNotification</a> method.
+    /// To schedule the delivery of your notification, pass an instance of this class to the <a href="Unity.Notifications.iOS.iOSNotificationCenter.html#Unity_Notifications_iOS_iOSNotificationCenter_ScheduleNotification_Unity_Notifications_iOS_iOSNotification_">iOSNotificationCenter.ScheduleNotification</a> method.
     /// </remarks>
     public class iOSNotification
     {
@@ -309,7 +309,7 @@ namespace Unity.Notifications.iOS
 
         /// <summary>
         /// The volume for the sound. Use null to use the default volume.
-        /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationsound/2963118-defaultcriticalsoundwithaudiovol?language=objc">Apple documentation</a> for supported values.
+        /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationsound/2963118-defaultcriticalsoundwithaudiovol">Apple documentation</a> for supported values.
         /// </summary>
         public float? SoundVolume { get; set; }
 
@@ -324,7 +324,7 @@ namespace Unity.Notifications.iOS
 
         /// <summary>
         /// The score the system uses to determine if the notification is the summary’s featured notification.
-        /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationcontent/3821031-relevancescore?language=objc">Apple documentation</a> for more details.
+        /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationcontent/3821031-relevancescore">Apple documentation</a> for more details.
         /// </summary>
         public double RelevanceScore
         {
@@ -334,7 +334,7 @@ namespace Unity.Notifications.iOS
 
         /// <summary>
         /// Arbitrary string data which can be retrieved when the notification is used to open the app or is received while the app is running.
-        /// Push notification is sent to the device as <a href="https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification?language=objc">JSON</see>.
+        /// Push notification is sent to the device as <a href="https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification">JSON</a>.
         /// The value for data key is set to the Data property on notification.
         /// </summary>
         public string Data

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
@@ -6,8 +6,8 @@ using UnityEngine;
 namespace Unity.Notifications.iOS
 {
     /// <summary>
-    /// Constants indicating how to present a notification in a foreground app
-    /// For more information see <a href="https://developer.apple.com/documentation/usernotifications/unnotificationpresentationoptions?language=objc"/>Apple documentation</a>
+    /// Constants indicating how to present a notification in a foreground app.
+    /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationpresentationoptions"/>Apple documentation</a> for more information.
     /// </summary>
     [Flags]
     public enum PresentationOption
@@ -45,7 +45,7 @@ namespace Unity.Notifications.iOS
 
     /// <summary>
     /// The type of sound to use for the notification.
-    /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationsound?language=objc">Apple documentation</a> for details.
+    /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationsound">Apple documentation</a> for details.
     /// </summary>
     public enum NotificationSoundType
     {
@@ -72,7 +72,7 @@ namespace Unity.Notifications.iOS
 
     /// <summary>
     /// Importance and delivery timing of a notification.
-    /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel?language=objc">Apple documentation</a> for details. Available since iOS 15, always Active on lower versions.
+    /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel">Apple documentation</a> for details. Available since iOS 15, always Active on lower versions.
     /// </summary>
     public enum NotificationInterruptionLevel
     {
@@ -164,7 +164,7 @@ namespace Unity.Notifications.iOS
 
     /// <summary>
     /// The iOSNotification class is used schedule local notifications. It includes the content of the notification and the trigger conditions for delivery.
-    /// An instance of this class is also returned when receiving remote notifications..
+    /// An instance of this class is also returned when receiving remote notifications.
     /// </summary>
     /// <remarks>
     /// Create an instance of this class when you want to schedule the delivery of a local notification. It contains the entire notification  payload to be delivered

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
@@ -7,8 +7,10 @@ namespace Unity.Notifications.iOS
 {
     /// <summary>
     /// Constants indicating how to present a notification in a foreground app.
-    /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationpresentationoptions"/>Apple documentation</a> for more information.
     /// </summary>
+    /// <remarks>
+    /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationpresentationoptions"/>Apple documentation</a> for more information.
+    /// </remarks>
     [Flags]
     public enum PresentationOption
     {

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationAction.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationAction.cs
@@ -65,7 +65,7 @@ namespace Unity.Notifications.iOS
         /// Options for the action. Can be a combination of given flags.
         /// </summary>
         /// <remarks>
-        /// Refer to Apple documentation for <a href="https://developer.apple.com/documentation/usernotifications/unnotificationactionoptions">UNNotificationActionOptions</a> for exact meanings.
+        /// For information on the options, refer to Apple documentation <a href="https://developer.apple.com/documentation/usernotifications/unnotificationactionoptions">UNNotificationActionOptions</a>.
         /// </remarks>
         public iOSNotificationActionOptions Options { get; set; }
 
@@ -73,7 +73,7 @@ namespace Unity.Notifications.iOS
         /// Set the icon for action using system symbol image name.
         /// </summary>
         /// <remarks>
-        /// <a href="https://developer.apple.com/documentation/usernotifications/unnotificationactionicon/3747241-iconwithsystemimagename">Apple documentation</a>
+        /// Refer to <a href="https://developer.apple.com/documentation/usernotifications/unnotificationactionicon/3747241-iconwithsystemimagename">Apple documentation</a>
         /// </remarks>
         public string SystemImageName
         {
@@ -89,7 +89,7 @@ namespace Unity.Notifications.iOS
         /// Set the icon for action using image from app's bundle.
         /// </summary>
         /// <remarks>
-        /// <a href="https://developer.apple.com/documentation/usernotifications/unnotificationactionicon/3747242-iconwithtemplateimagename">Apple documentation</a>
+        /// Refer to <a href="https://developer.apple.com/documentation/usernotifications/unnotificationactionicon/3747242-iconwithtemplateimagename">Apple documentation</a>
         /// </remarks>
         public string TemplateImageName
         {

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationAction.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationAction.cs
@@ -4,9 +4,10 @@ namespace Unity.Notifications.iOS
 {
     /// <summary>
     /// Options for notification actions.
-    /// These represent values from UNNotificationActionOptions.
-    /// For more information, refer to <see href="https://developer.apple.com/documentation/usernotifications/unnotificationactionoptions">Apple documentation</see>.
     /// </summary>
+    /// <remarks>
+    /// These represent values from <a href="https://developer.apple.com/documentation/usernotifications/unnotificationactionoptions">UNNotificationActionOptions</a>.
+    /// </remarks>
     [Flags]
     public enum iOSNotificationActionOptions
     {
@@ -62,15 +63,18 @@ namespace Unity.Notifications.iOS
 
         /// <summary>
         /// Options for the action. Can be a combination of given flags.
-        /// Refer to Apple documentation for UNNotificationActionOptions for exact meanings.
-        /// <see href="https://developer.apple.com/documentation/usernotifications/unnotificationactionoptions"/>
         /// </summary>
+        /// <remarks>
+        /// Refer to Apple documentation for <a href="https://developer.apple.com/documentation/usernotifications/unnotificationactionoptions">UNNotificationActionOptions</a> for exact meanings.
+        /// </remarks>
         public iOSNotificationActionOptions Options { get; set; }
 
         /// <summary>
         /// Set the icon for action using system symbol image name.
-        /// <see href="https://developer.apple.com/documentation/usernotifications/unnotificationactionicon/3747241-iconwithsystemimagename?language=objc"/>
         /// </summary>
+        /// <remarks>
+        /// <a href="https://developer.apple.com/documentation/usernotifications/unnotificationactionicon/3747241-iconwithsystemimagename">Apple documentation</a>
+        /// </remarks>
         public string SystemImageName
         {
             get { return _imageType == iOSNotificationActionIconType.SystemImageName ? _image : null; }
@@ -83,8 +87,10 @@ namespace Unity.Notifications.iOS
 
         /// <summary>
         /// Set the icon for action using image from app's bundle.
-        /// <see href="https://developer.apple.com/documentation/usernotifications/unnotificationactionicon/3747242-iconwithtemplateimagename?language=objc"/>
         /// </summary>
+        /// <remarks>
+        /// <a href="https://developer.apple.com/documentation/usernotifications/unnotificationactionicon/3747242-iconwithtemplateimagename">Apple documentation</a>
+        /// </remarks>
         public string TemplateImageName
         {
             get { return _imageType == iOSNotificationActionIconType.TemplateImageName ? _image : null; }

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationAttachment.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationAttachment.cs
@@ -2,8 +2,7 @@ namespace Unity.Notifications.iOS
 {
     /// <summary>
     /// Notification attachment.
-    /// Refer to Apple documentation for details.
-    /// <see href="https://developer.apple.com/documentation/usernotifications/unnotificationattachment?language=objc"/>
+    /// Refer to <a href="https://developer.apple.com/documentation/usernotifications/unnotificationattachment">Apple documentation</a> for details.
     /// </summary>
     public struct iOSNotificationAttachment
     {

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCategory.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCategory.cs
@@ -16,22 +16,22 @@ namespace Unity.Notifications.iOS
         None = 0,
 
         /// <summary>
-        /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationcategoryoptions/customdismissaction?language=objc">UNNotificationCategoryOptionCustomDismissAction</a>.
+        /// Refer to <a href="https://developer.apple.com/documentation/usernotifications/unnotificationcategoryoptions/customdismissaction?language=objc">UNNotificationCategoryOptionCustomDismissAction</a>.
         /// </summary>
         CustomDismissAction = (1 << 0),
 
         /// <summary>
-        /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationcategoryoptions/allowincarplay?language=objc">UNNotificationCategoryOptionAllowInCarPlay</a>.
+        /// Refer to <a href="https://developer.apple.com/documentation/usernotifications/unnotificationcategoryoptions/allowincarplay?language=objc">UNNotificationCategoryOptionAllowInCarPlay</a>.
         /// </summary>
         AllowInCarPlay = (1 << 1),
 
         /// <summary>
-        /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationcategoryoptions/hiddenpreviewsshowtitle?language=objc">UNNotificationCategoryOptionHiddenPreviewsShowTitle</a>.
+        /// Refer to <a href="https://developer.apple.com/documentation/usernotifications/unnotificationcategoryoptions/hiddenpreviewsshowtitle?language=objc">UNNotificationCategoryOptionHiddenPreviewsShowTitle</a>.
         /// </summary>
         HiddenPreviewsShowTitle = (1 << 2),
 
         /// <summary>
-        /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationcategoryoptions/hiddenpreviewsshowsubtitle?language=objc">UNNotificationCategoryOptionHiddenPreviewsShowSubtitle</a>.
+        /// Refer to <a href="https://developer.apple.com/documentation/usernotifications/unnotificationcategoryoptions/hiddenpreviewsshowsubtitle?language=objc">UNNotificationCategoryOptionHiddenPreviewsShowSubtitle</a>.
         /// </summary>
         HiddenPreviewsShowSubtitle = (1 << 3),
     }
@@ -55,7 +55,7 @@ namespace Unity.Notifications.iOS
 
         /// <summary>
         /// Get actions set for this category.
-        /// For more info see <a href="Unity.Notifications.iOS.iOSNotificationAction.html">iOSNotificationAction</a>.
+        /// For more information, refer to <a href="Unity.Notifications.iOS.iOSNotificationAction.html">iOSNotificationAction</a>.
         /// </summary>
         public iOSNotificationAction[] Actions { get { return m_Actions.ToArray(); } }
 
@@ -70,7 +70,7 @@ namespace Unity.Notifications.iOS
         public string HiddenPreviewsBodyPlaceholder { get; set; }
 
         /// <summary>
-        /// A <a href="https://developer.apple.com/documentation/usernotifications/unnotificationcategory/2963112-categorysummaryformat">format</a> string for the summary description used when the system groups the category’s notifications.
+        /// A <a href="https://developer.apple.com/documentation/usernotifications/unnotificationcategory/2963112-categorysummaryformat">format</a> string used for the summary description when the system groups the notifications based on their category.
         /// </summary>
         public string SummaryFormat { get; set; }
 

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCategory.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCategory.cs
@@ -5,8 +5,7 @@ namespace Unity.Notifications.iOS
 {
     /// <summary>
     /// Options for notification category. Multiple options can be combined.
-    /// These represent values from UNNotificationCategoryOptions.
-    /// <see href="https://developer.apple.com/documentation/usernotifications/unnotificationcategoryoptions"/>
+    /// These represent values from <a href="https://developer.apple.com/documentation/usernotifications/unnotificationcategoryoptions">UNNotificationCategoryOptions</a>.
     /// </summary>
     [Flags]
     public enum iOSNotificationCategoryOptions
@@ -37,25 +36,22 @@ namespace Unity.Notifications.iOS
 
         /// <summary>
         /// Get actions set for this category.
-        /// For more info see <see cref="iOSNotificationAction"/>.
+        /// For more info see <a href="Unity.Notifications.iOS.iOSNotificationAction.html">iOSNotificationAction</a>.
         /// </summary>
         public iOSNotificationAction[] Actions { get { return m_Actions.ToArray(); } }
 
         /// <summary>
-        /// Intent identifiers set for this category.
-        /// <see href="https://developer.apple.com/documentation/usernotifications/unnotificationcategory/1649282-intentidentifiers"/>
+        /// Intent <a href="https://developer.apple.com/documentation/usernotifications/unnotificationcategory/1649282-intentidentifiers">identifiers</a> set for this category.
         /// </summary>
         public string[] IntentIdentifiers { get { return m_IntentIdentifiers.ToArray(); } }
 
         /// <summary>
-        /// The placeholder text to display when the system disables notification previews for the app.
-        /// <see href="https://developer.apple.com/documentation/usernotifications/unnotificationcategory/2873736-hiddenpreviewsbodyplaceholder"/>
+        /// The <a href="https://developer.apple.com/documentation/usernotifications/unnotificationcategory/2873736-hiddenpreviewsbodyplaceholder">placeholder</a> text to display when the system disables notification previews for the app.
         /// </summary>
         public string HiddenPreviewsBodyPlaceholder { get; set; }
 
         /// <summary>
-        /// A format string for the summary description used when the system groups the category’s notifications.
-        /// <see href="https://developer.apple.com/documentation/usernotifications/unnotificationcategory/2963112-categorysummaryformat"/>
+        /// A <a href="https://developer.apple.com/documentation/usernotifications/unnotificationcategory/2963112-categorysummaryformat">format</a> string for the summary description used when the system groups the category’s notifications.
         /// </summary>
         public string SummaryFormat { get; set; }
 

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCategory.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCategory.cs
@@ -10,10 +10,29 @@ namespace Unity.Notifications.iOS
     [Flags]
     public enum iOSNotificationCategoryOptions
     {
+        /// <summary>
+        /// No options specified.
+        /// </summary>
         None = 0,
+
+        /// <summary>
+        /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationcategoryoptions/customdismissaction?language=objc">UNNotificationCategoryOptionCustomDismissAction</a>.
+        /// </summary>
         CustomDismissAction = (1 << 0),
+
+        /// <summary>
+        /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationcategoryoptions/allowincarplay?language=objc">UNNotificationCategoryOptionAllowInCarPlay</a>.
+        /// </summary>
         AllowInCarPlay = (1 << 1),
+
+        /// <summary>
+        /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationcategoryoptions/hiddenpreviewsshowtitle?language=objc">UNNotificationCategoryOptionHiddenPreviewsShowTitle</a>.
+        /// </summary>
         HiddenPreviewsShowTitle = (1 << 2),
+
+        /// <summary>
+        /// See <a href="https://developer.apple.com/documentation/usernotifications/unnotificationcategoryoptions/hiddenpreviewsshowsubtitle?language=objc">UNNotificationCategoryOptionHiddenPreviewsShowSubtitle</a>.
+        /// </summary>
         HiddenPreviewsShowSubtitle = (1 << 3),
     }
 

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCenter.cs
@@ -13,6 +13,7 @@ namespace Unity.Notifications.iOS
         /// <summary>
         /// The delegate type for the notification received callbacks.
         /// </summary>
+        /// <param name="notification">The notification sthat has been received.</param>
         public delegate void NotificationReceivedCallback(iOSNotification notification);
 
         /// <summary>
@@ -176,7 +177,7 @@ namespace Unity.Notifications.iOS
         /// <summary>
         /// Queries for the last notification used to open the app.
         /// </summary>
-        /// <returns>An asynchronous operation that can be used in a coroutine to retrieve the notification.</returns>
+        /// <returns>An asynchronous operation that can be used in a coroutine to retrieve the notification</returns>
         public static QueryLastRespondedNotificationOp QueryLastRespondedNotification()
         {
             return new QueryLastRespondedNotificationOp();

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationCenter.cs
@@ -13,7 +13,7 @@ namespace Unity.Notifications.iOS
         /// <summary>
         /// The delegate type for the notification received callbacks.
         /// </summary>
-        /// <param name="notification">The notification sthat has been received.</param>
+        /// <param name="notification">The notification that has been received.</param>
         public delegate void NotificationReceivedCallback(iOSNotification notification);
 
         /// <summary>

--- a/com.unity.mobile.notifications/Tests/Editor/ApiTestsiOS.cs
+++ b/com.unity.mobile.notifications/Tests/Editor/ApiTestsiOS.cs
@@ -4,7 +4,7 @@ using Unity.Notifications.iOS;
 
 namespace Unity.Notifications.Tests
 {
-    public class ApiTestsiOS
+    internal class ApiTestsiOS
     {
         [Test]
         public void TimeIntervalTrigger_MeasuredInSeconds()


### PR DESCRIPTION
New package tooling found a bunch of errors in documentation, mostly missing or missformatted stuff, and poorly supported <see> tags that should be replaced by <a> tags. This PR addresses that.