### PR TITLE
Swift trampoline fixes

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,5 +1,6 @@
 test_editors:
   - version: trunk
+  - version: 6000.6
   - version: 6000.5
   - version: 6000.4
   - version: 6000.3

--- a/com.unity.mobile.notifications/Editor/iOSNotificationPostProcessor.cs
+++ b/com.unity.mobile.notifications/Editor/iOSNotificationPostProcessor.cs
@@ -55,6 +55,7 @@ public class iOSNotificationPostProcessor : MonoBehaviour
     private static void PatchPBXProject(string path, bool needLocationFramework, bool addPushNotificationCapability, bool useReleaseAPSEnv, bool addTimeSensitiveEntitlement)
     {
         var pbxProjectPath = PBXProject.GetPBXProjectPath(path);
+        List<string> swiftPropertiesToAdd = new();
 
         var needsToWriteChanges = false;
 
@@ -87,6 +88,7 @@ public class iOSNotificationPostProcessor : MonoBehaviour
         if (needLocationFramework && !pbxProject.ContainsFramework(unityFrameworkTarget, "CoreLocation.framework"))
         {
             pbxProject.AddFrameworkToProject(unityFrameworkTarget, "CoreLocation.framework", false);
+            swiftPropertiesToAdd.Add("-DUNITY_USES_LOCATION");
             needsToWriteChanges = true;
         }
 
@@ -100,6 +102,7 @@ public class iOSNotificationPostProcessor : MonoBehaviour
         // Update the entitlements file.
         if (addPushNotificationCapability)
         {
+            swiftPropertiesToAdd.Add("-DUNITY_USES_REMOTE_NOTIFICATIONS");
             var capManager = new ProjectCapabilityManager(pbxProjectPath, entitlementsFileName, "Unity-iPhone");
             capManager.AddPushNotifications(!useReleaseAPSEnv);
             capManager.WriteToFile();
@@ -122,6 +125,12 @@ public class iOSNotificationPostProcessor : MonoBehaviour
                 pbxProject.AddBuildProperty(mainTarget, "CODE_SIGN_ENTITLEMENTS", entitlementsFileName);
                 needsToWriteChanges = true;
             }
+        }
+
+        if (swiftPropertiesToAdd.Count > 0)
+        {
+            pbxProject.UpdateBuildProperty(unityFrameworkTarget, "OTHER_SWIFT_FLAGS", swiftPropertiesToAdd, new string[0]);
+            needsToWriteChanges = true;
         }
 
         if (needsToWriteChanges)

--- a/com.unity.mobile.notifications/Editor/iOSNotificationPostProcessor.cs
+++ b/com.unity.mobile.notifications/Editor/iOSNotificationPostProcessor.cs
@@ -42,6 +42,7 @@ public class iOSNotificationPostProcessor : MonoBehaviour
         List<string> swiftPropertiesToAdd = new();
 
         var needsToWriteChanges = false;
+        var needsCodeSignEntitlements = false;
 
         var pbxProject = new PBXProject();
         pbxProject.ReadFromString(File.ReadAllText(pbxProjectPath));
@@ -76,11 +77,16 @@ public class iOSNotificationPostProcessor : MonoBehaviour
             needsToWriteChanges = true;
         }
 
-        var entitlementsFileName = pbxProject.GetBuildPropertyForAnyConfig(mainTarget, "CODE_SIGN_ENTITLEMENTS");
-        if (entitlementsFileName == null)
+        string entitlementsFileName = null;
+        if (addPushNotificationCapability || addTimeSensitiveEntitlement)
         {
-            var bundleIdentifier = PlayerSettings.GetApplicationIdentifier(BuildTargetGroup.iOS);
-            entitlementsFileName = string.Format("{0}.entitlements", bundleIdentifier.Substring(bundleIdentifier.LastIndexOf(".") + 1));
+            entitlementsFileName = pbxProject.GetBuildPropertyForAnyConfig(mainTarget, "CODE_SIGN_ENTITLEMENTS");
+            if (entitlementsFileName == null)
+            {
+                var bundleIdentifier = PlayerSettings.GetApplicationIdentifier(BuildTargetGroup.iOS);
+                entitlementsFileName = string.Format("{0}.entitlements", bundleIdentifier.Substring(bundleIdentifier.LastIndexOf(".") + 1));
+                needsCodeSignEntitlements = true;
+            }
         }
 
         // Update the entitlements file.
