### PR TITLE
Add renovation rules

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,8 @@
+{
+    "packageRules": [
+        {
+            "matchDatasources": ["maven"],
+            "registryUrls": ["https://mvnrepository.com/repos/google"]
+        }
+    ]
+}


### PR DESCRIPTION
For integration with renovation service.
It does not look automatically for dependencies in google repo from which big picture sample takes dependncy.