### PR TITLE
Android cleanup after min spec bump

### DIFF
--- a/com.unity.mobile.notifications/Documentation~/Android.md
+++ b/com.unity.mobile.notifications/Documentation~/Android.md
@@ -34,8 +34,6 @@ On devices that use Android versions prior to 8.0, this package emulates the sam
 
 ## Schedule notifications at exact time
 
-Before Android 6.0 notifications can be scheduled only at approximate time.
-
 Since Android 12.0 (API level 31) android.permission.SCHEDULE_EXACT_ALARM permission has to be added to the manifest to enable exact scheduling, see [documentation](https://developer.android.com/reference/android/Manifest.permission#SCHEDULE_EXACT_ALARM). Note, that adding this permission does not guarantee you'll be able to use exact scheduling. You can check it by calling AndroidNotificationCenter.UsingExactScheduling. You may need to request user permission to schedule at exact times by calling AndroidNotificationCenter.RequestExactScheduling().
 
 Since Android 13.0 (API level 33) the android.permission.USE_EXACT_ALARM is and alternative permission to enable exact scheduling.
@@ -130,7 +128,7 @@ Usually, Unity generates a unique id for each notification after you schedule it
 var id = AndroidNotificationCenter.SendNotification(notification, "channel_id");
 ```
 
-You can use this id to track, cancel, or update the notification. The following example shows how to check the notification status and perform any actions depending on the result. Notification status tracking only works on Android 6.0 Marshmallow and above.
+You can use this id to track, cancel, or update the notification. The following example shows how to check the notification status and perform any actions depending on the result.
 
 ```c#
 var notificationStatus = AndroidNotificationCenter.CheckScheduledNotificationStatus(id);

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/build.gradle
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/build.gradle
@@ -23,7 +23,7 @@ android {
     buildToolsVersion unityLib.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 22
+        minSdkVersion 23
         consumerProguardFiles "proguard-rules.pro"
     }
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
@@ -11,7 +11,6 @@ import android.app.NotificationChannelGroup;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
-import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
@@ -245,7 +245,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
         channel.id = id;
         channel.name = prefs.getString("title", "undefined");
-        channel.importance = prefs.getInt("importance", NotificationManager.IMPORTANCE_DEFAULT);
+        channel.importance = prefs.getInt("importance", 3 /* NotificationManager.IMPORTANCE_DEFAULT */);
         channel.description = prefs.getString("description", "undefined");
         channel.enableLights = prefs.getBoolean("enableLights", false);
         channel.enableVibration = prefs.getBoolean("enableVibration", false);

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
@@ -95,8 +95,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
         if (mRandom == null)
             mRandom = new Random();
 
-        Bundle metaData = getAppMetadata();
-
         mOpenActivity = UnityNotificationUtilities.getOpenAppActivity(mContext);
         if (mOpenActivity == null)
             throw new RuntimeException("Failed to determine Activity to be opened when tapping notification");

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
@@ -502,17 +502,11 @@ public class UnityNotificationManager extends BroadcastReceiver {
     }
 
     private PendingIntent getActivityPendingIntent(int id, Intent intent, int flags) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
-            return PendingIntent.getActivity(mContext, id, intent, flags | PendingIntent.FLAG_IMMUTABLE);
-        else
-            return PendingIntent.getActivity(mContext, id, intent, flags);
+        return PendingIntent.getActivity(mContext, id, intent, flags | PendingIntent.FLAG_IMMUTABLE);
     }
 
     private PendingIntent getBroadcastPendingIntent(int id, Intent intent, int flags) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
-            return PendingIntent.getBroadcast(mContext, id, intent, flags | PendingIntent.FLAG_IMMUTABLE);
-        else
-            return PendingIntent.getBroadcast(mContext, id, intent, flags);
+        return PendingIntent.getBroadcast(mContext, id, intent, flags | PendingIntent.FLAG_IMMUTABLE);
     }
 
     // Save the notification intent to SharedPreferences if reschedule_on_restart is true,

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
@@ -72,7 +72,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
     public static final String KEY_SMALL_ICON = "smallIcon";
     public static final String KEY_CHANNEL_ID = "channelID";
     public static final String KEY_SHOW_IN_FOREGROUND = "com.unity.showInForeground";
