### PR TITLE
Add missing entry to Android proguard

### DIFF
--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this package will be documented in this file.
 
+## [Unreleased]
+
+### Fixes:
+- [Android] Add missing proguard rule for NotificationChannelWrapper.
+
 ## [2.4.0] - 2024-10-11
 
 ### Changes & Improvements:

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/build.gradle
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/build.gradle
@@ -29,7 +29,6 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/proguard-rules.pro
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/proguard-rules.pro
@@ -1,3 +1,4 @@
 # Accessed from C# code
 -keep class com.unity.androidnotifications.UnityNotificationManager { public *; }
+-keep class com.unity.androidnotifications.NotificationChannelWrapper { public *; }
 -keep interface com.unity.androidnotifications.NotificationCallback { *; }


### PR DESCRIPTION
https://jira.unity3d.com/browse/MNB-90
Proguard entry for NotificationChannelWrapper was not present, hence this class is not prevented from being minified/obfuscated, even though it is being used from C# and obfuscation should be disabled for it. There were no issues in the past, but likely with Android tools updated, being non-public, the class got obfuscated and C# code is no longer able to retrieve channel details.

The issue happens with Release builds. The exception shows that class gets renamed to a single-letter and it's fields are not found either due to renames to single letter names too.

Only tested trunk on a single device, as this bug is build-time (hence Android version or device are irrelevant). Unity version is only relevant  with regard that in the past the class was preserved even without explicit rule present (Android tools). The added rule is correct regardless.