### PR TITLE
Add 6.1 to tested versions

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,5 +1,6 @@
 test_editors:
   - version: trunk
+  - version: 6000.1
   - version: 6000.0
   - version: 2022.3
   - version: 2021.3


### PR DESCRIPTION
Unity 6.1 is current last stable release, should be tested as well.