### PR TITLE
Swift trampoline fixes

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -79,6 +79,8 @@ test_iOS_Swift_{{ editor.version }}:
     model: M1
   variables:
     IOS_SIMULATOR_SDK: 1
+    HOMEBREW_NO_AUTO_UPDATE: 1
+    HOMEBREW_NO_INSTALL_FROM_API: 1
   commands:
     - curl -s {{ utr.url_unix }} --output utr
     - chmod u+x utr

--- a/com.unity.mobile.notifications/Editor/iOSNotificationPostProcessor.cs
+++ b/com.unity.mobile.notifications/Editor/iOSNotificationPostProcessor.cs
@@ -131,7 +131,13 @@ public class iOSNotificationPostProcessor : MonoBehaviour
 
     private static void PatchPlist(string path, List<Unity.Notifications.NotificationSetting> settings, bool addPushNotificationCapability)
     {
-        var plistPath = path + "/Info.plist";
+        var plistPath = Path.Combine(path, "Info.plist");
+        if (!File.Exists(plistPath))
+        {
+            // When using Swift trampoline since 6.7 the file is under MainApp subdir, fallback to that
+            path = Path.Combine(path, "MainApp");
+            plistPath = Path.Combine(path, "Info.plist");
+        }
         var plist = new PlistDocument();
         plist.ReadFromString(File.ReadAllText(plistPath));
 


### PR DESCRIPTION
https://jira.unity3d.com/browse/UUM-151886
In latest trunk the location of Info.plist file changed in swift trampoline, which broke mobile notification post processor. The fix is trivial - check if file exists and fallback to new location.
Additionally, disable homebrew update as that is causing issues with unity tools we retrieve through it.

Testing:
In general the error was caught by automation.
Tested manually both trampolines to see that info plist entries are found on startup, permission request still works correctly and push notifications do work.