@@ -90,6 +96,7 @@ public class iOSNotificationPostProcessor : MonoBehaviour
             var capManager = new ProjectCapabilityManager(pbxProjectPath, entitlementsFileName, "Unity-iPhone");
             capManager.AddPushNotifications(!useReleaseAPSEnv);
             capManager.WriteToFile();
+            needsToWriteChanges = true;
         }
 
         if (addTimeSensitiveEntitlement)
@@ -104,11 +111,12 @@ public class iOSNotificationPostProcessor : MonoBehaviour
                 entitlementsFile.root["com.apple.developer.usernotifications.time-sensitive"] = new PlistElementBoolean(true);
                 entitlementsFile.WriteToFile(entitlementsFilePath);
             }
-            if (pbxProject.GetBuildPropertyForAnyConfig(mainTarget, "CODE_SIGN_ENTITLEMENTS") == null)
-            {
-                pbxProject.AddBuildProperty(mainTarget, "CODE_SIGN_ENTITLEMENTS", entitlementsFileName);
-                needsToWriteChanges = true;
-            }
+        }
+
+        if (needsCodeSignEntitlements)
+        {
+            pbxProject.AddBuildProperty(mainTarget, "CODE_SIGN_ENTITLEMENTS", entitlementsFileName);
+            needsToWriteChanges = true;
         }
 
         if (swiftPropertiesToAdd.Count > 0)

--- a/com.unity.mobile.notifications/Editor/iOSNotificationPostProcessor.cs
+++ b/com.unity.mobile.notifications/Editor/iOSNotificationPostProcessor.cs
@@ -90,9 +90,6 @@ public class iOSNotificationPostProcessor : MonoBehaviour
             needsToWriteChanges = true;
         }
 
-        if (needsToWriteChanges)
-            File.WriteAllText(pbxProjectPath, pbxProject.WriteToString());
-
         var entitlementsFileName = pbxProject.GetBuildPropertyForAnyConfig(mainTarget, "CODE_SIGN_ENTITLEMENTS");
         if (entitlementsFileName == null)
         {
@@ -123,9 +120,12 @@ public class iOSNotificationPostProcessor : MonoBehaviour
             if (pbxProject.GetBuildPropertyForAnyConfig(mainTarget, "CODE_SIGN_ENTITLEMENTS") == null)
             {
                 pbxProject.AddBuildProperty(mainTarget, "CODE_SIGN_ENTITLEMENTS", entitlementsFileName);
-                pbxProject.WriteToFile(pbxProjectPath);
+                needsToWriteChanges = true;
             }
         }
+
+        if (needsToWriteChanges)
+            pbxProject.WriteToFile(pbxProjectPath);
     }
 
     private static void PatchPlist(string path, List<Unity.Notifications.NotificationSetting> settings, bool addPushNotificationCapability)

--- a/com.unity.mobile.notifications/Editor/iOSNotificationPostProcessor.cs
+++ b/com.unity.mobile.notifications/Editor/iOSNotificationPostProcessor.cs
@@ -193,7 +193,12 @@ public class iOSNotificationPostProcessor : MonoBehaviour
         if (!(needLocationFramework || addPushNotificationCapability))
             return;
 
-        var preprocessorPath = path + "/Classes/Preprocessor.h";
+        var preprocessorPath = Path.Combine(path, "Classes/Preprocessor.h");
+#if UNITY_6000_5_OR_NEWER
+        if (PlayerSettings.xcodeProjectType == XcodeProjectType.Swift)
+            preprocessorPath = Path.Combine(path, "UnityFramework/Prefix/Preprocessor.h");
+#endif
+
         var preprocessor = File.ReadAllText(preprocessorPath);
         var needsToWriteChanges = false;
 

--- a/com.unity.mobile.notifications/Editor/iOSNotificationPostProcessor.cs
+++ b/com.unity.mobile.notifications/Editor/iOSNotificationPostProcessor.cs
@@ -17,22 +17,6 @@ public class iOSNotificationPostProcessor : MonoBehaviour
         if (buildTarget != BuildTarget.iOS)
             return;
 
