### PR TITLE
Reboot receiver entirely in the manifest

### DIFF
--- a/com.unity.mobile.notifications/Editor/AndroidNotificationPostProcessor.cs
+++ b/com.unity.mobile.notifications/Editor/AndroidNotificationPostProcessor.cs
@@ -177,11 +177,6 @@ namespace Unity.Notifications
 <manifest xmlns:android=""http://schemas.android.com/apk/res/android"" package=""com.unity.androidnotifications"">
   <application>
     <receiver android:name=""com.unity.androidnotifications.UnityNotificationManager"" android:exported=""false"" />
-    <receiver android:name=""com.unity.androidnotifications.UnityNotificationRestartReceiver"" android:enabled=""false"" android:exported=""false"">
-      <intent-filter>
-        <action android:name=""android.intent.action.BOOT_COMPLETED"" />
-      </intent-filter>
-    </receiver>
     <meta-data android:name=""com.unity.androidnotifications.exact_scheduling"" android:value=""0"" />
   </application>
   <uses-permission android:name=""android.permission.POST_NOTIFICATIONS"" />
@@ -236,7 +231,18 @@ namespace Unity.Notifications
 
             if (settings.RescheduleOnRestart)
             {
-                AppendAndroidMetadataField(manifestPath, manifestDoc, "reschedule_notifications_on_restart", "true");
+                var manifestNode = manifestDoc.SelectSingleNode("manifest");
+                var applicationNode = manifestNode.SelectSingleNode("application");
+                var receiver = manifestDoc.CreateElement("receiver");
+                receiver.SetAttribute("name", kAndroidNamespaceURI, "com.unity.androidnotifications.UnityNotificationRestartReceiver");
+                receiver.SetAttribute("exported", kAndroidNamespaceURI, "false");
+                applicationNode.AppendChild(receiver);
+                var filterNode = manifestDoc.CreateElement("intent-filter");
+                receiver.AppendChild(filterNode);
+                var actionNode = manifestDoc.CreateElement("action");
+                actionNode.SetAttribute("name", kAndroidNamespaceURI, "android.intent.action.BOOT_COMPLETED");
+                filterNode.AppendChild(actionNode);
+
                 AppendAndroidPermissionField(manifestPath, manifestDoc, "android.permission.RECEIVE_BOOT_COMPLETED");
             }
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
@@ -101,19 +101,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
         Bundle metaData = getAppMetadata();
 
-        Boolean rescheduleOnRestart = false;
-        if (metaData != null)
-            rescheduleOnRestart = metaData.getBoolean("reschedule_notifications_on_restart", false);
-
-        if (rescheduleOnRestart) {
-            ComponentName receiver = new ComponentName(mContext, UnityNotificationRestartReceiver.class);
-            PackageManager pm = mContext.getPackageManager();
-
-            pm.setComponentEnabledSetting(receiver,
-                PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
-                PackageManager.DONT_KILL_APP);
-        }
-
         mOpenActivity = UnityNotificationUtilities.getOpenAppActivity(mContext);
         if (mOpenActivity == null)
             throw new RuntimeException("Failed to determine Activity to be opened when tapping notification");


### PR DESCRIPTION
https://jira.unity3d.com/browse/MNB-80
Android manifest for notifications always has a disabled receiver for rescheduling notifications after reboot. This receiver then is enabled by Java code depending on setting, value of which is also in the manifest as meta-data.
While receiver can be created by code, they are then bound to context lifecycle, as such it is better to have this receiver in the [manifest](https://developer.android.com/develop/background-work/background-tasks/broadcasts#android-14).
This PR removes the Java code to enable the receiver and moves the logic to post processing: we will only add receiver to manifest if user has enabled reschedule on boot setting.

Developer testing:
- tested that manifest items are added as requested in Unity 2022.3 and 6 (different code path before 6)
- tested that after reboot notification still arives (Pixel 5, Android 13)

Additional testing required:
- whether notifications work after reboot on more devices and Android versions; when in doubt - check without these changes