### PR TITLE
Swift trampoline support

### DIFF
--- a/TestProjects/Main/Assets/Scripts/Helpers/SafeArea.cs
+++ b/TestProjects/Main/Assets/Scripts/Helpers/SafeArea.cs
@@ -33,6 +33,9 @@ namespace Unity.Notifications.Tests.Sample
 
         void ApplySafeArea(Rect r)
         {
+            // Very early in the load process screen size may not be determined yet
+            if (Screen.width == 0 || Screen.height == 0)
+                return;
             LastSafeArea = r;
 
             // Convert safe area rectangle from absolute pixels to normalised anchor coordinates

--- a/TestProjects/Main/Assets/Scripts/iOSTest.cs
+++ b/TestProjects/Main/Assets/Scripts/iOSTest.cs
@@ -128,33 +128,39 @@ namespace Unity.Notifications.Tests.Sample
                 .Gray($"isPaused = {isPaused}", 1);
             if (isPaused == false)
             {
-                var op = iOSNotificationCenter.QueryLastRespondedNotification();
-                iOSNotification notification = op.Notification;
-                if (notification != null)
+                StartCoroutine(CheckNotificationAfterPause());
+            }
+        }
+
+        IEnumerator CheckNotificationAfterPause()
+        {
+            var op = iOSNotificationCenter.QueryLastRespondedNotification();
+            yield return op;
+            iOSNotification notification = op.Notification;
+            if (notification != null)
+            {
+                m_LOGGER.Green($"Notification found:", 1);
+                if (notification.Data != "IGNORE")
                 {
-                    m_LOGGER.Green($"Notification found:", 1);
-                    if (notification.Data != "IGNORE")
+                    m_LOGGER
+                        .Orange($"[{DateTime.Now.ToString("HH:mm:ss.ffffff")}] Received notification")
+                        .Orange($"Setting BADGE to {iOSNotificationCenter.GetDeliveredNotifications().Length + 1}", 1)
+                        .Properties(notification, 1);
+                    string lastAction = op.ActionId;
+                    string lastTextInput = op.UserText;
+                    if (lastAction != null)
                     {
+                        string output = lastTextInput != null ? $"Used action {lastAction} with input '{lastTextInput}'" : $"Used action {lastAction}";
                         m_LOGGER
-                            .Orange($"[{DateTime.Now.ToString("HH:mm:ss.ffffff")}] Received notification")
-                            .Orange($"Setting BADGE to {iOSNotificationCenter.GetDeliveredNotifications().Length + 1}", 1)
-                            .Properties(notification, 1);
-                        string lastAction = op.ActionId;
-                        string lastTextInput = op.UserText;
-                        if (lastAction != null)
-                        {
-                            string output = lastTextInput != null ? $"Used action {lastAction} with input '{lastTextInput}'" : $"Used action {lastAction}";
-                            m_LOGGER
-                                .Orange(output);
-                        }
-                        iOSNotificationCenter.ApplicationBadge =
-                            iOSNotificationCenter.GetDeliveredNotifications().Length + 1;
+                            .Orange(output);
                     }
+                    iOSNotificationCenter.ApplicationBadge =
+                        iOSNotificationCenter.GetDeliveredNotifications().Length + 1;
                 }
-                else
-                {
-                    m_LOGGER.Red("Notification not found!", 1);
-                }
+            }
+            else
+            {
+                m_LOGGER.Red("Notification not found!", 1);
             }
         }
 

--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this package will be documented in this file.
 ## [Unreleased]
 
 ### Changes & Improvements:
-- Unity 6.0 or later is required
+- Unity 6.0 or later is required.
+- [iOS] Package is now compatible with the Swift Xcode project type (introduced in Unity 6.5).
 
 ## [2.4.3] - 2026-01-29
 

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationLifeCycleManager.mm
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationLifeCycleManager.mm
@@ -8,7 +8,15 @@
 #import <objc/runtime.h>
 
 #import "UnityNotificationManager.h"
+
+#if UNITY_XCODE_PROJECT_TYPE_SWIFT
+#import "UnityFramework/UnityFramework-Swift.h"
+#define kUnityWillFinishLaunchingWithOptions UnityNotifications.applicationWillFinishLaunching
+#define kUnityDidRegisterForRemoteNotificationsWithDeviceToken UnityNotifications.applicationDidRegisterForRemoteNotifications
+#define kUnityDidFailToRegisterForRemoteNotificationsWithError UnityNotifications.applicationDidFailToRegisterForRemoteNotifications
+#else
 #import "Classes/PluginBase/AppDelegateListener.h"
