### PR TITLE
Add CI to test iOS Swift trampoline

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -83,6 +83,9 @@ test_iOS_Swift_{{ editor.version }}:
   commands:
     - curl -s {{ utr.url_unix }} --output utr
     - chmod u+x utr
+    - brew tap unity/homebrew-unity git@github.cds.internal.unity3d.com:unity/homebrew-unity.git
+    - brew trust unity/unity
+    - brew install unity/unity/unity-downloader-cli
     - unity-downloader-cli -c Editor -c iOS -u {{ editor.version }} --wait --fast
     - ./utr --testproject=TestProjects/AutomatedTests --editor-location=.Editor --suite=playmode --platform=ios --artifacts_path=upm-ci~/test-results/ios --timeout=900 --extra-editor-arg="-upmNoDefaultPackages" --extra-editor-arg="-executeMethod" --extra-editor-arg=UnityEditor.iOS.iOSTests.UseSwiftTrampoline --player-save-path=build/players --build-only
     - ./utr --testproject=TestProjects/AutomatedTests --editor-location=.Editor --suite=playmode --platform=ios --artifacts_path=upm-ci~/test-results/ios --timeout=900 --extra-editor-arg="-executeMethod" --extra-editor-arg=UnityEditor.iOS.iOSTests.UseSwiftTrampoline --player-load-path=build/players

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -8,6 +8,7 @@ test_editors:
 
 swift_trampoline_editors:
   - version: trunk
+  - version: 6000.6
 
 artifactory:
   production: https://artifactory.prd.it.unity3d.com/artifactory/api/

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -120,3 +120,6 @@ test_trigger:
     - .yamato/upm-ci.yml#test_Android_{{ editor.version }}
     - .yamato/upm-ci.yml#test_iOS_{{ editor.version }}
     {% endfor %}
+    {% for editor in swift_trampoline_editors %}
+    - .yamato/upm-ci.yml#test_iOS_Swift_{{ editor.version }}
+    {% endfor %}

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -8,8 +8,6 @@ test_editors:
 
 swift_trampoline_editors:
   - version: trunk
-  - version: 6000.6
-  - version: 6000.5
 
 artifactory:
   production: https://artifactory.prd.it.unity3d.com/artifactory/api/

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -6,6 +6,11 @@ test_editors:
   - version: 6000.3
   - version: 6000.0
 
+swift_trampoline_editors:
+  - version: trunk
+  - version: 6000.6
+  - version: 6000.5
+
 artifactory:
   production: https://artifactory.prd.it.unity3d.com/artifactory/api/
 
@@ -57,6 +62,30 @@ test_iOS_{{ editor.version }}:
     - unity-downloader-cli -c Editor -c iOS -u {{ editor.version }} --wait --fast
     - ./utr --testproject=TestProjects/AutomatedTests --editor-location=.Editor --suite=playmode --platform=ios --artifacts_path=upm-ci~/test-results/ios --timeout=900 --extra-editor-arg="-upmNoDefaultPackages" --player-save-path=build/players --build-only
     - ./utr --testproject=TestProjects/AutomatedTests --editor-location=.Editor --suite=playmode --platform=ios --artifacts_path=upm-ci~/test-results/ios --timeout=900 --player-load-path=build/players
+  artifacts:
+    packages:
+      paths:
+        - "upm-ci~/**/*"
+  dependencies:
+    - .yamato/wrench/package-pack-jobs.yml#package_pack_-_mobile_notifications
+{% endfor %}
+
+{% for editor in swift_trampoline_editors %}
+test_iOS_Swift_{{ editor.version }}:
+  name: Test {{ editor.version }} on iOS (Swift)
+  agent:
+    type: Unity::VM::osx
+    image: automation-tooling/macos-14-arm64-unity:v2.7891464
+    flavor: b1.medium
+    model: M1
+  variables:
+    IOS_SIMULATOR_SDK: 1
+  commands:
+    - curl -s {{ utr.url_unix }} --output utr
+    - chmod u+x utr
+    - unity-downloader-cli -c Editor -c iOS -u {{ editor.version }} --wait --fast
+    - ./utr --testproject=TestProjects/AutomatedTests --editor-location=.Editor --suite=playmode --platform=ios --artifacts_path=upm-ci~/test-results/ios --timeout=900 --extra-editor-arg="-upmNoDefaultPackages" --extra-editor-arg="-executeMethod" --extra-editor-arg=UnityEditor.iOS.iOSTests.UseSwiftTrampoline --player-save-path=build/players --build-only
+    - ./utr --testproject=TestProjects/AutomatedTests --editor-location=.Editor --suite=playmode --platform=ios --artifacts_path=upm-ci~/test-results/ios --timeout=900 --extra-editor-arg="-executeMethod" --extra-editor-arg=UnityEditor.iOS.iOSTests.UseSwiftTrampoline --player-load-path=build/players
   artifacts:
     packages:
       paths:


### PR DESCRIPTION
https://jira.unity3d.com/browse/PLAT-22075

Add CI to run iOS tests using Swift trampoline. Only Unity 6.6 and later is supported.