### PR TITLE
Android small icon support for unified notifications

### DIFF
--- a/TestProjects/Main/Assets/Scripts/UnifiedTest.cs
+++ b/TestProjects/Main/Assets/Scripts/UnifiedTest.cs
@@ -41,6 +41,7 @@ public class UnifiedTest : MonoBehaviour
         args.AndroidChannelId = "UnifiedNotifications";
         args.AndroidChannelName = "Unified notifications";
         args.AndroidChannelDescription = "Unified test scene channel";
+        args.AndroidSmallIcon = "icon_0";
         args.PresentationOptions = presentationOptions;
         NotificationCenter.Initialize(args);
         NotificationCenter.OnNotificationReceived += OnNotificationReceived;

--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this package will be documented in this file.
 
 ### Changes & Improvements:
 - Unity 6.0 or later is required.
+- [Android] Added ability to set default small icon when using unified API.
 - [iOS] Package is now compatible with the Swift Xcode project type (introduced in Unity 6.5).
 
 ## [2.4.3] - 2026-01-29

--- a/com.unity.mobile.notifications/Runtime/Unified/Notification.cs
+++ b/com.unity.mobile.notifications/Runtime/Unified/Notification.cs
@@ -38,7 +38,9 @@ namespace Unity.Notifications
             return n.notification;
 #else
             var ret = n.notification;
-            if (ret != null && n.Identifier.HasValue)
+            if (ret == null)
+                return null;
+            if (n.Identifier.HasValue)
                 ret.Identifier = n.Identifier.Value.ToString(CultureInfo.InvariantCulture);
             ret.ShowInForeground = n.ShowInForeground;
             return ret;

--- a/com.unity.mobile.notifications/Runtime/Unified/NotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Unified/NotificationCenter.cs
@@ -85,7 +85,7 @@ namespace Unity.Notifications
         /// A custom non-empty string to identify notification channel. Required, Android only.
         /// All notifications will be sent to this channel.
         /// Channel is created automatically during initialization if <see cref="AndroidChannelName"/> and <see cref="AndroidChannelDescription"/> are both set.
-        /// If name and description are left null, channel with given identifier has to be created manually (for example using <see cref="AndroidNotificationCenter.RegisterNotificationChannel(AndroidNotificationChannel)"/>).
+        /// If name and description are left null, channel with given identifier has to be created manually (for example using <see cref="Unity.Notifications.Android.AndroidNotificationCenter.RegisterNotificationChannel(AndroidNotificationChannel)"/>).
         /// </summary>
         public string AndroidChannelId { get; set; }
 

--- a/com.unity.mobile.notifications/Runtime/Unified/NotificationCenter.cs
+++ b/com.unity.mobile.notifications/Runtime/Unified/NotificationCenter.cs
@@ -106,6 +106,12 @@ namespace Unity.Notifications
         /// </summary>
         /// <seealso cref="AndroidChannelId"/>
         public string AndroidChannelDescription { get; set; }
+
+        /// <summary>
+        /// Small icon to be used for all notifications on Android. Optional, application icon will be used if not set.
+        /// This value will be assigned to <see cref="Unity.Notifications.Android.AndroidNotification.SmallIcon"/>.
+        /// </summary>
+        public string AndroidSmallIcon { get; set; }
     }
 
     /// <summary>
@@ -275,6 +281,7 @@ namespace Unity.Notifications
 #if UNITY_ANDROID
             var n = (AndroidNotification)notification;
             schedule.Schedule(ref n);
+            n.SmallIcon = s_Args.AndroidSmallIcon;
             if (notification.Identifier.HasValue)
             {
                 AndroidNotificationCenter.SendNotificationWithExplicitID(n, category, notification.Identifier.Value);


### PR DESCRIPTION
https://jira.unity3d.com/browse/PLAT-21686
On Android notifications are required to have small icon. Unity APIs do not require it, we use app icon if not provided.
Unified notifications API does not allow to set icon as there is no such thing on iOS. However, there were user complains in the past that using something else than app icon is desirable. This PR adds ability to set small icon to NotificationCenter. This we we keep things the way they are - small icon cannot be set on notification, but user can configure the icon to be used on all notifications sent via unified APIs. If user wants to set icon per-notification, android specific notification API should be used instead of unified one.
Couple unrelated changes: one link in documentation does not work due to class not being fully qualified and a possible null exception was noticed for iOS (very low probability, only would happen in a scenario where notification would not work anyway due to not being setup properly).

Tested using Main test project (Unified scene). Icon is set up there and shows correctly. The scenario without icon is covered by automated tests.
Tested on: Pixel 5 (Android 13)