### PR TITLE
Add weekday support for iOS calendar trigger

### DIFF
--- a/com.unity.mobile.notifications/CHANGELOG.md
+++ b/com.unity.mobile.notifications/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this package will be documented in this file.
 ### Changes & Improvements:
 - Unity 6.0 or later is required.
 - [iOS] Package is now compatible with the Swift Xcode project type (introduced in Unity 6.5).
+- [iOS] Added support for scheduling notifications on particular weekdays.
 
 ## [2.4.3] - 2026-01-29
 

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.h
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.h
@@ -69,6 +69,7 @@ typedef struct iOSNotificationData
             int hour;
             int minute;
             int second;
+            int weekday;
             unsigned char repeats;
         } calendar;
 

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationData.m
@@ -176,6 +176,7 @@ iOSNotificationData UNNotificationRequestToiOSNotificationData(UNNotificationReq
         notificationData.trigger.calendar.hour = (int)date.hour;
         notificationData.trigger.calendar.minute = (int)date.minute;
         notificationData.trigger.calendar.second = (int)date.second;
+        notificationData.trigger.calendar.weekday = (int)date.weekday;
         notificationData.trigger.calendar.repeats = (int)calendarTrigger.repeats;
     }
     else if ([request.trigger isKindOfClass: [UNLocationNotificationTrigger class]])

--- a/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
+++ b/com.unity.mobile.notifications/Runtime/iOS/Plugins/UnityNotificationManager.m
@@ -338,6 +338,8 @@ bool validateAuthorizationStatus(UnityNotificationManager* manager)
             date.minute = data->trigger.calendar.minute;
         if (data->trigger.calendar.second >= 0)
             date.second = data->trigger.calendar.second;
+        if (data->trigger.calendar.weekday > 0)
+            date.weekday = data->trigger.calendar.weekday;
 
         date.calendar = [NSCalendar calendarWithIdentifier: NSCalendarIdentifierGregorian];
         if ([@"1" isEqualToString: [userInfo objectForKey: @"OriginalUtc"]])

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotification.cs
@@ -115,6 +115,7 @@ namespace Unity.Notifications.iOS
         public Int32 hour;
         public Int32 minute;
         public Int32 second;
+        public Int32 weekday;
         public Byte repeats;
     }
 
@@ -403,6 +404,7 @@ namespace Unity.Notifications.iOS
                             data.trigger.calendar.hour = trigger.Hour != null ? trigger.Hour.Value : -1;
                             data.trigger.calendar.minute = trigger.Minute != null ? trigger.Minute.Value : -1;
                             data.trigger.calendar.second = trigger.Second != null ? trigger.Second.Value : -1;
+                            data.trigger.calendar.weekday = trigger.iOSWeekday;
                             data.trigger.calendar.repeats = (byte)(trigger.Repeats ? 1 : 0);
                             break;
                         }
@@ -446,6 +448,7 @@ namespace Unity.Notifications.iOS
                                 Hour = (data.trigger.calendar.hour >= 0) ? (int?)data.trigger.calendar.hour : null,
                                 Minute = (data.trigger.calendar.minute >= 0) ? (int?)data.trigger.calendar.minute : null,
                                 Second = (data.trigger.calendar.second >= 0) ? (int?)data.trigger.calendar.second : null,
+                                iOSWeekday = data.trigger.calendar.weekday,
                                 UtcTime = false,
                                 Repeats = data.trigger.calendar.repeats != 0
                             };

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationTriggers.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationTriggers.cs
@@ -212,6 +212,8 @@ namespace Unity.Notifications.iOS
         /// <value>Number indicating second or null to ignore second</value>
         public int? Second { get; set; }
 
+        public DayOfWeek? Weekday { get; set; }
+
         /// <summary>
         /// Are Date and Time field in UTC time. When false, use local time.
         /// </summary>
@@ -281,6 +283,32 @@ namespace Unity.Notifications.iOS
                 Minute = dt.Minute;
             if (Second != null)
                 Second = dt.Second;
+        }
+
+        internal int iOSWeekday
+        {
+            get
+            {
+                if (!Weekday.HasValue)
+                    return -1;
+                // In C# Monday=1, on iOS Sunday=1
+                int ret = 1 + (int)Weekday.Value;
+                if (ret > 7)
+                    ret = 1;
+                return ret;
+            }
+            set
+            {
+                if (value <= 0 || value > 7)
+                    Weekday = null;
+                else
+                {
+                    value = value - 1;
+                    if (value == 0)
+                        value = 7;
+                    Weekday = (DayOfWeek)value;
+                }
+            }
         }
     }
 }

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationTriggers.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationTriggers.cs
@@ -212,6 +212,9 @@ namespace Unity.Notifications.iOS
         /// <value>Number indicating second or null to ignore second</value>
         public int? Second { get; set; }
 
