### PR TITLE
Update test versions

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,7 +1,7 @@
 test_editors:
   - version: trunk
+  - version: 6000.3
   - version: 6000.2
-  - version: 6000.1
   - version: 6000.0
   - version: 2022.3
   - version: 2021.3


### PR DESCRIPTION
Unity 6.1 is no longer supported and 6.3 branched off from trunk.