-    public static final String KEY_NOTIFICATION_DISMISSED = "com.unity.NotificationDismissed";
     public static final String KEY_BIG_LARGE_ICON = "com.unity.BigLargeIcon";
     public static final String KEY_BIG_PICTURE = "com.unity.BigPicture";
     public static final String KEY_BIG_CONTENT_TITLE = "com.unity.BigContentTytle";
@@ -428,15 +427,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
         PendingIntent pendingIntent = PendingIntent.getActivity(mContext, id, openAppIntent, PendingIntent.FLAG_IMMUTABLE);
         builder.setContentIntent(pendingIntent);
 
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            // Can't check StatusBar notifications pre-M, so ask to be notified when dismissed
-            Intent deleteIntent = new Intent(mContext, UnityNotificationManager.class);
-            deleteIntent.setAction(KEY_NOTIFICATION_DISMISSED); // need action to distinguish intent from content one
-            deleteIntent.putExtra(KEY_NOTIFICATION_DISMISSED, id);
-            PendingIntent deletePending = getBroadcastPendingIntent(id, deleteIntent, 0);
-            builder.setDeleteIntent(deletePending);
-        }
-
         finalizeNotificationForDisplay(builder);
         return builder.build();
     }
@@ -677,15 +667,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
     }
 
     public void onReceive(Intent intent) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            if (KEY_NOTIFICATION_DISMISSED.equals(intent.getAction())) {
-                int removedId = intent.getIntExtra(KEY_NOTIFICATION_DISMISSED, -1);
-                if (removedId > 0) synchronized (this) {
-                    mVisibleNotifications.remove(removedId);
-                }
-                return;
-            }
-        }
         showNotification(intent);
     }
 

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
@@ -425,7 +425,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         Intent openAppIntent = new Intent(mContext, openActivity);
         openAppIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
         openAppIntent.putExtra(KEY_NOTIFICATION_ID, id);
-        PendingIntent pendingIntent = getActivityPendingIntent(id, openAppIntent, 0);
+        PendingIntent pendingIntent = PendingIntent.getActivity(mContext, id, openAppIntent, PendingIntent.FLAG_IMMUTABLE);
         builder.setContentIntent(pendingIntent);
 
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
@@ -499,10 +499,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
         Intent intent = new Intent(mContext, UnityNotificationManager.class);
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
         return intent;