+        /// <summary>
+        /// Day of week to schedule notification for or null to ignore this property.
+        /// </summary>
         public DayOfWeek? Weekday { get; set; }
 
         /// <summary>

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationTriggers.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationTriggers.cs
@@ -238,7 +238,7 @@ namespace Unity.Notifications.iOS
             if (UtcTime)
                 return this;
 
-            var notificationTime = AssignDateTimeComponents(DateTime.Now).ToUniversalTime();
+            var notificationTime = AssignDateTimeComponents(DateTimeOffset.Now).ToUniversalTime();
             iOSNotificationCalendarTrigger result = this;
             result.UtcTime = true;
             result.AssignNonEmptyComponents(notificationTime);
@@ -254,14 +254,14 @@ namespace Unity.Notifications.iOS
             if (!UtcTime)
                 return this;
 
-            var notificationTime = AssignDateTimeComponents(DateTime.UtcNow).ToLocalTime();
+            var notificationTime = AssignDateTimeComponents(DateTimeOffset.UtcNow).ToLocalTime();
             iOSNotificationCalendarTrigger result = this;
             result.UtcTime = false;
             result.AssignNonEmptyComponents(notificationTime);
             return result;
         }
 
-        internal DateTime AssignDateTimeComponents(DateTime dt)
+        internal DateTimeOffset AssignDateTimeComponents(DateTimeOffset dt)
         {
             int year = Year != null ? Year.Value : dt.Year;
             int month = Month != null ? Month.Value : dt.Month;
@@ -269,10 +269,10 @@ namespace Unity.Notifications.iOS
             int hour = Hour != null ? Hour.Value : dt.Hour;
             int minute = Minute != null ? Minute.Value : dt.Minute;
             int second = Second != null ? Second.Value : dt.Second;
-            return new DateTime(year, month, day, hour, minute, second, dt.Kind);
+            return new DateTimeOffset(year, month, day, hour, minute, second, dt.Offset);
         }
 
-        internal void AssignNonEmptyComponents(DateTime dt)
+        internal void AssignNonEmptyComponents(DateTimeOffset dt)
         {
             if (Year != null)
                 Year = dt.Year;

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationTriggers.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationTriggers.cs
@@ -302,7 +302,7 @@ namespace Unity.Notifications.iOS
                 if (value <= 0 || value > 7)
                     Weekday = null;
                 else
-                    Weekday = (DayOfWeek)value - 1;
+                    Weekday = (DayOfWeek)(value - 1);
             }
         }
     }

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationTriggers.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationTriggers.cs
@@ -294,23 +294,15 @@ namespace Unity.Notifications.iOS
             {
                 if (!Weekday.HasValue)
                     return -1;
-                // In C# Monday=1, on iOS Sunday=1
-                int ret = 1 + (int)Weekday.Value;
-                if (ret > 7)
-                    ret = 1;
-                return ret;
+                // In C# Sunday=0, Saturday=6, on iOS Sunday=1, Saturday=7
+                return 1 + (int)Weekday.Value;
             }
             set
             {
                 if (value <= 0 || value > 7)
                     Weekday = null;
                 else
-                {
-                    value = value - 1;
-                    if (value == 0)
-                        value = 7;
-                    Weekday = (DayOfWeek)value;
-                }
+                    Weekday = (DayOfWeek)value - 1;
             }
         }
     }

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationTriggers.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationTriggers.cs
@@ -238,12 +238,12 @@ namespace Unity.Notifications.iOS
             if (UtcTime)
                 return this;
 
-            var now = DateTimeOffset.Now;
-            var notificationTime = AssignDateTimeComponents(now).ToUniversalTime();
+            var nowWithComponents= AssignDateTimeComponents(DateTimeOffset.Now);
+            var notificationTime = nowWithComponents.ToUniversalTime();
             iOSNotificationCalendarTrigger result = this;
             result.UtcTime = true;
             result.AssignNonEmptyComponents(notificationTime);
-            result.Weekday = WeekdayToUtc(Weekday, now);
+            result.Weekday = WeekdayToUtc(Weekday, nowWithComponents);
             return result;
         }
 