-        // Check if we have the minimal iOS version set.
-        bool hasMinOSVersion;
-        try
-        {
-            var requiredVersion = new Version(10, 0);
-            var currentVersion = new Version(PlayerSettings.iOS.targetOSVersionString);
-            hasMinOSVersion = currentVersion >= requiredVersion;
-        }
-        catch (Exception)
-        {
-            hasMinOSVersion = false;
-        }
-
-        if (!hasMinOSVersion)
-            Debug.Log("UserNotifications framework is only available on iOS 10.0+, please make sure that you set a correct `Target minimum iOS Version` in Player Settings.");
-
         var settings = NotificationSettingsManager.Initialize().iOSNotificationSettingsFlat;
 
         var needLocationFramework = (bool)settings.Find(i => i.Key == NotificationSettings.iOSSettings.USE_LOCATION_TRIGGER).Value;

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityMobileNotificationsBridge.swift
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityMobileNotificationsBridge.swift
@@ -3,23 +3,23 @@
 import Foundation
 
 @_cdecl("UnityMobileNotifications_applicationWillFinishLaunchingName")
-func applicationWillFinishLaunchingName() -> String {
-    UnityNotifications.applicationWillFinishLaunching.rawValue
+func applicationWillFinishLaunchingName() -> Notification.Name {
+    UnityNotifications.applicationWillFinishLaunching
 }
 
 @_cdecl("UnityMobileNotifications_applicationDidRegisterForRemoteNotificationsName")
-func applicationDidRegisterForRemoteNotificationsName() -> String {
-    UnityNotifications.applicationDidRegisterForRemoteNotifications.rawValue
+func applicationDidRegisterForRemoteNotificationsName() -> Notification.Name {
+    UnityNotifications.applicationDidRegisterForRemoteNotifications
 }
 
 @_cdecl("UnityMobileNotifications_applicationDidFailToRegisterForRemoteNotificationsName")
-func applicationDidFailToRegisterForRemoteNotificationsName() -> String {
-    UnityNotifications.applicationDidFailToRegisterForRemoteNotifications.rawValue
+func applicationDidFailToRegisterForRemoteNotificationsName() -> Notification.Name {
+    UnityNotifications.applicationDidFailToRegisterForRemoteNotifications
 }
 
 @_cdecl("UnityMobileNotifications_remoteNotificationsDeviceTokenKey")
-func remoteNotificationsDeviceTokenKey() -> String {
-    UnityNotifications.remoteNotificationsDeviceTokenKey
+func remoteNotificationsDeviceTokenKey() -> NSString {
+    UnityNotifications.remoteNotificationsDeviceTokenKey as NSString
 }
 
 #endif

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityMobileNotificationsBridge.swift
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityMobileNotificationsBridge.swift
@@ -1,0 +1,25 @@
+#if UNITY_XCODE_PROJECT_TYPE_SWIFT
+
+import Foundation
+
+@_cdecl("UnityMobileNotifications_applicationWillFinishLaunchingName")
+func applicationWillFinishLaunchingName() -> String {
+    UnityNotifications.applicationWillFinishLaunching.rawValue
+}
+
+@_cdecl("UnityMobileNotifications_applicationDidRegisterForRemoteNotificationsName")
+func applicationDidRegisterForRemoteNotificationsName() -> String {
+    UnityNotifications.applicationDidRegisterForRemoteNotifications.rawValue
+}
+
+@_cdecl("UnityMobileNotifications_applicationDidFailToRegisterForRemoteNotificationsName")
+func applicationDidFailToRegisterForRemoteNotificationsName() -> String {
+    UnityNotifications.applicationDidFailToRegisterForRemoteNotifications.rawValue
+}
+
+@_cdecl("UnityMobileNotifications_remoteNotificationsDeviceTokenKey")
+func remoteNotificationsDeviceTokenKey() -> String {
+    UnityNotifications.remoteNotificationsDeviceTokenKey
+}
+
+#endif

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityMobileNotificationsBridge.swift.meta
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityMobileNotificationsBridge.swift.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a6755e49d1b234e6bb7a4955e713b3b8

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationLifeCycleManager.mm
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationLifeCycleManager.mm
@@ -10,10 +10,16 @@
 #import "UnityNotificationManager.h"
 
 #if UNITY_XCODE_PROJECT_TYPE_SWIFT
-#import "UnityFramework/UnityFramework-Swift.h"
-#define kUnityWillFinishLaunchingWithOptions UnityNotifications.applicationWillFinishLaunching
-#define kUnityDidRegisterForRemoteNotificationsWithDeviceToken UnityNotifications.applicationDidRegisterForRemoteNotifications
-#define kUnityDidFailToRegisterForRemoteNotificationsWithError UnityNotifications.applicationDidFailToRegisterForRemoteNotifications
+extern "C"
+{
+    NSString* UnityMobileNotifications_applicationWillFinishLaunchingName();
+    NSString* UnityMobileNotifications_applicationDidRegisterForRemoteNotificationsName();
+    NSString* UnityMobileNotifications_applicationDidFailToRegisterForRemoteNotificationsName();
+    NSString* UnityMobileNotifications_remoteNotificationsDeviceTokenKey();
+}
+#define kUnityWillFinishLaunchingWithOptions UnityMobileNotifications_applicationWillFinishLaunchingName()
+#define kUnityDidRegisterForRemoteNotificationsWithDeviceToken UnityMobileNotifications_applicationDidRegisterForRemoteNotificationsName()
+#define kUnityDidFailToRegisterForRemoteNotificationsWithError UnityMobileNotifications_applicationDidFailToRegisterForRemoteNotificationsName()
 #else
 #import "Classes/PluginBase/AppDelegateListener.h"
 #endif
@@ -104,7 +110,7 @@
     NSData* deviceToken = nil;
 
 #if UNITY_XCODE_PROJECT_TYPE_SWIFT
-    id token = [notification.userInfo objectForKey: UnityNotifications.remoteNotificationsDeviceTokenKey];
+    id token = [notification.userInfo objectForKey: UnityMobileNotifications_remoteNotificationsDeviceTokenKey()];
 #else
     id token = notification.userInfo;
 #endif

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationLifeCycleManager.mm
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationLifeCycleManager.mm
@@ -12,9 +12,9 @@
 #if UNITY_XCODE_PROJECT_TYPE_SWIFT
 extern "C"
 {
-    NSString* UnityMobileNotifications_applicationWillFinishLaunchingName();
-    NSString* UnityMobileNotifications_applicationDidRegisterForRemoteNotificationsName();
-    NSString* UnityMobileNotifications_applicationDidFailToRegisterForRemoteNotificationsName();
+    NSNotificationName UnityMobileNotifications_applicationWillFinishLaunchingName();
+    NSNotificationName UnityMobileNotifications_applicationDidRegisterForRemoteNotificationsName();
+    NSNotificationName UnityMobileNotifications_applicationDidFailToRegisterForRemoteNotificationsName();
     NSString* UnityMobileNotifications_remoteNotificationsDeviceTokenKey();
 }
 #define kUnityWillFinishLaunchingWithOptions UnityMobileNotifications_applicationWillFinishLaunchingName()

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationWrapper.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationWrapper.m
@@ -9,17 +9,17 @@
 #import "UnityNotificationManager.h"
 
 
-int _NativeSizeof_iOSNotificationAuthorizationData()
+int _NativeSizeof_iOSNotificationAuthorizationData(void)
 {
     return sizeof(iOSNotificationAuthorizationData);
 }
 
-int _NativeSizeof_iOSNotificationData()
+int _NativeSizeof_iOSNotificationData(void)
 {
     return sizeof(iOSNotificationData);
 }
 
-int _NativeSizeof_NotificationSettingsData()
+int _NativeSizeof_NotificationSettingsData(void)
 {
     return sizeof(NotificationSettingsData);
 }
@@ -57,12 +57,12 @@ void _RequestAuthorization(void* request, int options, BOOL registerRemote)
     center.delegate = manager;
 }
 
-int _RegisteredForRemoteNotifications()
+int _RegisteredForRemoteNotifications(void)
 {
     return [UIApplication sharedApplication].registeredForRemoteNotifications;
 }
 
-void _UnregisterForRemoteNotifications()
+void _UnregisterForRemoteNotifications(void)
 {
     UnityNotificationManager* manager = [UnityNotificationManager sharedInstance];
     [manager unregisterForRemoteNotifications];
@@ -74,7 +74,7 @@ void _ScheduleLocalNotification(iOSNotificationData data)
     [manager scheduleLocalNotification: &data];
 }
 
-NotificationSettingsData _GetNotificationSettings()
+NotificationSettingsData _GetNotificationSettings(void)
 {
     UnityNotificationManager* manager = [UnityNotificationManager sharedInstance];
     return UNNotificationSettingsToNotificationSettingsData(manager.cachedNotificationSettings);
@@ -133,7 +133,7 @@ void _RemoveScheduledNotification(const char* identifier)
     [[UnityNotificationManager sharedInstance] updateScheduledNotificationList];
 }
 
-void _RemoveAllScheduledNotifications()
+void _RemoveAllScheduledNotifications(void)
 {
     UNUserNotificationCenter* center = [UNUserNotificationCenter currentNotificationCenter];
     [center removeAllPendingNotificationRequests];
@@ -147,7 +147,7 @@ void _RemoveDeliveredNotification(const char* identifier)
     [[UnityNotificationManager sharedInstance] updateDeliveredNotificationList];
 }
 
-void _RemoveAllDeliveredNotifications()
+void _RemoveAllDeliveredNotifications(void)
 {
     UNUserNotificationCenter* center = [UNUserNotificationCenter currentNotificationCenter];
     [center removeAllDeliveredNotifications];
@@ -159,18 +159,18 @@ void _SetApplicationBadge(long badge)
     [[UIApplication sharedApplication] setApplicationIconBadgeNumber: badge];
 }
 
-long _GetApplicationBadge()
+long _GetApplicationBadge(void)
 {
     return [UIApplication sharedApplication].applicationIconBadgeNumber;
 }
 
-int _GetAppOpenedUsingNotification()
+int _GetAppOpenedUsingNotification(void)
 {
     UnityNotificationManager* manager = [UnityNotificationManager sharedInstance];
     return manager.launchedWithNotification;
 }
 
-iOSNotificationData* _GetLastNotificationData()
+iOSNotificationData* _GetLastNotificationData(void)
 {
     UnityNotificationManager* manager = [UnityNotificationManager sharedInstance];
     UNNotification* notification = manager.lastReceivedNotification;
@@ -184,7 +184,7 @@ iOSNotificationData* _GetLastNotificationData()
     return ret;
 }
 
-const char* _GetLastRespondedNotificationAction()
+const char* _GetLastRespondedNotificationAction(void)
 {
     UnityNotificationManager* manager = [UnityNotificationManager sharedInstance];
     NSString* action = manager.lastRespondedNotificationAction;
@@ -193,7 +193,7 @@ const char* _GetLastRespondedNotificationAction()
     return strdup(action.UTF8String);
 }
 
-const char* _GetLastRespondedNotificationUserText()
+const char* _GetLastRespondedNotificationUserText(void)
 {
     UnityNotificationManager* manager = [UnityNotificationManager sharedInstance];
     NSString* userText = manager.lastRespondedNotificationUserText;
@@ -351,7 +351,7 @@ void _SetNotificationCategories(void* categorySet)
     [UNUserNotificationCenter.currentNotificationCenter setNotificationCategories: categories];
 }
 
-void _OpenNotificationSettings()
+void _OpenNotificationSettings(void)
 {
     NSString* urlString;
     if (@available(iOS 15.4, *))


### PR DESCRIPTION
https://jira.unity3d.com/browse/UUM-147194

Fix issues with Swift trampoline support:
- Preprocessor.h file is in a different location, so patching of it was broken
- defines were not added for Swift language, only Objective-C
- there is a difference between Swift trampoline in trunk and previous versions (UnityAPI not a thing in older); solved the issue by having swift source file to access Swift APIs

Other changes, not specific to Swift:
- Add 6.6 to tested versions
- Remove ancient check for targetting iOS 10 or later, min spec guarantees 13+
- entitlement files was not correctly added if time sensitive notifications were not enabled in settings
- fixed a bunch of trivial compiler warnings

Testing:
- Tested that Objective-C trampoline still builds and registers for push with device token retrieve on 6.0
- Tested that Swift trampoline builds and registers for push with token retrieve on 6.5 and trunk
- remainder should be covered by automation (Objective-C only)