+#endif
 
 @interface UnityNotificationLifeCycleManager : NSObject
 

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationLifeCycleManager.mm
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationLifeCycleManager.mm
@@ -85,7 +85,7 @@
          usingBlock:^(NSNotification *notification) {
              NSLog(@"didRegisterForRemoteNotificationsWithDeviceToken");
              UnityNotificationManager* manager = [UnityNotificationManager sharedInstance];
-             [manager finishRemoteNotificationRegistration: UNAuthorizationStatusAuthorized notification: notification];
+             [manager finishRemoteNotificationRegistration: UNAuthorizationStatusAuthorized deviceToken: [UnityNotificationLifeCycleManager deviceTokenFromNotification: notification]];
          }];
 
         [nc addObserverForName: kUnityDidFailToRegisterForRemoteNotificationsWithError
@@ -94,9 +94,25 @@
          usingBlock:^(NSNotification *notification) {
              NSLog(@"didFailToRegisterForRemoteNotificationsWithError");
              UnityNotificationManager* manager = [UnityNotificationManager sharedInstance];
-             [manager finishRemoteNotificationRegistration: UNAuthorizationStatusDenied notification: notification];
+             [manager finishRemoteNotificationRegistration: UNAuthorizationStatusDenied deviceToken: nil];
          }];
     });
+}
+
++ (NSData*)deviceTokenFromNotification:(NSNotification*)notification
+{
+    NSData* deviceToken = nil;
+
+#if UNITY_XCODE_PROJECT_TYPE_SWIFT
+    id token = [notification.userInfo objectForKey: UnityNotifications.remoteNotificationsDeviceTokenKey];
+#else
+    id token = notification.userInfo;
+#endif
+
+    if ([token isKindOfClass: NSData.class])
+        deviceToken = token;
+
+    return deviceToken;
 }
 
 @end

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.h
@@ -30,7 +30,7 @@
 
 - (id)init;
 - (void)finishAuthorization:(struct iOSNotificationAuthorizationData*)authData forRequest:(void*)request;
-- (void)finishRemoteNotificationRegistration:(UNAuthorizationStatus)status notification:(NSNotification*)notification;
+- (void)finishRemoteNotificationRegistration:(UNAuthorizationStatus)status deviceToken:(NSData*)deviceToken;
 - (void)updateScheduledNotificationList;
 - (void)updateDeliveredNotificationList;
 - (void)updateNotificationSettings;

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -169,7 +169,7 @@
         return;
     }
 
-    iOSNotificationData notificationData;
+    iOSNotificationData notificationData = {};
     BOOL haveNotificationData = NO;
     if (self.onNotificationReceivedCallback != NULL)
     {

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -52,7 +52,7 @@
         self.onAuthorizationCompletionCallback(request, *authData);
 }
 
-- (void)finishRemoteNotificationRegistration:(UNAuthorizationStatus)status notification:(NSNotification*)notification
+- (void)finishRemoteNotificationRegistration:(UNAuthorizationStatus)status deviceToken:(NSData*)devToken
 {
     struct iOSNotificationAuthorizationData authData;
     authData.granted = status == UNAuthorizationStatusAuthorized;
@@ -61,7 +61,7 @@
     NSString* deviceToken = nil;
     if (authData.granted)
     {
-        deviceToken = [UnityNotificationManager deviceTokenFromNotification: notification];
+        deviceToken = [UnityNotificationManager deviceTokenToString: devToken];
         authData.deviceToken = [deviceToken UTF8String];
     }
 
@@ -139,12 +139,9 @@
     _remoteNotificationsRegistered = UNAuthorizationStatusNotDetermined;
 }
 
-+ (NSString*)deviceTokenFromNotification:(NSNotification*)notification
++ (NSString*)deviceTokenToString:(NSData*)deviceTokenData
 {
-    NSData* deviceTokenData;
-    if ([notification.userInfo isKindOfClass: [NSData class]])
-        deviceTokenData = (NSData*)notification.userInfo;
-    else
+    if (deviceTokenData == nil)
         return nil;
 
     NSUInteger len = deviceTokenData.length;


### PR DESCRIPTION
https://jira.unity3d.com/browse/PLAT-21036
Make mobile notifications package work with Swift trampoline.
Changes:
- fix subscribing to OS notifications, which are between across trampolines
- fix device token retrieval (userInfo difference between trampolines)
- fix an issue with safe area handling and notification retrieval in unpause, issue with event timing in different trampones here
Testing:
- tested both trampolines using trunk
- simple notifications are sent in both
- device token is retrieved in both
- automation currently only tests Objective-C, adding it for Swift will be done as a separate task