@@ -256,12 +256,12 @@ namespace Unity.Notifications.iOS
             if (!UtcTime)
                 return this;
 
-            var now = DateTimeOffset.UtcNow;
-            var notificationTime = AssignDateTimeComponents(now).ToLocalTime();
+            var nowWithComponents = AssignDateTimeComponents(DateTimeOffset.UtcNow);
+            var notificationTime = nowWithComponents.ToLocalTime();
             iOSNotificationCalendarTrigger result = this;
             result.UtcTime = false;
             result.AssignNonEmptyComponents(notificationTime);
-            result.Weekday = WeekdayToLocal(Weekday, now);
+            result.Weekday = WeekdayToLocal(Weekday, nowWithComponents);
             return result;
         }
 

--- a/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationTriggers.cs
+++ b/com.unity.mobile.notifications/Runtime/iOS/iOSNotificationTriggers.cs
@@ -238,10 +238,12 @@ namespace Unity.Notifications.iOS
             if (UtcTime)
                 return this;
 
-            var notificationTime = AssignDateTimeComponents(DateTimeOffset.Now).ToUniversalTime();
+            var now = DateTimeOffset.Now;
+            var notificationTime = AssignDateTimeComponents(now).ToUniversalTime();
             iOSNotificationCalendarTrigger result = this;
             result.UtcTime = true;
             result.AssignNonEmptyComponents(notificationTime);
+            result.Weekday = WeekdayToUtc(Weekday, now);
             return result;
         }
 
@@ -254,10 +256,12 @@ namespace Unity.Notifications.iOS
             if (!UtcTime)
                 return this;
 
-            var notificationTime = AssignDateTimeComponents(DateTimeOffset.UtcNow).ToLocalTime();
+            var now = DateTimeOffset.UtcNow;
+            var notificationTime = AssignDateTimeComponents(now).ToLocalTime();
             iOSNotificationCalendarTrigger result = this;
             result.UtcTime = false;
             result.AssignNonEmptyComponents(notificationTime);
+            result.Weekday = WeekdayToLocal(Weekday, now);
             return result;
         }
 
@@ -286,6 +290,26 @@ namespace Unity.Notifications.iOS
                 Minute = dt.Minute;
             if (Second != null)
                 Second = dt.Second;
+        }
+
+        internal static DayOfWeek? WeekdayToUtc(DayOfWeek? weekday, DateTimeOffset start)
+        {
+            return WeekdayTZAdjust(weekday, start, d => d.ToUniversalTime());
+        }
+
+        internal static DayOfWeek? WeekdayToLocal(DayOfWeek? weekday, DateTimeOffset start)
+        {
+            return WeekdayTZAdjust(weekday, start, d => d.ToLocalTime());
+        }
+
+        internal static DayOfWeek? WeekdayTZAdjust(DayOfWeek? weekday, DateTimeOffset start, Func<DateTimeOffset, DateTimeOffset> convertTZ)
+        {
+            if (weekday == null)
+                return null;
+            var day = weekday.Value;
+            while (start.DayOfWeek != day)
+                start = start.AddDays(1);
+            return convertTZ(start).DayOfWeek;
         }
 
         internal int iOSWeekday

--- a/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
@@ -531,4 +531,22 @@ class iOSNotificationTests
         Assert.AreEqual(5, result.Day);
         Assert.IsFalse(result.UtcTime);
     }
+
+    [Test]
+    public void iOSCalendarTrigger_HandlesWeekday()
+    {
+        var trigger = new iOSNotificationCalendarTrigger();
+        Assert.AreEqual(-1, trigger.iOSWeekday);
+
+        // On iOS week starts on Sunday=1, C# Sunday=0
+        trigger.Weekday = DayOfWeek.Sunday;
+        Assert.AreEqual(1, trigger.iOSWeekday);
+        trigger.Weekday = DayOfWeek.Wednesday;
+        Assert.AreEqual(4, trigger.iOSWeekday);
+
+        trigger.iOSWeekday = 7;
+        Assert.AreEqual(DayOfWeek.Saturday, trigger.Weekday);
+        trigger.iOSWeekday = 1;
+        Assert.AreEqual(DayOfWeek.Sunday, trigger.Weekday);
+    }
 }

--- a/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
@@ -208,6 +208,39 @@ class iOSNotificationTests
 
     [UnityTest]
     [UnityPlatform(RuntimePlatform.IPhonePlayer)]