-    }
-
-    private PendingIntent getActivityPendingIntent(int id, Intent intent, int flags) {
-        return PendingIntent.getActivity(mContext, id, intent, flags | PendingIntent.FLAG_IMMUTABLE);
     }
 
     private PendingIntent getBroadcastPendingIntent(int id, Intent intent, int flags) {

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
@@ -409,7 +409,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         mScheduledNotifications.put(Integer.valueOf(id), notificationBuilder);
         intent.putExtra(KEY_NOTIFICATION_ID, id);
 
-        PendingIntent broadcast = getBroadcastPendingIntent(id, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent broadcast = PendingIntent.getBroadcast(mContext, id, intent, PendingIntent.FLAG_UPDATE_CURRENT|PendingIntent.FLAG_IMMUTABLE);
         scheduleNotificationIntentAlarm(repeatInterval, fireTime, broadcast);
     }
 
@@ -452,7 +452,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         for (String id : ids) {
             // Get the given broadcast PendingIntent by id as request code.
             // FLAG_NO_CREATE is set to return null if the described PendingIntent doesn't exist.
-            PendingIntent broadcast = getBroadcastPendingIntent(Integer.valueOf(id), intent, PendingIntent.FLAG_NO_CREATE);
+            PendingIntent broadcast = PendingIntent.getBroadcast(mContext, Integer.parseInt(id), intent, PendingIntent.FLAG_NO_CREATE|PendingIntent.FLAG_IMMUTABLE);
             if (broadcast == null) {
                 invalid.add(id);
             }
@@ -489,10 +489,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
         Intent intent = new Intent(mContext, UnityNotificationManager.class);
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
         return intent;
-    }
-
-    private PendingIntent getBroadcastPendingIntent(int id, Intent intent, int flags) {
-        return PendingIntent.getBroadcast(mContext, id, intent, flags | PendingIntent.FLAG_IMMUTABLE);
     }
 
     // Save the notification intent to SharedPreferences if reschedule_on_restart is true,
@@ -605,7 +601,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
     // Check if the pending notification with the given id has been registered.
     public boolean checkIfPendingNotificationIsRegistered(int id) {
         Intent intent = new Intent(mActivity, UnityNotificationManager.class);
-        return (getBroadcastPendingIntent(id, intent, PendingIntent.FLAG_NO_CREATE) != null);
+        return null != PendingIntent.getBroadcast(mContext, id, intent, PendingIntent.FLAG_NO_CREATE|PendingIntent.FLAG_IMMUTABLE);
     }
 
     // Cancel all the pending notifications.
@@ -633,7 +629,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
     // Cancel a pending notification by id.
     void cancelPendingNotificationIntent(int id) {
         Intent intent = new Intent(mContext, UnityNotificationManager.class);
-        PendingIntent broadcast = getBroadcastPendingIntent(id, intent, PendingIntent.FLAG_NO_CREATE);
+        PendingIntent broadcast = PendingIntent.getBroadcast(mContext, id, intent, PendingIntent.FLAG_NO_CREATE|PendingIntent.FLAG_IMMUTABLE);
 
         if (broadcast != null) {
             AlarmManager alarmManager = (AlarmManager) mContext.getSystemService(Context.ALARM_SERVICE);

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
@@ -755,7 +755,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
     private void finalizeNotificationForDisplay(Notification.Builder notificationBuilder) {
         String icon = notificationBuilder.getExtras().getString(KEY_SMALL_ICON);
         Object ico = getIconForUri(icon);
-        if (ico != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        if (ico != null) {
             notificationBuilder.setSmallIcon((Icon)ico);
         } else {
             int iconId = UnityNotificationUtilities.findResourceIdInContextByName(mContext, icon);
@@ -768,7 +768,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         icon = notificationBuilder.getExtras().getString(KEY_LARGE_ICON);
         Object largeIcon = getIcon(icon);
         if (largeIcon != null) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && largeIcon instanceof Icon)
+            if (largeIcon instanceof Icon)
                 notificationBuilder.setLargeIcon((Icon)largeIcon);
             else
                 notificationBuilder.setLargeIcon((Bitmap)largeIcon);
@@ -794,7 +794,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
     private Object getIconForUri(String uri) {
         if (uri == null || uri.length() == 0)
             return null;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && uri.indexOf("://") > 0) {
+        if (uri.indexOf("://") > 0) {
             return Icon.createWithContentUri(uri);
         }
 
@@ -804,7 +804,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
     private Object getIconFromResources(String name, boolean forceBitmap) {
         int iconId = UnityNotificationUtilities.findResourceIdInContextByName(mContext, name);
         if (iconId != 0) {
-            if (!forceBitmap && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+            if (!forceBitmap)
                 return Icon.createWithResource(mContext, iconId);
             return BitmapFactory.decodeResource(mContext.getResources(), iconId);
         }
@@ -895,7 +895,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         String largeIcon = extras.getString(KEY_BIG_LARGE_ICON);
         Object ico = getIcon(largeIcon);
         if (ico != null) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && ico instanceof Icon)
+            if (ico instanceof Icon)
                 style.bigLargeIcon((Icon)ico);
             else
                 style.bigLargeIcon((Bitmap)ico);
@@ -903,7 +903,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
         if (picture.charAt(0) == '/') {
             style.bigPicture(BitmapFactory.decodeFile(picture));
-        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && picture.indexOf("://") > 0) {
+        } else if (picture.indexOf("://") > 0) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 Icon icon = Icon.createWithContentUri(picture);
                 style.bigPicture(icon);

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
@@ -318,7 +318,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
     public NotificationChannelWrapper[] getNotificationChannels() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             List<NotificationChannel> channels = getNotificationManager().getNotificationChannels();
-            if (channels.size() == 0)
+            if (channels.isEmpty())
                 return null;
             NotificationChannelWrapper[] channelList = new NotificationChannelWrapper[channels.size()];
             int i = 0;
@@ -330,7 +330,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         } else {
             SharedPreferences prefs = mContext.getSharedPreferences(NOTIFICATION_CHANNELS_SHARED_PREFS, Context.MODE_PRIVATE);
             Set<String> channelIdsSet = prefs.getStringSet(NOTIFICATION_CHANNELS_SHARED_PREFS_KEY, new HashSet<>());
-            if (channelIdsSet.size() == 0)
+            if (channelIdsSet.isEmpty())
                 return null;
             NotificationChannelWrapper[] channels = new NotificationChannelWrapper[channelIdsSet.size()];
             int i = 0;
@@ -513,7 +513,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
                 idsMarkedForRemoval.add(id);
         }
 
-        if (idsMarkedForRemoval.size() > 0) {
+        if (!idsMarkedForRemoval.isEmpty()) {
             ids = new HashSet<>(ids);
             for (String id : idsMarkedForRemoval) {
                 ids.remove(id);
@@ -754,7 +754,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
     }
 
     private Object getIcon(String icon) {
-        if (icon == null || icon.length() == 0)
+        if (icon == null || icon.isEmpty())
             return null;
         if (icon.charAt(0) == '/') {
             return BitmapFactory.decodeFile(icon);
@@ -768,7 +768,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
     }
 
     private Object getIconForUri(String uri) {
-        if (uri == null || uri.length() == 0)
+        if (uri == null || uri.isEmpty())
             return null;
         if (uri.indexOf("://") > 0) {
             return Icon.createWithContentUri(uri);
@@ -843,7 +843,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
     }
 
     public static void setNotificationIcon(Notification.Builder notificationBuilder, String keyName, String icon) {
-        if (icon == null || icon.length() == 0 && notificationBuilder.getExtras().getString(keyName) != null)
+        if (icon == null || icon.isEmpty() && notificationBuilder.getExtras().getString(keyName) != null)
             notificationBuilder.getExtras().remove(keyName);
         else
             notificationBuilder.getExtras().putString(keyName, icon);
@@ -852,7 +852,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
     public void setupBigPictureStyle(Notification.Builder builder,
             String largeIcon, String picture, String contentTitle, String contentDescription, String summaryText, boolean showWhenCollapsed) {
         Bundle extras = builder.getExtras();
-        if (picture == null || picture.length() == 0)
+        if (picture == null || picture.isEmpty())
             return;
         extras.putString(KEY_BIG_LARGE_ICON, largeIcon);
         extras.putString(KEY_BIG_PICTURE, picture);
@@ -1005,7 +1005,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
             Uri uri = Uri.fromParts("package", mContext.getPackageName(), null);
             settingsIntent.setData(uri);
         } else {
-            if (channelId != null && channelId.length() > 0) {
+            if (channelId != null && !channelId.isEmpty()) {
                 settingsIntent = new Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS);
                 settingsIntent.putExtra(Settings.EXTRA_CHANNEL_ID, channelId);
             } else {

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
@@ -429,10 +429,9 @@ public class UnityNotificationManager extends BroadcastReceiver {
         Log.d(TAG_UNITY, "Checking for invalid notification IDs still hanging around");
 
         Set<String> invalid = findInvalidNotificationIds(ids);
-        Set<String> currentIds = new HashSet<>(ids);
         for (String id : invalid) {
-            currentIds.remove(id);
-            mScheduledNotifications.remove(id);
+            ids.remove(id);
+            mScheduledNotifications.remove(Integer.valueOf(id));
         }
 
         // in case we have saved intents, clear them

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
@@ -89,7 +89,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         mActivity = activity;
         mNotificationCallback = notificationCallback;
         if (mScheduledNotifications == null)
-            mScheduledNotifications = new ConcurrentHashMap();
+            mScheduledNotifications = new ConcurrentHashMap<>();
         if (mBackgroundThread == null || !mBackgroundThread.isAlive())
             mBackgroundThread = new UnityNotificationBackgroundThread(this, mScheduledNotifications);
         if (mRandom == null)
@@ -105,7 +105,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
     static synchronized UnityNotificationManager getNotificationManagerImpl(Context context) {
         if (mUnityNotificationManager == null) {
             mUnityNotificationManager = new UnityNotificationManager();
-            mUnityNotificationManager.mScheduledNotifications = new ConcurrentHashMap();
+            mUnityNotificationManager.mScheduledNotifications = new ConcurrentHashMap<>();
         }
 
         // always assign context, as it might change
@@ -297,13 +297,13 @@ public class UnityNotificationManager extends BroadcastReceiver {
             getNotificationManager().deleteNotificationChannel(id);
         } else {
             SharedPreferences prefs = mContext.getSharedPreferences(NOTIFICATION_CHANNELS_SHARED_PREFS, Context.MODE_PRIVATE);
-            Set<String> channelIds = prefs.getStringSet(NOTIFICATION_CHANNELS_SHARED_PREFS_KEY, new HashSet());
+            Set<String> channelIds = prefs.getStringSet(NOTIFICATION_CHANNELS_SHARED_PREFS_KEY, new HashSet<>());
 
             if (!channelIds.contains(id))
                 return;
 
             // Remove from the notification channel ids SharedPreferences.
-            channelIds = new HashSet(channelIds);
+            channelIds = new HashSet<>(channelIds);
             channelIds.remove(id);
             SharedPreferences.Editor editor = prefs.edit().clear();
             editor.putStringSet(NOTIFICATION_CHANNELS_SHARED_PREFS_KEY, channelIds);
@@ -329,7 +329,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
             return channelList;
         } else {
             SharedPreferences prefs = mContext.getSharedPreferences(NOTIFICATION_CHANNELS_SHARED_PREFS, Context.MODE_PRIVATE);
-            Set<String> channelIdsSet = prefs.getStringSet(NOTIFICATION_CHANNELS_SHARED_PREFS_KEY, new HashSet());
+            Set<String> channelIdsSet = prefs.getStringSet(NOTIFICATION_CHANNELS_SHARED_PREFS_KEY, new HashSet<>());
             if (channelIdsSet.size() == 0)
                 return null;
             NotificationChannelWrapper[] channels = new NotificationChannelWrapper[channelIdsSet.size()];
@@ -493,7 +493,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
     synchronized List<Notification.Builder> loadSavedNotifications() {
         Set<String> ids = getScheduledNotificationIDs();
 
-        List<Notification.Builder> intent_data_list = new ArrayList();
+        List<Notification.Builder> intent_data_list = new ArrayList<>();
         Set<String> idsMarkedForRemoval = new HashSet<String>();
 
         for (String id : ids) {

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
@@ -540,9 +540,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
     }
 
     private boolean canScheduleExactAlarms(AlarmManager alarmManager) {
-        // exact scheduling supported since Android 6
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M)
-            return false;
         if (mExactSchedulingSetting < 0) {
             Bundle metaData = getAppMetadata();
             if (metaData != null)
@@ -566,7 +563,7 @@ public class UnityNotificationManager extends BroadcastReceiver {
         AlarmManager alarmManager = (AlarmManager) mContext.getSystemService(Context.ALARM_SERVICE);
 
         if (repeatInterval <= 0) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && canScheduleExactAlarms(alarmManager)) {
+            if (canScheduleExactAlarms(alarmManager)) {
                 alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, fireTime, broadcast);
             } else {
                 alarmManager.set(AlarmManager.RTC_WAKEUP, fireTime, broadcast);

--- a/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
+++ b/com.unity.mobile.notifications/Runtime/Android/Plugins/mobilenotifications.androidlib/src/main/java/com/unity/androidnotifications/UnityNotificationManager.java
@@ -52,7 +52,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
     private Class mOpenActivity = null;
     private UnityNotificationBackgroundThread mBackgroundThread;
     private Random mRandom;
-    private HashSet<Integer> mVisibleNotifications;
     private ConcurrentHashMap<Integer, Notification.Builder> mScheduledNotifications;
     private NotificationCallback mNotificationCallback;
     private int mExactSchedulingSetting = -1;
@@ -95,8 +94,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
             mBackgroundThread = new UnityNotificationBackgroundThread(this, mScheduledNotifications);
         if (mRandom == null)
             mRandom = new Random();
-        if (mVisibleNotifications == null)
-            mVisibleNotifications = new HashSet<>();
 
         Bundle metaData = getAppMetadata();
 
@@ -110,7 +107,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
     static synchronized UnityNotificationManager getNotificationManagerImpl(Context context) {
         if (mUnityNotificationManager == null) {
             mUnityNotificationManager = new UnityNotificationManager();
-            mUnityNotificationManager.mVisibleNotifications = new HashSet<>();
             mUnityNotificationManager.mScheduledNotifications = new ConcurrentHashMap();
         }
 
@@ -458,19 +454,11 @@ public class UnityNotificationManager extends BroadcastReceiver {
             }
         }
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            StatusBarNotification[] active = getNotificationManager().getActiveNotifications();
-            for (StatusBarNotification notification : active) {
-                // any notifications in status bar are still valid
-                String id = String.valueOf(notification.getId());
-                invalid.remove(id);
-            }
-        }
-        else synchronized (this) {
-            for (Integer visibleId : mVisibleNotifications) {
-                String id = String.valueOf(visibleId);
-                invalid.remove(id);
-            }
+        StatusBarNotification[] active = getNotificationManager().getActiveNotifications();
+        for (StatusBarNotification notification : active) {
+            // any notifications in status bar are still valid
+            String id = String.valueOf(notification.getId());
+            invalid.remove(id);
         }
 
         // if app is launched with notification, user still has access to it
@@ -575,16 +563,9 @@ public class UnityNotificationManager extends BroadcastReceiver {
 
     // Check the notification status by id.
     public int checkNotificationStatus(int id) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            for (StatusBarNotification n : getNotificationManager().getActiveNotifications()) {
-                if (id == n.getId())
-                    return 2;
-            }
-        } else synchronized (this) {
-            for (Integer notificationId : mVisibleNotifications) {
-                if (notificationId.intValue() == id)
-                    return 2;
-            }
+        for (StatusBarNotification n : getNotificationManager().getActiveNotifications()) {
+            if (id == n.getId())
+                return 2;
         }
 
         if (mScheduledNotifications.containsKey(id))
@@ -718,9 +699,6 @@ public class UnityNotificationManager extends BroadcastReceiver {
         boolean showInForeground = notification.extras.getBoolean(KEY_SHOW_IN_FOREGROUND, true);
         if (!isInForeground() || showInForeground) {
             getNotificationManager().notify(id, notification);
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) synchronized (this) {
-                mVisibleNotifications.add(Integer.valueOf(id));
-            }
         }
 
         long repeatInterval = notification.extras.getLong(KEY_REPEAT_INTERVAL, -1);
@@ -964,14 +942,12 @@ public class UnityNotificationManager extends BroadcastReceiver {
     }
 
     public Notification getNotificationFromIntent(Intent intent) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            if (intent.hasExtra(KEY_NOTIFICATION_ID)) {
-                int id = intent.getExtras().getInt(KEY_NOTIFICATION_ID);
-                StatusBarNotification[] shownNotifications = getNotificationManager().getActiveNotifications();
-                for (StatusBarNotification n : shownNotifications) {
-                    if (n.getId() == id) {
-                        return n.getNotification();
-                    }
+        if (intent.hasExtra(KEY_NOTIFICATION_ID)) {
+            int id = intent.getExtras().getInt(KEY_NOTIFICATION_ID);
+            StatusBarNotification[] shownNotifications = getNotificationManager().getActiveNotifications();
+            for (StatusBarNotification n : shownNotifications) {
+                if (n.getId() == id) {
+                    return n.getNotification();
                 }
             }
         }


### PR DESCRIPTION
https://jira.unity3d.com/browse/PLAT-19434
Android code cleanup after min spec bump. Package now is compatible with Unity 6.0, which requires Android 6 (M, API level 23), so all the code paths for the older versions can go away.
Some unrelated changes: Rider warning cleaned up.
There is a single functional change: the code cleaning up old notifications was not correct - did not modify set passed as parameter. This change does not have user-visible effect, we simply kept information on notifications longer then we should have, past their expiration time.

Tested on Pixel 5 with Android 13:
- notifications work, tapping one opens the app
- cancel notification works
- update notification works correctly
- killing app or restarting device, scheduled notification arrives as expected

*Please carefully review the code changes so that no condition was flipped anywhere.*