### PR TITLE
Forward port 2.5 branch and fix CI

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -79,6 +79,8 @@ test_iOS_Swift_{{ editor.version }}:
     model: M1
   variables:
     IOS_SIMULATOR_SDK: 1
+    HOMEBREW_NO_AUTO_UPDATE: 1
+    HOMEBREW_NO_INSTALL_FROM_API: 1
   commands:
     - curl -s {{ utr.url_unix }} --output utr
     - chmod u+x utr

--- a/com.unity.mobile.notifications/Editor/iOSNotificationPostProcessor.cs
+++ b/com.unity.mobile.notifications/Editor/iOSNotificationPostProcessor.cs
@@ -131,7 +131,13 @@ public class iOSNotificationPostProcessor : MonoBehaviour
 
     private static void PatchPlist(string path, List<Unity.Notifications.NotificationSetting> settings, bool addPushNotificationCapability)
     {
-        var plistPath = path + "/Info.plist";
+        var plistPath = Path.Combine(path, "Info.plist");
+        if (!File.Exists(plistPath))
+        {
+            // When using Swift trampoline since 6.7 the file is under MainApp subdir, fallback to that
+            path = Path.Combine(path, "MainApp");
+            plistPath = Path.Combine(path, "Info.plist");
+        }
         var plist = new PlistDocument();
         plist.ReadFromString(File.ReadAllText(plistPath));
 


### PR DESCRIPTION
https://jira.unity3d.com/browse/PLAT-22315
Forward-port PR that landed to release/2.5 branch.
Fix CI:
- trunk dropped x64 Mac Editor, fix by using ARM64 in all branches
- change image to the arm64; same image as used by Swift (downside that we lose lower than iOS 16 coverage)
- homebrew and unity-downloader-cli setup same as used by swift