+    public IEnumerator SendNotificationUsingCalendarTrigger_WeekDay_NotificationIsReceived()
+    {
+        var dt = DateTime.Now.AddSeconds(5);
+        var trigger = new iOSNotificationCalendarTrigger()
+        {
+            Weekday = dt.DayOfWeek,
+            Hour = dt.Hour,
+            Minute = dt.Minute,
+            Second = dt.Second,
+        };
+
+        var notification = new iOSNotification()
+        {
+            Title = "Weekday",
+            Body = "Day of the week",
+            ShowInForeground = true,
+            ForegroundPresentationOption = PresentationOption.Alert,
+            Trigger = trigger,
+        };
+
+        iOSNotificationCenter.ScheduleNotification(notification);
+        Debug.Log($"SendNotificationUsingCalendarTrigger_WeekDay_NotificationIsReceived, Notification should arrive on: {dt}");
+        yield return WaitForNotification(20.0f);
+        Debug.Log($"SendNotificationUsingCalendarTrigger_WeekDay_NotificationIsReceived, wait finished at: {DateTime.Now}");
+        Assert.AreEqual(1, receivedNotificationCount);
+        Assert.IsNotNull(lastReceivedNotification);
+        Assert.AreEqual("Weekday", lastReceivedNotification.Title);
+        var retTrigger = (iOSNotificationCalendarTrigger)lastReceivedNotification.Trigger;
+        Assert.AreEqual(dt.DayOfWeek, retTrigger.Weekday);
+    }
+
+    [UnityTest]
+    [UnityPlatform(RuntimePlatform.IPhonePlayer)]
     public IEnumerator SendNotification_AllPropertiesRoundtrip()
     {
         var trigger = new iOSNotificationTimeIntervalTrigger()

--- a/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
+++ b/com.unity.mobile.notifications/Tests/Runtime/iOS/iOSNotificationTests.cs
@@ -549,4 +549,42 @@ class iOSNotificationTests
         trigger.iOSWeekday = 1;
         Assert.AreEqual(DayOfWeek.Sunday, trigger.Weekday);
     }
+
+    [Test]
+    public void iOSCalendarTrigger_TimezoneHandling_HandlesWeekend()
+    {
+        var trigger = new iOSNotificationCalendarTrigger();
+        trigger.Year = 2020;
+        trigger.Month = 10;
+        trigger.Day = 20;
+
+        // Convert to UTC, Weekday stays null
+        var trigger2 = trigger.ToUtc();
+        Assert.IsNull(trigger2.Weekday);
+
+        // convert to UTC with Weekday, it stays
+        trigger.Weekday = DayOfWeek.Wednesday;
+        trigger2 = trigger.ToUtc();
+        Assert.IsNotNull(trigger2.Weekday);
+
+        // Convert to local, Weekday preserved
+        trigger = trigger2.ToLocal();
+        Assert.IsNotNull(trigger.Weekday);
+
+        // Convert to local without Weekday, stays null
+        trigger2.Weekday = null;
+        trigger = trigger2.ToLocal();
+        Assert.IsNull(trigger.Weekday);
+    }
+
+    [Test]
+    public void iOSCalendarTrigger_WeekdayHandling()
+    {
+        var date = new DateTimeOffset(2025, 1, 2, 23, 50, 0, TimeSpan.FromHours(-2));
+        Assert.IsNull(iOSNotificationCalendarTrigger.WeekdayToUtc(null, date));
+        Assert.AreEqual(DayOfWeek.Saturday, iOSNotificationCalendarTrigger.WeekdayToUtc(DayOfWeek.Friday, date));
+
+        date = new DateTimeOffset(2025, 1, 2, 0, 50, 0, TimeSpan.FromHours(0));
+        Assert.AreEqual(DayOfWeek.Saturday, iOSNotificationCalendarTrigger.WeekdayTZAdjust(DayOfWeek.Sunday, date, date => date.ToOffset(TimeSpan.FromHours(-3))));
+    }
 }


### PR DESCRIPTION
https://jira.unity3d.com/browse/PLAT-21698
Add support for scheduling notifications to happen on a particular day of week. iOS only.
A new property Weekday added to iOSCalendarTrigger to support this.
Some code changes were made to enable better automated test coverage.

Tested manually and covered by automation where possible. Full conversion of trigger between UTC and local is time zone dependent, automation covers it partially, full conversion tested locally. Notification delivery is tested automatically, not being delivered if day is different from today was tested locally.